### PR TITLE
Add four contrib example scripts/modules (stroops formatting, policy summary, session expiry watcher, rate limited fetch queue)

### DIFF
--- a/contrib/examples/format-policy-summary/README.md
+++ b/contrib/examples/format-policy-summary/README.md
@@ -1,0 +1,41 @@
+# format-policy-summary
+
+Formats a policy spending limit and a window (in seconds) as a human
+readable sentence, such as `"100 XLM per day"`.
+
+## Usage
+
+```ts
+import { formatPolicySummary } from "./format-policy-summary";
+
+formatPolicySummary(100, 86400); // "100 XLM per day"
+```
+
+Or run it as a script:
+
+```sh
+npx tsx format-policy-summary.ts 100 86400
+```
+
+## API
+
+```ts
+function formatPolicySummary(
+  limit: bigint | number | string,
+  windowSeconds: number,
+  options?: { unit?: string }, // defaults to "XLM"
+): string;
+```
+
+Recognized windows (`60`, `3600`, `86400`, `604800`) get a friendly label.
+Any other window length falls back to printing the raw seconds.
+
+## Examples
+
+| Limit | Window (s) | Output                     |
+| ----- | ---------- | --------------------------- |
+| `100`   | `3600`       | `100 XLM per hour`          |
+| `50`    | `86400`      | `50 XLM per day`            |
+| `1000`  | `604800`     | `1000 XLM per week`         |
+| `25`    | `60`         | `25 XLM per minute`         |
+| `10`    | `120`        | `10 XLM per 120 seconds`    |

--- a/contrib/examples/format-policy-summary/format-policy-summary.ts
+++ b/contrib/examples/format-policy-summary/format-policy-summary.ts
@@ -1,0 +1,47 @@
+/**
+ * Formats a spending limit and a window (in seconds) as a human readable
+ * sentence, e.g. "100 XLM per day". Falls back to printing the raw seconds
+ * for window lengths that don't have a friendly label.
+ */
+
+const WINDOW_LABELS: Record<number, string> = {
+  60: "minute",
+  3600: "hour",
+  86400: "day",
+  604800: "week",
+};
+
+export interface FormatPolicySummaryOptions {
+  unit?: string;
+}
+
+export function formatPolicySummary(
+  limit: bigint | number | string,
+  windowSeconds: number,
+  options: FormatPolicySummaryOptions = {},
+): string {
+  const unit = options.unit ?? "XLM";
+  const label = WINDOW_LABELS[windowSeconds];
+
+  if (label) {
+    return `${limit} ${unit} per ${label}`;
+  }
+
+  return `${limit} ${unit} per ${windowSeconds} seconds`;
+}
+
+function main(): void {
+  const [limit, windowSeconds] = process.argv.slice(2);
+
+  if (!limit || !windowSeconds) {
+    console.error("Usage: tsx format-policy-summary.ts <limit> <windowSeconds>");
+    process.exitCode = 1;
+    return;
+  }
+
+  console.log(formatPolicySummary(limit, Number(windowSeconds)));
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main();
+}

--- a/contrib/examples/format-stroops/README.md
+++ b/contrib/examples/format-stroops/README.md
@@ -1,0 +1,38 @@
+# format-stroops
+
+Converts a raw stroops amount into a human readable XLM string with up to 7
+decimal places, using `BigInt` so large balances don't lose precision.
+
+## Usage
+
+```ts
+import { formatStroops } from "./format-stroops";
+
+formatStroops(10_000_000n); // "1"
+```
+
+Or run it as a script:
+
+```sh
+npx tsx format-stroops.ts 10000000
+```
+
+## API
+
+```ts
+function formatStroops(stroops: bigint | number | string): string;
+```
+
+Trailing zero decimal digits are trimmed, and a whole-XLM amount is returned
+without a decimal point.
+
+## Examples
+
+| Input (stroops) | Output       |
+| ---------------- | ------------ |
+| `0`               | `0`          |
+| `1`               | `0.0000001`  |
+| `100000`          | `0.01`       |
+| `10000000`        | `1`          |
+| `123456789`       | `12.3456789` |
+| `9999999999999999` | `999999999.9999999` |

