### PR TITLE
contrib: four example modules (policy templates, env signer, tx grouping, mock WebAuthn)

### DIFF
--- a/contrib/examples/group-tx-by-day/README.md
+++ b/contrib/examples/group-tx-by-day/README.md
@@ -1,0 +1,33 @@
+# Group transaction history by day
+
+A standalone example that takes an array of sample transactions with
+timestamps and groups them into buckets keyed by calendar day.
+
+## What it does
+
+`groupTransactionsByDay(transactions)` in `group-tx-by-day.ts`:
+
+- Uses each transaction's `timestamp` field (ISO 8601 string) to compute a
+  UTC calendar-day key (`YYYY-MM-DD`).
+- Returns one group per day, in chronological order — oldest day first.
+- Within a day, transactions keep their original input order.
+
+The SDK doesn't ship a dedicated "transaction history" type, so
+`SampleTransaction` here is a minimal shape (`hash`, `timestamp`, `amount`,
+`status`) combining an ISO timestamp with `TxStatus` from
+`src/tx-status.ts`, the pattern a wallet activity feed would typically use.
+
+The bundled `SAMPLE_TRANSACTIONS` span three different days
+(2026-07-20, 2026-07-22, and 2026-07-25/26) to exercise the day boundary.
+
+## Run it
+
+```sh
+npx tsx contrib/examples/group-tx-by-day/group-tx-by-day.ts
+```
+
+## Test it
+
+```sh
+npm test -- contrib/examples/group-tx-by-day
+```

--- a/contrib/examples/group-tx-by-day/group-tx-by-day.test.ts
+++ b/contrib/examples/group-tx-by-day/group-tx-by-day.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+import { groupTransactionsByDay, type SampleTransaction } from "./group-tx-by-day";
+
+const TRANSACTIONS: SampleTransaction[] = [
+  { hash: "tx-b", timestamp: "2026-01-02T10:00:00Z", amount: "1", status: "success" },
+  { hash: "tx-a", timestamp: "2026-01-01T23:00:00Z", amount: "2", status: "success" },
+  { hash: "tx-c", timestamp: "2026-01-01T01:00:00Z", amount: "3", status: "pending" },
+  { hash: "tx-d", timestamp: "2026-01-03T00:00:01Z", amount: "4", status: "failed" },
+];
+
+describe("groupTransactionsByDay", () => {
+  it("buckets transactions spanning three days into three chronologically ordered groups", () => {
+    const groups = groupTransactionsByDay(TRANSACTIONS);
+
+    expect(groups.map((g) => g.day)).toEqual(["2026-01-01", "2026-01-02", "2026-01-03"]);
+    expect(groups[0]!.transactions.map((t) => t.hash)).toEqual(["tx-a", "tx-c"]);
+    expect(groups[1]!.transactions.map((t) => t.hash)).toEqual(["tx-b"]);
+    expect(groups[2]!.transactions.map((t) => t.hash)).toEqual(["tx-d"]);
+  });
+
+  it("returns an empty array for no transactions", () => {
+    expect(groupTransactionsByDay([])).toEqual([]);
+  });
+});

