### PR TITLE
feat(examples): connect/session/policy example scripts

### DIFF
--- a/contrib/examples/connect-wallet-mock/README.md
+++ b/contrib/examples/connect-wallet-mock/README.md
@@ -1,0 +1,34 @@
+# Connect to an existing wallet by keyId (mock)
+
+Demonstrates the `connect()` flow shape: look up a wallet's `contractId` from
+its passkey `keyId` via a backend, without a real WebAuthn prompt or network
+call. Uses a small in-file `MockWalletBackend` seeded with one known `keyId`.
+
+## What it shows
+
+- A known `keyId` resolves to a session (`{ accountId, keyId, connected }`).
+- An unknown `keyId` produces a clear, catchable error instead of a raw
+  `undefined` or an unhandled crash.
+
+## Run it
+
+```sh
+npx tsx connect-wallet.ts
+```
+
+Expected output:
+
+```
+Connected: {
+  accountId: 'CABC123KNOWNWALLETCONTRACTADDRESSXXXXXXXXXXXXXXXXXXXXXXXX',
+  keyId: 'keyid-known-abc123',
+  connected: true
+}
+Could not connect: connectWallet: no wallet is registered for keyId "keyid-unknown-does-not-exist"
+```
+
+## Tests
+
+```sh
+npx vitest run contrib/examples/connect-wallet-mock
+```

--- a/contrib/examples/connect-wallet-mock/connect-wallet.test.ts
+++ b/contrib/examples/connect-wallet-mock/connect-wallet.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+import { MockWalletBackend, connectWallet } from "./connect-wallet";
+
+describe("connectWallet (mock backend)", () => {
+  const backend = new MockWalletBackend({
+    "keyid-known-abc123": { contractId: "CABC123" },
+  });
+
+  it("resolves a known keyId to its session", async () => {
+    await expect(connectWallet(backend, "keyid-known-abc123")).resolves.toEqual({
+      accountId: "CABC123",
+      keyId: "keyid-known-abc123",
+      connected: true,
+    });
+  });
+
+  it("throws a clear error for an unknown keyId", async () => {
+    await expect(connectWallet(backend, "nope")).rejects.toThrow(
+      'no wallet is registered for keyId "nope"',
+    );
+  });
+});

--- a/contrib/examples/connect-wallet-mock/connect-wallet.ts
+++ b/contrib/examples/connect-wallet-mock/connect-wallet.ts
@@ -1,0 +1,62 @@
+// Example: connect to an existing wallet by keyId against a small in-file
+// mock backend, and print the resolved session.
+//
+// Run with: npx tsx connect-wallet.ts
+
+export interface MockBackendRecord {
+  contractId: string;
+}
+
+/** A tiny stand-in for the real WalletBackend.lookupContractId round trip. */
+export class MockWalletBackend {
+  #byKeyId: Map<string, MockBackendRecord>;
+
+  constructor(seed: Record<string, MockBackendRecord>) {
+    this.#byKeyId = new Map(Object.entries(seed));
+  }
+
+  async lookupContractId(keyId: string): Promise<MockBackendRecord | undefined> {
+    return this.#byKeyId.get(keyId);
+  }
+}
+
+export interface ConnectResult {
+  accountId: string;
+  keyId: string;
+  connected: true;
+}
+
+export async function connectWallet(
+  backend: MockWalletBackend,
+  keyId: string,
+): Promise<ConnectResult> {
+  const record = await backend.lookupContractId(keyId);
+  if (!record) {
+    throw new Error(`connectWallet: no wallet is registered for keyId "${keyId}"`);
+  }
+  return { accountId: record.contractId, keyId, connected: true };
+}
+
+async function main() {
+  const backend = new MockWalletBackend({
+    "keyid-known-abc123": { contractId: "CABC123KNOWNWALLETCONTRACTADDRESSXXXXXXXXXXXXXXXXXXXXXXXX" },
+  });
+
+  // Known keyId: resolves and prints the session.
+  const session = await connectWallet(backend, "keyid-known-abc123");
+  console.log("Connected:", session);
+
+  // Unknown keyId: caught and reported clearly, not a raw stack trace.
+  const unknownKeyId = "keyid-unknown-does-not-exist";
+  try {
+    await connectWallet(backend, unknownKeyId);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    console.log(`Could not connect: ${message}`);
+  }
+}
+
+// Only run when executed directly (not when imported by the test file).
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main();
+}