--- a/contrib/examples/format-stroops/format-stroops.ts
+++ b/contrib/examples/format-stroops/format-stroops.ts
@@ -1,0 +1,40 @@
+/**
+ * Formats a raw stroops amount as a human readable XLM string.
+ *
+ * 1 XLM = 10,000,000 stroops (7 decimal places). All math is done with
+ * BigInt so arbitrarily large balances don't lose precision the way they
+ * would if we divided with floating point numbers.
+ */
+
+const STROOPS_PER_XLM = 10_000_000n;
+
+export function formatStroops(stroops: bigint | number | string): string {
+  const value = typeof stroops === "bigint" ? stroops : BigInt(stroops);
+  const negative = value < 0n;
+  const abs = negative ? -value : value;
+
+  const whole = abs / STROOPS_PER_XLM;
+  const fraction = abs % STROOPS_PER_XLM;
+
+  const fractionDigits = fraction.toString().padStart(7, "0").replace(/0+$/, "");
+
+  const formatted = fractionDigits.length > 0 ? `${whole}.${fractionDigits}` : whole.toString();
+
+  return negative ? `-${formatted}` : formatted;
+}
+
+function main(): void {
+  const input = process.argv[2];
+
+  if (!input) {
+    console.error("Usage: tsx format-stroops.ts <stroops>");
+    process.exitCode = 1;
+    return;
+  }
+
+  console.log(formatStroops(input));
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main();
+}

--- a/contrib/examples/rate-limited-fetch-queue/README.md
+++ b/contrib/examples/rate-limited-fetch-queue/README.md
@@ -1,0 +1,60 @@
+# rate-limited-fetch-queue
+
+A small, self contained queue that runs `fetch` calls with a maximum number
+in flight at once, queuing the rest and starting them in FIFO order as
+slots free up.
+
+## Usage
+
+```ts
+import { RateLimitedFetchQueue } from "./rate-limited-fetch-queue";
+
+const queue = new RateLimitedFetchQueue({ maxConcurrent: 3 });
+
+const results = await Promise.all(
+  urls.map((url) => queue.enqueue(url).then((res) => res.json())),
+);
+```
+
+## API
+
+```ts
+new RateLimitedFetchQueue(options: RateLimitedFetchQueueOptions)
+```
+
+- `options.maxConcurrent` — maximum number of `fetch` calls in flight at
+  once.
+- `options.fetchFn` — optional `fetch` implementation override, useful for
+  tests.
+
+Methods:
+
+- `queue.enqueue(input, init?)` — returns a `Promise<Response>` that
+  resolves/rejects the same way `fetch(input, init)` would.
+- `queue.pending` — number of calls still waiting for a slot.
+- `queue.inFlight` — number of calls currently running.
+
+Each call to `enqueue` returns its own promise, so results line up with the
+order calls were enqueued (e.g. via `Promise.all`) even though the
+underlying requests may finish in a different order.
+
+## Demo
+
+`demo.ts` enqueues 5 fake requests with `maxConcurrent: 2` and logs when
+each one starts/finishes, showing only 2 running at a time and the final
+results array preserving enqueue order:
+
+```sh
+npx tsx demo.ts
+# [0ms] start  /a
+# [0ms] start  /b
+# [300ms] finish /a
+# [300ms] start  /c
+# [300ms] finish /b
+# [300ms] start  /d
+# [600ms] finish /c
+# [600ms] start  /e
+# [600ms] finish /d
+# [900ms] finish /e
+# results (in enqueue order): [ '/a', '/b', '/c', '/d', '/e' ]
+```

--- a/contrib/examples/rate-limited-fetch-queue/demo.ts
+++ b/contrib/examples/rate-limited-fetch-queue/demo.ts
@@ -1,0 +1,40 @@
+/**
+ * Demonstrates RateLimitedFetchQueue enqueuing more calls than the
+ * concurrency limit. Uses a fake `fetchFn` with an artificial delay instead
+ * of hitting the network. Run with:
+ *
+ *   npx tsx demo.ts
+ */
+
+import { RateLimitedFetchQueue } from "./rate-limited-fetch-queue";
+
+const start = Date.now();
+const elapsed = () => `${Date.now() - start}ms`;
+
+const fakeFetch = (input: RequestInfo | URL): Promise<Response> => {
+  const label = String(input);
+  const delayMs = 300;
+
+  console.log(`[${elapsed()}] start  ${label}`);
+
+  return new Promise((resolve) => {
+    setTimeout(() => {
+      console.log(`[${elapsed()}] finish ${label}`);
+      resolve(new Response(label));
+    }, delayMs);
+  });
+};
+
+async function main() {
+  const queue = new RateLimitedFetchQueue({ maxConcurrent: 2, fetchFn: fakeFetch as typeof fetch });
+
+  const urls = ["/a", "/b", "/c", "/d", "/e"];
+
+  // Enqueue all five up front; only 2 should be "in flight" at a time.
+  const results = await Promise.all(urls.map((url) => queue.enqueue(url).then((r) => r.text())));
+
+  // Results line up with the enqueue order, regardless of completion order.
+  console.log("results (in enqueue order):", results);
+}
+
+main();