--- a/contrib/examples/group-tx-by-day/group-tx-by-day.ts
+++ b/contrib/examples/group-tx-by-day/group-tx-by-day.ts
@@ -1,0 +1,66 @@
+// Standalone example: group an array of sample transactions (with
+// timestamps) into buckets keyed by calendar day, oldest day first.
+
+import type { TxStatus } from "../../../src/tx-status";
+
+/** A minimal "transaction history item" shape. The SDK doesn't ship a
+ * dedicated history type; this mirrors how `src/tx-status.ts`'s `TxStatus`
+ * and the ISO timestamps used elsewhere in the SDK (e.g. `WalletSession`,
+ * `GeneratedPolicy`) would typically be combined for a wallet activity feed. */
+export interface SampleTransaction {
+  hash: string;
+  /** ISO 8601 timestamp string. */
+  timestamp: string;
+  amount: string;
+  status: TxStatus;
+}
+
+export interface DayGroup {
+  /** Calendar day key, UTC, `YYYY-MM-DD`. */
+  day: string;
+  transactions: SampleTransaction[];
+}
+
+function dayKey(timestamp: string): string {
+  const iso = new Date(timestamp).toISOString();
+  return iso.slice(0, 10);
+}
+
+/** Groups `transactions` by their UTC calendar day, using `timestamp` as the
+ * day key. Groups are returned in chronological order (oldest day first);
+ * within a group, transactions keep their input order. */
+export function groupTransactionsByDay(transactions: SampleTransaction[]): DayGroup[] {
+  const byDay = new Map<string, SampleTransaction[]>();
+  for (const tx of transactions) {
+    const key = dayKey(tx.timestamp);
+    const bucket = byDay.get(key);
+    if (bucket) {
+      bucket.push(tx);
+    } else {
+      byDay.set(key, [tx]);
+    }
+  }
+  return [...byDay.keys()].sort().map((day) => ({ day, transactions: byDay.get(day)! }));
+}
+
+const SAMPLE_TRANSACTIONS: SampleTransaction[] = [
+  { hash: "tx-1", timestamp: "2026-07-20T09:15:00Z", amount: "10.0000000", status: "success" },
+  { hash: "tx-2", timestamp: "2026-07-20T18:42:00Z", amount: "2.5000000", status: "success" },
+  { hash: "tx-3", timestamp: "2026-07-22T08:03:00Z", amount: "1.2500000", status: "pending" },
+  { hash: "tx-4", timestamp: "2026-07-25T23:59:59Z", amount: "5.0000000", status: "failed" },
+  { hash: "tx-5", timestamp: "2026-07-26T00:00:01Z", amount: "7.0000000", status: "success" },
+];
+
+export function main(): void {
+  const groups = groupTransactionsByDay(SAMPLE_TRANSACTIONS);
+  for (const group of groups) {
+    console.log(`${group.day}: ${group.transactions.length} transaction(s)`);
+    for (const tx of group.transactions) {
+      console.log(`  ${tx.hash} ${tx.timestamp} ${tx.status}`);
+    }
+  }
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main();
+}

--- a/contrib/examples/list-policy-templates/README.md
+++ b/contrib/examples/list-policy-templates/README.md
@@ -1,0 +1,39 @@
+# List policy templates (mock backend)
+
+A standalone example that calls a mocked `policies.listTemplates()`-style
+function and prints the returned templates.
+
+## What it does
+
+`list-templates.ts` builds a `PolicyClient` (from `createPolicyClient` in
+`src/policy-client.ts`) with an injected `fetch` that serves three hardcoded
+`PolicyTemplateInfo` entries for `GET /policies/templates` instead of calling
+a real gateway. `main()` calls `listTemplates()` and prints each template's
+`type` (its id) and `description`.
+
+## Run it
+
+```sh
+npx tsx contrib/examples/list-policy-templates/list-templates.ts
+```
+
+## Test it
+
+```sh
+npm test -- contrib/examples/list-policy-templates
+```
+
+## Mapping to the real policies API
+
+In a real integration you'd construct the client the same way but point it at
+your gateway and skip the `fetch` override:
+
+```ts
+const client = createPolicyClient({ apiUrl: "https://api.myapp.com", network: "mainnet" });
+const templates = await client.listTemplates();
+```
+
+That issues `GET {apiUrl}/policies/templates` against your deployed
+policy-service and returns the live `PolicyTemplateInfo[]` — the same shape
+this example fabricates locally, so code written against the mock output
+here works unchanged against the real backend.