--- a/contrib/examples/generate-policy-body/README.md
+++ b/contrib/examples/generate-policy-body/README.md
@@ -1,0 +1,39 @@
+# Generate a spending-limit policy body
+
+Builds a spending-limit policy request body from a daily limit (in stroops)
+and a rolling window (in seconds), mirroring `vellar-sdk`'s
+`SpendingConstructor` shape (`src/policy-types.ts`).
+
+## Run it
+
+```sh
+npx tsx generate-policy-body.ts <dailyLimitStroops> <windowSeconds>
+```
+
+Example invocation — a 100 XLM (1,000,000,000 stroops) daily limit over a
+24-hour window:
+
+```sh
+npx tsx generate-policy-body.ts 1000000000 86400
+```
+
+Expected output:
+
+```json
+{
+  "type": "spending-limit",
+  "constructorArgs": {
+    "dailyLimitStroops": "1000000000",
+    "windowSeconds": 86400
+  }
+}
+```
+
+Both arguments must be positive integers — the script exits with an error
+otherwise (e.g. `0`, a negative number, or non-numeric input).
+
+## Tests
+
+```sh
+npx vitest run contrib/examples/generate-policy-body
+```

--- a/contrib/examples/generate-policy-body/generate-policy-body.test.ts
+++ b/contrib/examples/generate-policy-body/generate-policy-body.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+import { buildSpendingPolicyBody } from "./generate-policy-body";
+
+describe("buildSpendingPolicyBody", () => {
+  it("builds a spending-limit body from a limit and window", () => {
+    expect(buildSpendingPolicyBody("1000000000", "86400")).toEqual({
+      type: "spending-limit",
+      constructorArgs: {
+        dailyLimitStroops: "1000000000",
+        windowSeconds: 86400,
+      },
+    });
+  });
+
+  it("rejects a non-positive limit", () => {
+    expect(() => buildSpendingPolicyBody("0", "86400")).toThrow(RangeError);
+    expect(() => buildSpendingPolicyBody("-5", "86400")).toThrow(RangeError);
+  });
+
+  it("rejects a non-positive window", () => {
+    expect(() => buildSpendingPolicyBody("1000000000", "0")).toThrow(RangeError);
+  });
+
+  it("rejects a non-numeric argument", () => {
+    expect(() => buildSpendingPolicyBody("abc", "86400")).toThrow(RangeError);
+    expect(() => buildSpendingPolicyBody("1000000000", "abc")).toThrow(RangeError);
+  });
+});

--- a/contrib/examples/generate-policy-body/generate-policy-body.ts
+++ b/contrib/examples/generate-policy-body/generate-policy-body.ts
@@ -1,0 +1,63 @@
+// Example: build a spending-limit policy request body from a daily limit
+// (in stroops) and a rolling window (in seconds), given as CLI arguments.
+// Mirrors vellar-sdk's SpendingConstructor shape (src/policy-types.ts).
+//
+// Run with: npx tsx generate-policy-body.ts <dailyLimitStroops> <windowSeconds>
+// Example:  npx tsx generate-policy-body.ts 1000000000 86400
+
+export interface SpendingPolicyBody {
+  type: "spending-limit";
+  constructorArgs: {
+    dailyLimitStroops: string;
+    windowSeconds: number;
+  };
+}
+
+function parsePositiveInteger(raw: string, label: string): number {
+  const value = Number(raw);
+  if (!Number.isFinite(value) || !Number.isInteger(value) || value <= 0) {
+    throw new RangeError(`${label} must be a positive integer, got "${raw}"`);
+  }
+  return value;
+}
+
+export function buildSpendingPolicyBody(
+  dailyLimitStroops: string,
+  windowSeconds: string,
+): SpendingPolicyBody {
+  // dailyLimitStroops is validated as a positive integer but kept as a string
+  // in the body — spending limits are i128 stroop amounts, too large for a
+  // JS number to represent exactly.
+  parsePositiveInteger(dailyLimitStroops, "limit");
+  const window = parsePositiveInteger(windowSeconds, "windowSeconds");
+
+  return {
+    type: "spending-limit",
+    constructorArgs: {
+      dailyLimitStroops,
+      windowSeconds: window,
+    },
+  };
+}
+
+function main() {
+  const [limitArg, windowArg] = process.argv.slice(2);
+  if (!limitArg || !windowArg) {
+    console.error("Usage: npx tsx generate-policy-body.ts <dailyLimitStroops> <windowSeconds>");
+    process.exitCode = 1;
+    return;
+  }
+
+  try {
+    const body = buildSpendingPolicyBody(limitArg, windowArg);
+    console.log(JSON.stringify(body, null, 2));
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    console.error(`Error: ${message}`);
+    process.exitCode = 1;
+  }
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main();
+}