--- a/contrib/examples/rate-limited-fetch-queue/rate-limited-fetch-queue.ts
+++ b/contrib/examples/rate-limited-fetch-queue/rate-limited-fetch-queue.ts
@@ -1,0 +1,69 @@
+/**
+ * A queue that runs `fetch` calls with a maximum number in flight at once,
+ * queuing the rest. Requests start in FIFO order as concurrency slots free
+ * up; each call's returned promise resolves independently with its own
+ * response once it completes.
+ */
+
+type FetchLike = typeof fetch;
+type FetchInput = Parameters<FetchLike>[0];
+type FetchInit = Parameters<FetchLike>[1];
+
+interface QueuedTask {
+  input: FetchInput;
+  init: FetchInit;
+  resolve: (response: Response) => void;
+  reject: (reason: unknown) => void;
+}
+
+export interface RateLimitedFetchQueueOptions {
+  maxConcurrent: number;
+  /** Injectable fetch implementation, mainly useful for tests. */
+  fetchFn?: FetchLike;
+}
+
+export class RateLimitedFetchQueue {
+  private readonly maxConcurrent: number;
+  private readonly fetchFn: FetchLike;
+  private readonly queue: QueuedTask[] = [];
+  private active = 0;
+
+  constructor(options: RateLimitedFetchQueueOptions) {
+    if (options.maxConcurrent < 1) {
+      throw new RangeError("maxConcurrent must be at least 1");
+    }
+    this.maxConcurrent = options.maxConcurrent;
+    this.fetchFn = options.fetchFn ?? fetch;
+  }
+
+  /** Enqueues a fetch call. Resolves/rejects like `fetch` would. */
+  enqueue(input: FetchInput, init?: FetchInit): Promise<Response> {
+    return new Promise((resolve, reject) => {
+      this.queue.push({ input, init, resolve, reject });
+      this.drain();
+    });
+  }
+
+  get pending(): number {
+    return this.queue.length;
+  }
+
+  get inFlight(): number {
+    return this.active;
+  }
+
+  private drain(): void {
+    while (this.active < this.maxConcurrent && this.queue.length > 0) {
+      const task = this.queue.shift();
+      if (!task) break;
+
+      this.active++;
+      this.fetchFn(task.input, task.init)
+        .then(task.resolve, task.reject)
+        .finally(() => {
+          this.active--;
+          this.drain();
+        });
+    }
+  }
+}

--- a/contrib/examples/session-expiry-watcher/README.md
+++ b/contrib/examples/session-expiry-watcher/README.md
@@ -1,0 +1,58 @@
+# session-expiry-watcher
+
+A small, self contained module that watches a session object with an
+`expiresAt` timestamp and invokes a callback shortly before it expires,
+using a single `setTimeout` timer.
+
+## Usage
+
+```ts
+import { SessionExpiryWatcher } from "./session-expiry-watcher";
+
+const watcher = new SessionExpiryWatcher(
+  { expiresAt: Date.now() + 60_000 },
+  {
+    warnBeforeMs: 10_000, // fire 10s before expiry
+    onExpiringSoon: (session) => {
+      console.log("Session expiring soon:", session.expiresAt);
+    },
+  },
+);
+
+watcher.start();
+
+// Later, e.g. on logout or component unmount:
+watcher.stop();
+```
+
+## API
+
+```ts
+new SessionExpiryWatcher(session: SessionLike, options: SessionExpiryWatcherOptions)
+```
+
+- `session.expiresAt` — epoch milliseconds when the session expires.
+- `options.warnBeforeMs` — how many milliseconds before expiry to fire the
+  callback.
+- `options.onExpiringSoon` — called once, shortly before expiry.
+- `options.now` — optional clock override, useful for tests.
+
+Methods:
+
+- `watcher.start()` — starts (or restarts) the timer.
+- `watcher.stop()` — clears the timer; safe to call multiple times.
+- `watcher.isRunning` — whether a timer is currently scheduled.
+
+If `expiresAt - warnBeforeMs` is already in the past, the callback fires on
+the next tick.
+
+## Demo
+
+`demo.ts` creates a session with a 2 second lifetime and a 1 second warning
+window, then logs when the callback fires:
+
+```sh
+npx tsx demo.ts
+# Starting watcher, expect a warning in ~1s...
+# Session expiring soon at 2026-07-27T12:00:01.000Z
+```