--- a/contrib/examples/list-policy-templates/list-templates.test.ts
+++ b/contrib/examples/list-policy-templates/list-templates.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it, vi } from "vitest";
+import { listPolicyTemplates, main } from "./list-templates";
+
+describe("listPolicyTemplates", () => {
+  it("returns at least 3 templates from the mock backend", async () => {
+    const templates = await listPolicyTemplates();
+    expect(templates.length).toBeGreaterThanOrEqual(3);
+    for (const template of templates) {
+      expect(typeof template.type).toBe("string");
+      expect(typeof template.description).toBe("string");
+      expect(template.description.length).toBeGreaterThan(0);
+    }
+  });
+});
+
+describe("main", () => {
+  it("prints each template's id and description", async () => {
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    await main();
+    const templates = await listPolicyTemplates();
+    expect(logSpy).toHaveBeenCalledTimes(templates.length);
+    for (const template of templates) {
+      expect(logSpy).toHaveBeenCalledWith(`${template.type}: ${template.description}`);
+    }
+    logSpy.mockRestore();
+  });
+});

--- a/contrib/examples/list-policy-templates/list-templates.ts
+++ b/contrib/examples/list-policy-templates/list-templates.ts
@@ -1,0 +1,64 @@
+// Standalone example: call a mocked policies.listTemplates() and print the
+// results. See ./README.md for how this maps to the real policies API.
+
+import { createPolicyClient } from "../../../src/policy-client";
+import type { PolicyTemplateInfo } from "../../../src/policy-types";
+
+const MOCK_TEMPLATES: PolicyTemplateInfo[] = [
+  {
+    type: "spending-limit-daily",
+    title: "Daily spending limit",
+    description:
+      "Caps total spend per rolling 24h window; enforced on-chain by a deployed policy contract.",
+    enforcement: { kind: "policy-contract", wasmHash: "mock-wasm-hash-spending-limit" },
+  },
+  {
+    type: "session-key-only",
+    title: "Session-key signer limits",
+    description:
+      "Restricts a session key to a fixed set of contract calls; enforced by the wallet's signer limits, no separate contract deployed.",
+    enforcement: { kind: "signer-limits" },
+  },
+  {
+    type: "unrestricted",
+    title: "No policy",
+    description: "No spending restriction is attached; the wallet's normal signer thresholds apply.",
+    enforcement: { kind: "none" },
+  },
+];
+
+/** A `fetch` stand-in that serves `MOCK_TEMPLATES` for GET /policies/templates
+ * and 404s everything else — enough to drive `createPolicyClient` without a
+ * real gateway. */
+function mockPoliciesFetch(): typeof fetch {
+  return (async (input: RequestInfo | URL) => {
+    const url = typeof input === "string" ? input : input.toString();
+    if (url.endsWith("/policies/templates")) {
+      return new Response(JSON.stringify(MOCK_TEMPLATES), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    }
+    return new Response(JSON.stringify({ error: "not found" }), { status: 404 });
+  }) as typeof fetch;
+}
+
+export async function listPolicyTemplates(): Promise<PolicyTemplateInfo[]> {
+  const client = createPolicyClient({
+    apiUrl: "https://example-gateway.invalid",
+    network: "testnet",
+    fetch: mockPoliciesFetch(),
+  });
+  return client.listTemplates();
+}
+
+export async function main(): Promise<void> {
+  const templates = await listPolicyTemplates();
+  for (const template of templates) {
+    console.log(`${template.type}: ${template.description}`);
+  }
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main();
+}

--- a/contrib/examples/mock-webauthn-assertion/README.md
+++ b/contrib/examples/mock-webauthn-assertion/README.md
@@ -1,0 +1,36 @@
+# Mock WebAuthnAssertionSigner
+
+A self-contained example implementing a mock `WebAuthnAssertionSigner` (see
+`src/x402-signer.ts`) that returns a fixed, canned assertion for any payload
+hash — for use in tests of the passkey x402 signer
+(`createPasskeyX402Signer`).
+
+> **The returned assertion is NOT cryptographically valid.** `MOCK_ASSERTION`
+> is deterministic filler (`authenticatorData`, `clientDataJSON`, `signature`,
+> and `keyId` are each a fixed, repeated byte value). It will build a
+> structurally correct signed auth entry, but the "signature" bytes are not a
+> real secp256r1 signature and will be rejected by any real on-chain
+> `__check_auth`. Use this only to exercise code paths that consume a
+> `WebAuthnAssertionSigner`, never against a real network.
+
+## What it does
+
+- `createMockWebAuthnAssertionSigner()` returns a `WebAuthnAssertionSigner`
+  whose `sign()` always resolves to `MOCK_ASSERTION`, regardless of the
+  payload hash it's given.
+- `signDummyEntryWithMock()` wires that mock signer into
+  `createPasskeyX402Signer` and uses it to sign a dummy V1
+  (`sorobanCredentialsAddress`) auth entry, returning the signed entry XDR —
+  demonstrating the full integration.
+
+## Run it
+
+```sh
+npx tsx contrib/examples/mock-webauthn-assertion/mock-webauthn-assertion.ts
+```
+
+## Test it
+
+```sh
+npm test -- contrib/examples/mock-webauthn-assertion
+```

--- a/contrib/examples/mock-webauthn-assertion/mock-webauthn-assertion.test.ts
+++ b/contrib/examples/mock-webauthn-assertion/mock-webauthn-assertion.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+import { xdr } from "@stellar/stellar-sdk";
+import {
+  createMockWebAuthnAssertionSigner,
+  MOCK_ASSERTION,
+  signDummyEntryWithMock,
+} from "./mock-webauthn-assertion";
+
+describe("createMockWebAuthnAssertionSigner", () => {
+  it("returns the fixed canned assertion for any payload hash", async () => {
+    const signer = createMockWebAuthnAssertionSigner();
+    const a = await signer.sign(new Uint8Array(32).fill(1));
+    const b = await signer.sign(new Uint8Array(32).fill(2));
+    expect(a).toEqual(MOCK_ASSERTION);
+    expect(b).toEqual(MOCK_ASSERTION);
+    expect(a.authenticatorData).toHaveLength(37);
+    expect(a.clientDataJSON).toHaveLength(50);
+    expect(a.signature).toHaveLength(64);
+    expect(a.keyId).toHaveLength(20);
+  });
+});
+
+describe("signDummyEntryWithMock", () => {
+  it("wires the mock into createPasskeyX402Signer and produces a signed V1 entry", async () => {
+    const signedXdr = await signDummyEntryWithMock();
+    const signed = xdr.SorobanAuthorizationEntry.fromXDR(signedXdr, "base64");
+    expect(signed.credentials().switch().name).toBe("sorobanCredentialsAddress");
+
+    const map = signed.credentials().address().signature().vec()![0]!.map()!;
+    const key = map[0]!.key();
+    expect(key.vec()![0]!.sym().toString()).toBe("Secp256r1");
+    expect(new Uint8Array(key.vec()![1]!.bytes())).toEqual(MOCK_ASSERTION.keyId);
+  });
+});

--- a/contrib/examples/mock-webauthn-assertion/mock-webauthn-assertion.ts
+++ b/contrib/examples/mock-webauthn-assertion/mock-webauthn-assertion.ts
@@ -1,0 +1,90 @@
+// Standalone example: a mock WebAuthnAssertionSigner that returns a fixed,
+// canned assertion for any payload hash, for use in tests of the passkey
+// x402 signer (createPasskeyX402Signer). See ./README.md — the returned
+// assertion is NOT cryptographically valid.
+
+import { Address, nativeToScVal, xdr } from "@stellar/stellar-sdk";
+import {
+  createPasskeyX402Signer,
+  type WebAuthnAssertion,
+  type WebAuthnAssertionSigner,
+} from "../../../src/x402-signer";
+
+/** A fixed, canned WebAuthn assertion. Every field is deterministic filler —
+ * this is NOT a real secp256r1 signature and will NOT pass on-chain
+ * verification. It exists purely to exercise code paths that consume a
+ * `WebAuthnAssertionSigner` without a real browser/passkey ceremony. */
+export const MOCK_ASSERTION: WebAuthnAssertion = {
+  authenticatorData: new Uint8Array(37).fill(0xa1),
+  clientDataJSON: new Uint8Array(50).fill(0xc1),
+  signature: new Uint8Array(64).fill(0xf1),
+  keyId: new Uint8Array(20).fill(0x99),
+};
+
+/** Builds a `WebAuthnAssertionSigner` that returns `MOCK_ASSERTION` for any
+ * payload hash it's asked to sign — no browser, no real passkey involved. */
+export function createMockWebAuthnAssertionSigner(): WebAuthnAssertionSigner {
+  return {
+    async sign(_payloadHash: Uint8Array): Promise<WebAuthnAssertion> {
+      return MOCK_ASSERTION;
+    },
+  };
+}
+
+/** Builds a minimal V1 (`sorobanCredentialsAddress`) auth entry for
+ * `contractAddress`, invoking a dummy `transfer` call — just enough
+ * structure for `createPasskeyX402Signer` to sign. Mirrors the fixture used
+ * in `src/x402-signer.test.ts`. */
+function makeV1AuthEntry(contractAddress: string, otherContractAddress: string) {
+  const addr = new Address(contractAddress);
+  const credentials = xdr.SorobanCredentials.sorobanCredentialsAddress(
+    new xdr.SorobanAddressCredentials({
+      address: addr.toScAddress(),
+      nonce: xdr.Int64.fromString("1"),
+      signatureExpirationLedger: 0,
+      signature: xdr.ScVal.scvVoid(),
+    }),
+  );
+  const rootInvocation = new xdr.SorobanAuthorizedInvocation({
+    function: xdr.SorobanAuthorizedFunction.sorobanAuthorizedFunctionTypeContractFn(
+      new xdr.InvokeContractArgs({
+        contractAddress: new Address(otherContractAddress).toScAddress(),
+        functionName: "transfer",
+        args: [
+          nativeToScVal(contractAddress, { type: "address" }),
+          nativeToScVal(otherContractAddress, { type: "address" }),
+          nativeToScVal(1n, { type: "i128" }),
+        ],
+      }),
+    ),
+    subInvocations: [],
+  });
+  return new xdr.SorobanAuthorizationEntry({ credentials, rootInvocation });
+}
+
+const PASSPHRASE = "Test SDF Network ; September 2015";
+const WALLET_ADDRESS = "CC5ZSTLTYKPNIFDSJ4233RVZPALGHHDBRTXGIN6Z3AJCWU57VR5ITXXR";
+const OTHER_ADDRESS = "CBIN4HTPJM2QLJ32DTRO6OCLIMM7TR7D74JDIPVQYLNYGL7SBWOXH5ND";
+
+/** Wires the mock signer into `createPasskeyX402Signer` and signs a dummy
+ * V1 auth entry, returning the signed entry XDR. */
+export async function signDummyEntryWithMock(): Promise<string> {
+  const signer = createPasskeyX402Signer({
+    address: WALLET_ADDRESS,
+    webAuthn: createMockWebAuthnAssertionSigner(),
+  });
+  const entry = makeV1AuthEntry(WALLET_ADDRESS, OTHER_ADDRESS);
+  return signer.signAuthEntry(entry.toXDR("base64"), {
+    networkPassphrase: PASSPHRASE,
+    expirationLedger: 1000,
+  });
+}
+
+export async function main(): Promise<void> {
+  const signedXdr = await signDummyEntryWithMock();
+  console.log(`signed with mock WebAuthn assertion, entry XDR length: ${signedXdr.length}`);
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main();
+}

--- a/contrib/examples/signer-from-env/README.md
+++ b/contrib/examples/signer-from-env/README.md
@@ -1,0 +1,41 @@
+# Session-key signer from an env secret
+
+A standalone example that reads an ed25519 secret key from an environment
+variable and constructs a `createSessionKeySigner` from it, with clear error
+handling when the variable is missing or malformed.
+
+## Environment variables
+
+- `VELLAR_SESSION_KEY_SECRET` — the ed25519 session key secret seed
+  (Stellar `S…` format, 56 characters). Read by `createSessionKeySignerFromEnv`.
+- `VELLAR_WALLET_ADDRESS` — the smart-account `C…` address this session key
+  pays for. Read by `main()` when run as a script.
+
+**Never commit a real secret key to source control or a `.env` file that
+gets checked in.** These are example/test values only — treat any secret
+that has ever touched a real wallet as compromised.
+
+## What it does
+
+`createSessionKeySignerFromEnv(address, envVarName?)`:
+
+1. Reads `process.env[envVarName]` (defaults to `VELLAR_SESSION_KEY_SECRET`).
+2. Throws a descriptive error if the variable is unset/empty, or if it
+   doesn't look like a Stellar secret key (wrong prefix/length) — before
+   ever handing it to `Keypair.fromSecret`.
+3. Otherwise calls `createSessionKeySigner({ address, secretKey })` from
+   `src/x402-signer.ts` and returns the resulting `SmartAccountX402Signer`.
+
+## Run it
+
+```sh
+export VELLAR_SESSION_KEY_SECRET="S..."
+export VELLAR_WALLET_ADDRESS="C..."
+npx tsx contrib/examples/signer-from-env/signer-from-env.ts
+```
+
+## Test it
+
+```sh
+npm test -- contrib/examples/signer-from-env
+```

--- a/contrib/examples/signer-from-env/signer-from-env.test.ts
+++ b/contrib/examples/signer-from-env/signer-from-env.test.ts
@@ -1,0 +1,40 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { Keypair } from "@stellar/stellar-sdk";
+import { createSessionKeySignerFromEnv, DEFAULT_ENV_VAR } from "./signer-from-env";
+
+const C_ADDRESS = "CC5ZSTLTYKPNIFDSJ4233RVZPALGHHDBRTXGIN6Z3AJCWU57VR5ITXXR";
+
+describe("createSessionKeySignerFromEnv", () => {
+  afterEach(() => {
+    delete process.env[DEFAULT_ENV_VAR];
+    delete process.env["CUSTOM_ENV_VAR"];
+  });
+
+  it("throws a clear error when the env var is unset", () => {
+    delete process.env[DEFAULT_ENV_VAR];
+    expect(() => createSessionKeySignerFromEnv(C_ADDRESS)).toThrow(
+      /environment variable "VELLAR_SESSION_KEY_SECRET" is not set/,
+    );
+  });
+
+  it("throws a clear error when the env var is malformed", () => {
+    process.env[DEFAULT_ENV_VAR] = "not-a-secret-key";
+    expect(() => createSessionKeySignerFromEnv(C_ADDRESS)).toThrow(
+      /does not look like a Stellar secret key/,
+    );
+  });
+
+  it("builds a session-key signer from a valid secret in the default env var", () => {
+    const kp = Keypair.random();
+    process.env[DEFAULT_ENV_VAR] = kp.secret();
+    const signer = createSessionKeySignerFromEnv(C_ADDRESS);
+    expect(signer.address).toBe(C_ADDRESS);
+  });
+
+  it("honors a custom env var name", () => {
+    const kp = Keypair.random();
+    process.env["CUSTOM_ENV_VAR"] = kp.secret();
+    const signer = createSessionKeySignerFromEnv(C_ADDRESS, "CUSTOM_ENV_VAR");
+    expect(signer.address).toBe(C_ADDRESS);
+  });
+});

--- a/contrib/examples/signer-from-env/signer-from-env.ts
+++ b/contrib/examples/signer-from-env/signer-from-env.ts
@@ -1,0 +1,57 @@
+// Standalone example: build a `createSessionKeySigner` from an ed25519
+// secret read out of an environment variable, failing loudly and clearly
+// when the variable is missing or malformed. See ./README.md for the env
+// var name and a warning about handling real secrets.
+
+import { createSessionKeySigner } from "../../../src/x402-signer";
+import type { SmartAccountX402Signer } from "../../../src/x402-types";
+
+/** Default environment variable name this example reads the session-key
+ * secret from. Override with the `envVarName` argument if your app uses a
+ * different name. */
+export const DEFAULT_ENV_VAR = "VELLAR_SESSION_KEY_SECRET";
+
+/**
+ * Reads a Stellar ed25519 secret seed (`S…`) from `process.env[envVarName]`
+ * and wraps it in a `createSessionKeySigner` for the given smart-account
+ * `address`. Throws a descriptive error — rather than letting a cryptic
+ * failure surface later — when the variable is unset, empty, or does not
+ * look like a Stellar secret key.
+ */
+export function createSessionKeySignerFromEnv(
+  address: string,
+  envVarName: string = DEFAULT_ENV_VAR,
+): SmartAccountX402Signer {
+  const secretKey = process.env[envVarName];
+  if (!secretKey || secretKey.trim() === "") {
+    throw new Error(
+      `signer-from-env: environment variable "${envVarName}" is not set. ` +
+        `Set it to an ed25519 session key secret (starts with "S") before calling createSessionKeySignerFromEnv().`,
+    );
+  }
+  if (!secretKey.startsWith("S") || secretKey.length !== 56) {
+    throw new Error(
+      `signer-from-env: environment variable "${envVarName}" does not look like a Stellar secret key ` +
+        `(expected a 56-character string starting with "S").`,
+    );
+  }
+  return createSessionKeySigner({ address, secretKey });
+}
+
+export async function main(): Promise<void> {
+  const address = process.env["VELLAR_WALLET_ADDRESS"];
+  if (!address) {
+    throw new Error(
+      'signer-from-env: environment variable "VELLAR_WALLET_ADDRESS" is not set (the smart-account C-address to sign for).',
+    );
+  }
+  const signer = createSessionKeySignerFromEnv(address);
+  console.log(`session-key signer ready for ${signer.address}`);
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main().catch((err) => {
+    console.error(err instanceof Error ? err.message : err);
+    process.exitCode = 1;
+  });
+}


### PR DESCRIPTION
## Summary

Four self-contained example modules under `contrib/examples/`, each addressing one assigned issue:

- `contrib/examples/list-policy-templates/` — calls a mocked `policies.listTemplates()` (via `createPolicyClient` with an injected `fetch`) returning 3 hardcoded templates, and prints each template's id/description.
- `contrib/examples/signer-from-env/` — reads an ed25519 secret from `VELLAR_SESSION_KEY_SECRET` and builds a `createSessionKeySigner`, with descriptive errors when the variable is missing or malformed.
- `contrib/examples/group-tx-by-day/` — groups sample transactions (with timestamps) into calendar-day buckets, oldest to newest, exercised across a 3+ day span.
- `contrib/examples/mock-webauthn-assertion/` — a mock `WebAuthnAssertionSigner` returning a fixed canned assertion, wired into `createPasskeyX402Signer` to sign a dummy auth entry (README documents the assertion is not cryptographically valid).

Each folder has its own README, implementation, and a vitest test file. All changes are confined to `contrib/`.

## Test plan

- [x] `npm test` — 147 tests pass (16 files, including the 4 new example test files)
- [x] `npm run typecheck` — passes
- [x] `npm run build` — passes
- [x] Each example script runs standalone via `npx tsx contrib/examples/<name>/<name>.ts`

Closes #19
Closes #53
Closes #59
Closes #65