--- a/contrib/examples/print-session/README.md
+++ b/contrib/examples/print-session/README.md
@@ -1,0 +1,35 @@
+# Print a wallet session
+
+Pretty-prints a `WalletSession` object's fields to the console with clear
+labels, using a hardcoded sample session.
+
+## The WalletSession shape
+
+From `vellar-sdk`'s `src/types.ts`:
+
+```ts
+interface WalletSession {
+  accountId: string;
+  network: "testnet" | "mainnet";
+  connected: boolean;
+  authMethod: "passkey";
+  createdAt: string;   // ISO timestamp
+  lastActiveAt: string; // ISO timestamp
+  serverSessionId?: string; // present after a real create()/connect()
+  keyId?: string;            // present after a real create()/connect()
+}
+```
+
+`serverSessionId` and `keyId` are optional — printed as `(none)` when absent.
+
+## Run it
+
+```sh
+npx tsx print-session.ts
+```
+
+## Tests
+
+```sh
+npx vitest run contrib/examples/print-session
+```

--- a/contrib/examples/print-session/print-session.test.ts
+++ b/contrib/examples/print-session/print-session.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it, vi } from "vitest";
+import { printSession, type WalletSession } from "./print-session";
+
+describe("printSession", () => {
+  it("labels and prints every field, including a value", () => {
+    const spy = vi.spyOn(console, "log").mockImplementation(() => {});
+    const session: WalletSession = {
+      accountId: "CFULL",
+      network: "mainnet",
+      connected: true,
+      authMethod: "passkey",
+      createdAt: "2026-01-01T00:00:00.000Z",
+      lastActiveAt: "2026-01-02T00:00:00.000Z",
+      serverSessionId: "sess_1",
+      keyId: "key_1",
+    };
+    printSession(session);
+
+    const lines = spy.mock.calls.map((call) => call.join(" "));
+    expect(lines.some((l) => l.includes("Account ID:") && l.includes("CFULL"))).toBe(true);
+    expect(lines.some((l) => l.includes("Server session ID:") && l.includes("sess_1"))).toBe(true);
+    expect(lines.some((l) => l.includes("Key ID:") && l.includes("key_1"))).toBe(true);
+    spy.mockRestore();
+  });
+
+  it("falls back to (none) for optional fields when absent", () => {
+    const spy = vi.spyOn(console, "log").mockImplementation(() => {});
+    const session: WalletSession = {
+      accountId: "CMIN",
+      network: "testnet",
+      connected: false,
+      authMethod: "passkey",
+      createdAt: "2026-01-01T00:00:00.000Z",
+      lastActiveAt: "2026-01-01T00:00:00.000Z",
+    };
+    printSession(session);
+
+    const lines = spy.mock.calls.map((call) => call.join(" "));
+    expect(lines.some((l) => l.includes("Server session ID:") && l.includes("(none)"))).toBe(true);
+    expect(lines.some((l) => l.includes("Key ID:") && l.includes("(none)"))).toBe(true);
+    spy.mockRestore();
+  });
+});

--- a/contrib/examples/print-session/print-session.ts
+++ b/contrib/examples/print-session/print-session.ts
@@ -1,0 +1,44 @@
+// Example: pretty-print a WalletSession's fields to the console with clear
+// labels. Uses a hardcoded sample session (see the WalletSession shape from
+// vellar-sdk's src/types.ts).
+//
+// Run with: npx tsx print-session.ts
+
+export interface WalletSession {
+  accountId: string;
+  network: "testnet" | "mainnet";
+  connected: boolean;
+  authMethod: "passkey";
+  createdAt: string;
+  lastActiveAt: string;
+  serverSessionId?: string;
+  keyId?: string;
+}
+
+const sampleSession: WalletSession = {
+  accountId: "CABC123SAMPLEWALLETCONTRACTADDRESSXXXXXXXXXXXXXXXXXXXXXX",
+  network: "testnet",
+  connected: true,
+  authMethod: "passkey",
+  createdAt: "2026-01-15T09:30:00.000Z",
+  lastActiveAt: "2026-01-15T10:12:45.000Z",
+  serverSessionId: "sess_7f3a9c2e",
+  keyId: "keyid-abc123base64url",
+};
+
+export function printSession(session: WalletSession): void {
+  console.log("Wallet session");
+  console.log("  Account ID:        ", session.accountId);
+  console.log("  Network:           ", session.network);
+  console.log("  Connected:         ", session.connected);
+  console.log("  Auth method:       ", session.authMethod);
+  console.log("  Created at:        ", session.createdAt);
+  console.log("  Last active at:    ", session.lastActiveAt);
+  console.log("  Server session ID: ", session.serverSessionId ?? "(none)");
+  console.log("  Key ID:            ", session.keyId ?? "(none)");
+}
+
+// Only run when executed directly (not when imported by the test file).
+if (import.meta.url === `file://${process.argv[1]}`) {
+  printSession(sampleSession);
+}