--- a/contrib/examples/session-expiry-watcher/demo.ts
+++ b/contrib/examples/session-expiry-watcher/demo.ts
@@ -1,0 +1,28 @@
+/**
+ * Demonstrates SessionExpiryWatcher with a short-lived session so the
+ * callback fires within a couple of seconds. Run with:
+ *
+ *   npx tsx demo.ts
+ */
+
+import { SessionExpiryWatcher, type SessionLike } from "./session-expiry-watcher";
+
+const SESSION_LIFETIME_MS = 2000;
+const WARN_BEFORE_MS = 1000;
+
+const session: SessionLike = {
+  expiresAt: Date.now() + SESSION_LIFETIME_MS,
+};
+
+const watcher = new SessionExpiryWatcher(session, {
+  warnBeforeMs: WARN_BEFORE_MS,
+  onExpiringSoon: (s) => {
+    console.log(`Session expiring soon at ${new Date(s.expiresAt).toISOString()}`);
+  },
+});
+
+console.log("Starting watcher, expect a warning in ~1s...");
+watcher.start();
+
+// Stopping the watcher after it has already fired is a no-op.
+setTimeout(() => watcher.stop(), SESSION_LIFETIME_MS + 500);

--- a/contrib/examples/session-expiry-watcher/session-expiry-watcher.ts
+++ b/contrib/examples/session-expiry-watcher/session-expiry-watcher.ts
@@ -1,0 +1,54 @@
+/**
+ * Watches a session object with an `expiresAt` timestamp and invokes a
+ * callback shortly before it expires, using a single timer.
+ */
+
+export interface SessionLike {
+  expiresAt: number; // epoch milliseconds
+}
+
+export interface SessionExpiryWatcherOptions {
+  /** How many milliseconds before expiry the callback should fire. */
+  warnBeforeMs: number;
+  /** Called once, shortly before the session expires. */
+  onExpiringSoon: (session: SessionLike) => void;
+  /** Injectable clock, mainly useful for tests. */
+  now?: () => number;
+}
+
+export class SessionExpiryWatcher {
+  private readonly session: SessionLike;
+  private readonly options: SessionExpiryWatcherOptions;
+  private timer: ReturnType<typeof setTimeout> | null = null;
+
+  constructor(session: SessionLike, options: SessionExpiryWatcherOptions) {
+    this.session = session;
+    this.options = options;
+  }
+
+  /** Starts (or restarts) the watcher's timer. */
+  start(): void {
+    this.stop();
+
+    const now = (this.options.now ?? Date.now)();
+    const fireAt = this.session.expiresAt - this.options.warnBeforeMs;
+    const delay = Math.max(0, fireAt - now);
+
+    this.timer = setTimeout(() => {
+      this.timer = null;
+      this.options.onExpiringSoon(this.session);
+    }, delay);
+  }
+
+  /** Stops the watcher and clears its timer, if any. */
+  stop(): void {
+    if (this.timer !== null) {
+      clearTimeout(this.timer);
+      this.timer = null;
+    }
+  }
+
+  get isRunning(): boolean {
+    return this.timer !== null;
+  }
+}


### PR DESCRIPTION

Adds four standalone, self contained examples under contrib/examples/,
each with its own README and no dependencies on src/ or the package
config.

## contrib/examples/format-stroops/
Exposes formatStroops(), converting a raw stroops amount into a human
readable XLM string (up to 7 decimals). Uses BigInt throughout so very
large amounts don't lose precision; handles zero and trims trailing
zero decimals.

## contrib/examples/format-policy-summary/
Exposes formatPolicySummary(), turning a spending limit and a window
(in seconds) into a sentence like "100 XLM per day". Friendly labels
for common windows (60/3600/86400/604800 seconds); falls back to
printing the raw seconds for anything else.

## contrib/examples/session-expiry-watcher/
A SessionExpiryWatcher class that watches a session's expiresAt
timestamp and invokes a callback warnBeforeMs before it expires, using
a single timer. Configurable warnBeforeMs, injectable clock,
start()/stop() controls. demo.ts exercises it with a 2s session
lifetime / 1s warning window.

## contrib/examples/rate-limited-fetch-queue/
A RateLimitedFetchQueue that runs fetch calls with a configurable
maxConcurrent limit in flight, queuing the rest in FIFO order. Each
enqueue() call returns its own promise, so results line up with
enqueue order regardless of completion order. demo.ts enqueues 5 fake
requests with maxConcurrent: 2 to show the queueing behavior.


Closes #21 
Closes #35 
Closes #47 
Closes #49 