--- a/contrib/examples/session-expiry-check/README.md
+++ b/contrib/examples/session-expiry-check/README.md
@@ -1,0 +1,30 @@
+# Session expiry check
+
+Checks a mock session expiry timestamp against the current time and reports
+`EXPIRED` or `ACTIVE`.
+
+## Run it
+
+```sh
+npx tsx session-expiry-check.ts <iso-timestamp>
+```
+
+Example — a timestamp in the past:
+
+```sh
+npx tsx session-expiry-check.ts 2020-01-01T00:00:00.000Z
+# Session expiry (2020-01-01T00:00:00.000Z): EXPIRED
+```
+
+Example — a timestamp in the future:
+
+```sh
+npx tsx session-expiry-check.ts 2030-01-01T00:00:00.000Z
+# Session expiry (2030-01-01T00:00:00.000Z): ACTIVE
+```
+
+## Tests
+
+```sh
+npx vitest run contrib/examples/session-expiry-check
+```

--- a/contrib/examples/session-expiry-check/session-expiry-check.test.ts
+++ b/contrib/examples/session-expiry-check/session-expiry-check.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+import { checkExpiry } from "./session-expiry-check";
+
+describe("checkExpiry", () => {
+  const now = new Date("2026-06-15T12:00:00.000Z");
+
+  it("reports a past timestamp as expired", () => {
+    expect(checkExpiry("2020-01-01T00:00:00.000Z", now)).toBe("expired");
+  });
+
+  it("reports a future timestamp as active", () => {
+    expect(checkExpiry("2030-01-01T00:00:00.000Z", now)).toBe("active");
+  });
+
+  it("treats an expiry exactly at now as expired", () => {
+    expect(checkExpiry(now.toISOString(), now)).toBe("expired");
+  });
+
+  it("rejects an invalid timestamp", () => {
+    expect(() => checkExpiry("not-a-date", now)).toThrow(RangeError);
+  });
+});

--- a/contrib/examples/session-expiry-check/session-expiry-check.ts
+++ b/contrib/examples/session-expiry-check/session-expiry-check.ts
@@ -1,0 +1,38 @@
+// Example: check a mock session expiry timestamp against the current time
+// and report whether it's expired or active.
+//
+// Run with: npx tsx session-expiry-check.ts <iso-timestamp>
+// Example:  npx tsx session-expiry-check.ts 2020-01-01T00:00:00.000Z
+
+export type ExpiryResult = "expired" | "active";
+
+export function checkExpiry(expiresAt: string, now: Date = new Date()): ExpiryResult {
+  const expiry = new Date(expiresAt);
+  if (Number.isNaN(expiry.getTime())) {
+    throw new RangeError(`"${expiresAt}" is not a valid ISO timestamp`);
+  }
+  return expiry.getTime() <= now.getTime() ? "expired" : "active";
+}
+
+function main() {
+  const arg = process.argv[2];
+  if (!arg) {
+    console.error("Usage: npx tsx session-expiry-check.ts <iso-timestamp>");
+    process.exitCode = 1;
+    return;
+  }
+
+  try {
+    const result = checkExpiry(arg);
+    console.log(`Session expiry (${arg}): ${result.toUpperCase()}`);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    console.error(`Error: ${message}`);
+    process.exitCode = 1;
+  }
+}
+
+// Only run when executed directly (not when imported by the test file).
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main();
+}


### PR DESCRIPTION
## Summary
Four standalone example scripts under contrib/examples/, each demonstrating a small piece of the wallet session and policy-body lifecycle with no real network/WebAuthn calls.

closes #10
closes #17
closes #18
closes #20

## Changes
- **#10 — connect-wallet-mock**: `connectWallet()` against a small in-file `MockWalletBackend`, resolving a known `keyId` to a session and throwing a clear caught error for an unknown one.
- **#17 — print-session**: pretty-prints a hardcoded `WalletSession` object's fields with clear labels; optional `serverSessionId`/`keyId` fall back to `(none)` when absent.
- **#18 — session-expiry-check**: CLI script comparing an ISO expiry timestamp (arg) against the current time, reporting `EXPIRED`/`ACTIVE`. An expiry exactly at "now" counts as expired.
- **#20 — generate-policy-body**: CLI script building a spending-limit policy body (matching the SDK's `SpendingConstructor` shape) from a daily limit (stroops) and window (seconds), validating both are positive integers.

## Test plan
- Each example has a colocated `*.test.ts` (vitest) — 12 new tests, all passing.
- Ran every script directly (`npx tsx ...`) and confirmed output matches each README exactly.
- `npm run typecheck`, `npm test` (149/149 passing), and `npm run build` all clean on top of this branch.
- All changes are confined to `contrib/examples/`; verified `git status` shows no files touched outside `contrib/`.