### PR TITLE
feat(examples): mock wallet-create, balance-read, fee, and policy-batch examples

### DIFF
--- a/contrib/examples/create-wallet-mock/README.md
+++ b/contrib/examples/create-wallet-mock/README.md
@@ -1,0 +1,31 @@
+# Create a wallet with a mock passkey kit
+
+Calls the real `createVellarWallet()` from the SDK with a small in-file mock
+`PasskeyKit` and backend — no real WebAuthn prompt, no network call — and
+prints the resulting session's `accountId` and `keyId`.
+
+## How the mock works
+
+- `createMockPasskeyKit()` returns fixed, deterministic identifiers from
+  `createWallet()` instead of prompting a real passkey ceremony.
+- `createMockBackend()` accepts the deployment and hands back a session id
+  without touching a real gateway.
+
+## Run it
+
+```sh
+npx tsx create-wallet.ts
+```
+
+Expected output:
+
+```
+accountId: CMOCKWALLETCONTRACTADDRESSXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+keyId:     mock-keyid-example-user
+```
+
+## Tests
+
+```sh
+npx vitest run contrib/examples/create-wallet-mock
+```

--- a/contrib/examples/create-wallet-mock/create-wallet.test.ts
+++ b/contrib/examples/create-wallet-mock/create-wallet.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+import { createVellarWallet } from "../../../src/index";
+import { createMockBackend, createMockPasskeyKit } from "./create-wallet";
+
+describe("createVellarWallet with a mocked passkey kit", () => {
+  it("creates a wallet and returns a session with accountId and keyId", async () => {
+    const wallet = createVellarWallet({
+      network: "testnet",
+      appName: "vellar-example-test",
+      kit: createMockPasskeyKit(),
+      backend: createMockBackend(),
+      sac: { getSACClient: () => ({ transfer: async () => "mock-tx" }) },
+      isValidAddress: () => true,
+    });
+
+    const session = await wallet.create({ username: "Test User" });
+
+    expect(session.accountId).toBe(
+      "CMOCKWALLETCONTRACTADDRESSXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+    );
+    expect(session.keyId).toBe("mock-keyid-test-user");
+    expect(session.connected).toBe(true);
+    expect(session.network).toBe("testnet");
+  });
+});

--- a/contrib/examples/create-wallet-mock/create-wallet.ts
+++ b/contrib/examples/create-wallet-mock/create-wallet.ts
@@ -1,0 +1,66 @@
+// Example: call the real createVellarWallet() with a small in-file mocked
+// PasskeyKit and backend (no real WebAuthn prompt, no network call), and
+// print the resulting session's accountId and keyId.
+//
+// Run with: npx tsx create-wallet.ts
+
+import { createVellarWallet, type PasskeyKitLike, type WalletBackend } from "../../../src/index";
+
+/** A minimal PasskeyKit stand-in: "creates" a wallet by returning fixed,
+ * deterministic identifiers instead of prompting WebAuthn. */
+function createMockPasskeyKit(): PasskeyKitLike {
+  return {
+    async createWallet(_app: string, user: string) {
+      return {
+        keyIdBase64: `mock-keyid-${user.toLowerCase().replace(/\s+/g, "-")}`,
+        contractId: "CMOCKWALLETCONTRACTADDRESSXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+        signedTx: "mock-signed-deployment-tx",
+      };
+    },
+    async connectWallet() {
+      throw new Error("mock kit: connectWallet is not used by this example");
+    },
+    async sign(tx: unknown) {
+      return tx;
+    },
+  };
+}
+
+/** A minimal backend stand-in: accepts the deployment and hands back a
+ * session id, without ever touching a real gateway. */
+function createMockBackend(): WalletBackend & {
+  submitTransaction(input: { signedXdr: string; network: "testnet" | "mainnet" }): Promise<{ hash: string }>;
+} {
+  return {
+    async submitWalletCreation() {
+      return { sessionId: "mock-session-id" };
+    },
+    async lookupContractId() {
+      return undefined;
+    },
+    async submitTransaction() {
+      return { hash: "mock-tx-hash" };
+    },
+  };
+}
+
+async function main() {
+  const wallet = createVellarWallet({
+    network: "testnet",
+    appName: "vellar-example",
+    kit: createMockPasskeyKit(),
+    backend: createMockBackend(),
+    sac: { getSACClient: () => ({ transfer: async () => "mock-tx" }) },
+    isValidAddress: () => true,
+  });
+
+  const session = await wallet.create({ username: "Example User" });
+  console.log("accountId:", session.accountId);
+  console.log("keyId:    ", session.keyId);
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main();
+}
+
+export { createMockPasskeyKit, createMockBackend };

--- a/contrib/examples/mock-fee-service/README.md
+++ b/contrib/examples/mock-fee-service/README.md
@@ -1,0 +1,28 @@
+# Mock fee estimation service
+
+A self-contained mock fee estimation function returning fixed sample fee
+values (in stroops) for `low`, `medium`, and `high` priority levels. Throws
+`UnknownFeePriorityError` for anything else.
+
+## Run it
+
+```sh
+npx tsx mock-fee-service.ts
+```
+
+Expected output:
+
+```
+low: 100 stroops
+medium: 10000 stroops
+high: 1000000 stroops
+invalid priority rejected: Unknown fee priority "urgent" — expected one of: low, medium, high
+```
+
+## Tests
+
+Covers all three valid priority levels plus an invalid one:
+
+```sh
+npx vitest run contrib/examples/mock-fee-service
+```

--- a/contrib/examples/mock-fee-service/mock-fee-service.test.ts
+++ b/contrib/examples/mock-fee-service/mock-fee-service.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from "vitest";
+import { estimateFee, UnknownFeePriorityError, type FeePriority } from "./mock-fee-service";
+
+describe("estimateFee", () => {
+  it.each([
+    ["low", 100n],
+    ["medium", 10_000n],
+    ["high", 1_000_000n],
+  ] as const)("returns a fixed fee for %s priority", (priority, expected) => {
+    expect(estimateFee(priority)).toBe(expected);
+  });
+
+  it("throws UnknownFeePriorityError for an unrecognized priority", () => {
+    expect(() => estimateFee("urgent" as FeePriority)).toThrow(UnknownFeePriorityError);
+    expect(() => estimateFee("urgent" as FeePriority)).toThrow(/Unknown fee priority "urgent"/);
+  });
+});

--- a/contrib/examples/mock-fee-service/mock-fee-service.ts
+++ b/contrib/examples/mock-fee-service/mock-fee-service.ts
@@ -1,0 +1,50 @@
+// Example: a mock fee estimation service returning fixed sample fee values
+// (in stroops) for low, medium, and high priority levels.
+//
+// Run with: npx tsx mock-fee-service.ts
+
+export type FeePriority = "low" | "medium" | "high";
+
+const FEES_BY_PRIORITY: Record<FeePriority, bigint> = {
+  low: 100n,
+  medium: 10_000n,
+  high: 1_000_000n,
+};
+
+export class UnknownFeePriorityError extends Error {
+  constructor(priority: string) {
+    super(
+      `Unknown fee priority "${priority}" — expected one of: ${Object.keys(FEES_BY_PRIORITY).join(", ")}`,
+    );
+    this.name = "UnknownFeePriorityError";
+  }
+}
+
+/** Returns a fixed sample fee (in stroops) for the given priority level. */
+export function estimateFee(priority: FeePriority): bigint {
+  const fee = FEES_BY_PRIORITY[priority];
+  if (fee === undefined) {
+    throw new UnknownFeePriorityError(priority);
+  }
+  return fee;
+}
+
+function main() {
+  for (const priority of ["low", "medium", "high"] as const) {
+    console.log(`${priority}: ${estimateFee(priority)} stroops`);
+  }
+
+  try {
+    // Deliberately an invalid priority (cast past the type system, since a
+    // real caller's input isn't statically known to be a FeePriority) to
+    // demonstrate the error path.
+    estimateFee("urgent" as FeePriority);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    console.log(`invalid priority rejected: ${message}`);
+  }
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main();
+}

--- a/contrib/examples/policy-simulation-batch-runner/README.md
+++ b/contrib/examples/policy-simulation-batch-runner/README.md
@@ -1,0 +1,43 @@
+# Policy simulation batch runner
+
+Simulates a candidate spending-limit policy against a batch of sample
+transactions all at once — a local evaluation (no network call) against the
+policy's `spendingLimits` and `allowlistedContracts` — and summarizes total
+pass/fail counts with a reason for each failure.
+
+## How it evaluates a transaction
+
+For each transaction, in this order:
+
+1. **Per-transaction limit** — fails if `amountXlm` exceeds
+   `spendingLimits.perTxXlm`.
+2. **Allowlist** — fails if the transaction has a `contractId` and
+   `allowlistedContracts` is set but doesn't include it.
+3. **Cumulative daily limit** — fails if adding this transaction's amount to
+   the running daily total (of previously *passed* transactions only) would
+   exceed `spendingLimits.dailyXlm`.
+
+A failed transaction's amount is never added to the running daily total —
+only passed transactions accumulate.
+
+## Run it
+
+```sh
+npx tsx batch-runner.ts
+```
+
+Expected output (5 sample transactions against a 200 XLM per-tx / 300 XLM
+daily / one-contract-allowlist policy):
+
+```
+Batch summary: 2/5 passed, 3/5 failed
+  FAIL tx-2: amount 250 XLM exceeds per-transaction limit 200 XLM
+  FAIL tx-3: contract CNOTALLOWLISTEDXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX is not in the allowlisted contracts
+  FAIL tx-5: cumulative daily total 350.00 XLM would exceed daily limit 300 XLM
+```
+
+## Tests
+
+```sh
+npx vitest run contrib/examples/policy-simulation-batch-runner
+```

--- a/contrib/examples/policy-simulation-batch-runner/batch-runner.test.ts
+++ b/contrib/examples/policy-simulation-batch-runner/batch-runner.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from "vitest";
+import type { PolicyDefinition } from "../../../src/types";
+import { runPolicySimulationBatch, type SampleTransaction } from "./batch-runner";
+
+describe("runPolicySimulationBatch", () => {
+  const policy: PolicyDefinition = {
+    version: "1",
+    type: "spending-limit",
+    owners: ["GOWNER"],
+    spendingLimits: { dailyXlm: "300", perTxXlm: "200" },
+    allowlistedContracts: ["CALLOWED"],
+  };
+
+  it("passes transactions within both the per-tx and daily limits", () => {
+    const transactions: SampleTransaction[] = [
+      { id: "tx-1", amountXlm: "100" },
+      { id: "tx-2", amountXlm: "150" },
+    ];
+    const result = runPolicySimulationBatch(policy, transactions);
+    expect(result).toEqual({ total: 2, passed: 2, failed: 0, failures: [] });
+  });
+
+  it("fails a transaction over the per-tx limit", () => {
+    const result = runPolicySimulationBatch(policy, [{ id: "tx-1", amountXlm: "250" }]);
+    expect(result.passed).toBe(0);
+    expect(result.failed).toBe(1);
+    expect(result.failures[0]).toEqual({
+      id: "tx-1",
+      reason: "amount 250 XLM exceeds per-transaction limit 200 XLM",
+    });
+  });
+
+  it("fails a transaction to a non-allowlisted contract", () => {
+    const result = runPolicySimulationBatch(policy, [
+      { id: "tx-1", amountXlm: "10", contractId: "CBADCONTRACT" },
+    ]);
+    expect(result.failures[0]).toEqual({
+      id: "tx-1",
+      reason: "contract CBADCONTRACT is not in the allowlisted contracts",
+    });
+  });
+
+  it("passes a transaction to an allowlisted contract", () => {
+    const result = runPolicySimulationBatch(policy, [
+      { id: "tx-1", amountXlm: "10", contractId: "CALLOWED" },
+    ]);
+    expect(result.passed).toBe(1);
+    expect(result.failed).toBe(0);
+  });
+
+  it("fails once the cumulative daily total would be exceeded, without double counting the failed amount", () => {
+    const transactions: SampleTransaction[] = [
+      { id: "tx-1", amountXlm: "200" },
+      { id: "tx-2", amountXlm: "150" }, // 200 + 150 = 350 > 300 daily limit
+      { id: "tx-3", amountXlm: "50" }, // 200 + 50 = 250 <= 300: passes, since tx-2's amount was never added
+    ];
+    const result = runPolicySimulationBatch(policy, transactions);
+    expect(result.passed).toBe(2);
+    expect(result.failed).toBe(1);
+    expect(result.failures[0]?.id).toBe("tx-2");
+    expect(result.failures[0]?.reason).toContain("exceed daily limit");
+  });
+
+  it("returns an empty summary for an empty batch", () => {
+    expect(runPolicySimulationBatch(policy, [])).toEqual({
+      total: 0,
+      passed: 0,
+      failed: 0,
+      failures: [],
+    });
+  });
+});

--- a/contrib/examples/policy-simulation-batch-runner/batch-runner.ts
+++ b/contrib/examples/policy-simulation-batch-runner/batch-runner.ts
@@ -1,0 +1,97 @@
+// Example: simulate a candidate spending-limit policy against a batch of
+// sample transactions all at once (no network call — a local evaluation
+// against the policy's spendingLimits/allowlistedContracts), and summarize
+// pass/fail counts with a reason for each failure.
+//
+// Run with: npx tsx batch-runner.ts
+
+import type { PolicyDefinition } from "../../../src/types";
+
+export interface SampleTransaction {
+  id: string;
+  /** Payment amount in whole XLM, as a decimal string. */
+  amountXlm: string;
+  /** Destination contract, when the transaction is a contract invocation. */
+  contractId?: string;
+}
+
+export interface BatchResult {
+  total: number;
+  passed: number;
+  failed: number;
+  failures: Array<{ id: string; reason: string }>;
+}
+
+/**
+ * Evaluates each transaction against the policy's per-tx limit, allowlist,
+ * and cumulative daily limit (in that order — the first violated rule is the
+ * reported reason). Transactions are evaluated in array order, and the daily
+ * total accumulates only over transactions that pass the earlier checks.
+ */
+export function runPolicySimulationBatch(
+  policy: PolicyDefinition,
+  transactions: SampleTransaction[],
+): BatchResult {
+  const perTxLimit = policy.spendingLimits?.perTxXlm
+    ? Number(policy.spendingLimits.perTxXlm)
+    : undefined;
+  const dailyLimit = policy.spendingLimits?.dailyXlm
+    ? Number(policy.spendingLimits.dailyXlm)
+    : undefined;
+  const allowlist = policy.allowlistedContracts;
+
+  const failures: BatchResult["failures"] = [];
+  let passed = 0;
+  let dailyTotal = 0;
+
+  for (const tx of transactions) {
+    const amount = Number(tx.amountXlm);
+    let reason: string | undefined;
+
+    if (perTxLimit !== undefined && amount > perTxLimit) {
+      reason = `amount ${tx.amountXlm} XLM exceeds per-transaction limit ${policy.spendingLimits!.perTxXlm} XLM`;
+    } else if (allowlist && allowlist.length > 0 && tx.contractId && !allowlist.includes(tx.contractId)) {
+      reason = `contract ${tx.contractId} is not in the allowlisted contracts`;
+    } else if (dailyLimit !== undefined && dailyTotal + amount > dailyLimit) {
+      reason = `cumulative daily total ${(dailyTotal + amount).toFixed(2)} XLM would exceed daily limit ${policy.spendingLimits!.dailyXlm} XLM`;
+    }
+
+    if (reason) {
+      failures.push({ id: tx.id, reason });
+    } else {
+      passed++;
+      dailyTotal += amount;
+    }
+  }
+
+  return { total: transactions.length, passed, failed: failures.length, failures };
+}
+
+function main() {
+  const samplePolicy: PolicyDefinition = {
+    version: "1",
+    type: "spending-limit",
+    owners: ["GOWNERAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF"],
+    spendingLimits: { dailyXlm: "300", perTxXlm: "200" },
+    allowlistedContracts: ["CUSDCAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"],
+  };
+
+  const sampleTransactions: SampleTransaction[] = [
+    { id: "tx-1", amountXlm: "100" }, // passes; daily total now 100
+    { id: "tx-2", amountXlm: "250" }, // fails: exceeds the 200 XLM per-tx limit
+    { id: "tx-3", amountXlm: "50", contractId: "CNOTALLOWLISTEDXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX" }, // fails: contract not allowlisted
+    { id: "tx-4", amountXlm: "150", contractId: "CUSDCAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA" }, // passes; daily total now 250
+    { id: "tx-5", amountXlm: "100" }, // fails: 250 + 100 = 350 exceeds the 300 XLM daily limit
+  ];
+
+  const result = runPolicySimulationBatch(samplePolicy, sampleTransactions);
+
+  console.log(`Batch summary: ${result.passed}/${result.total} passed, ${result.failed}/${result.total} failed`);
+  for (const failure of result.failures) {
+    console.log(`  FAIL ${failure.id}: ${failure.reason}`);
+  }
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main();
+}

--- a/contrib/examples/read-xlm-balance/README.md
+++ b/contrib/examples/read-xlm-balance/README.md
@@ -1,0 +1,43 @@
+# Read a native XLM balance
+
+Reads a native XLM balance for a given account using `vellar-sdk`'s
+RPC-backed balance reader (`createRpcBalanceReader` from the `vellar-sdk/rpc`
+subpath), and prints both the raw stroops amount and the formatted XLM
+amount.
+
+## Testnet RPC URL used
+
+`TESTNET.rpcUrl` from `src/config.ts`: `https://soroban-testnet.stellar.org`
+(SDF's public testnet Soroban RPC). The balance read is a simulated
+`balance(id)` contract call — no signature and no fee required.
+
+## Run it
+
+```sh
+npx tsx read-balance.ts <accountId>
+```
+
+Example:
+
+```sh
+npx tsx read-balance.ts GBRPYHIL2CI3FNQ4BXLFMNDLFJUNPU2HY3ZMFSHONUCEOASW7QC7OX2H
+```
+
+Expected output shape:
+
+```
+Account:  GBRPYHIL2CI3FNQ4BXLFMNDLFJUNPU2HY3ZMFSHONUCEOASW7QC7OX2H
+Balance:  1250000000 stroops (125 XLM)
+```
+
+Requires network access to reach the testnet RPC; the account must exist on
+testnet or the simulation call will fail with a clear error.
+
+## Tests
+
+The unit tests inject a mock `BalanceReader` so they don't depend on a live
+RPC call:
+
+```sh
+npx vitest run contrib/examples/read-xlm-balance
+```

--- a/contrib/examples/read-xlm-balance/read-balance.test.ts
+++ b/contrib/examples/read-xlm-balance/read-balance.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it, vi } from "vitest";
+import type { BalanceReader } from "../../../src/balances";
+import { readXlmBalance } from "./read-balance";
+
+describe("readXlmBalance", () => {
+  const xlm = { symbol: "XLM", contractId: "CNATIVE", decimals: 7 };
+
+  it("returns both raw stroops and formatted XLM", async () => {
+    const reader: BalanceReader = {
+      getTokenBalance: vi.fn().mockResolvedValue(1_250_000_000n),
+    };
+
+    const result = await readXlmBalance(reader, xlm, "GHOLDER");
+
+    expect(result.stroops).toBe(1_250_000_000n);
+    expect(result.xlm).toBe("125");
+    expect(reader.getTokenBalance).toHaveBeenCalledWith("CNATIVE", "GHOLDER");
+  });
+
+  it("propagates reader failures", async () => {
+    const reader: BalanceReader = {
+      getTokenBalance: vi.fn().mockRejectedValue(new Error("rpc unreachable")),
+    };
+    await expect(readXlmBalance(reader, xlm, "GHOLDER")).rejects.toThrow("rpc unreachable");
+  });
+});

--- a/contrib/examples/read-xlm-balance/read-balance.ts
+++ b/contrib/examples/read-xlm-balance/read-balance.ts
@@ -1,0 +1,55 @@
+// Example: read a native XLM balance for a given account using the SDK's
+// RPC-backed balance reader, and print both the raw stroops amount and the
+// formatted XLM amount.
+//
+// Run with: npx tsx read-balance.ts <accountId>
+// Example:  npx tsx read-balance.ts GBRPYHIL2CI3FNQ4BXLFMNDLFJUNPU2HY3ZMFSHONUCEOASW7QC7OX2H
+
+import { formatTokenAmount, type BalanceReader, type TokenInfo } from "../../../src/balances";
+import { createRpcBalanceReader, nativeToken } from "../../../src/rpc";
+import { TESTNET } from "../../../src/config";
+
+export interface XlmBalanceResult {
+  stroops: bigint;
+  xlm: string;
+}
+
+/** Reads and formats one account's native balance. Reader/token are injected
+ * so this is directly unit-testable without a real RPC round trip. */
+export async function readXlmBalance(
+  reader: BalanceReader,
+  token: TokenInfo,
+  accountId: string,
+): Promise<XlmBalanceResult> {
+  const stroops = await reader.getTokenBalance(token.contractId, accountId);
+  return { stroops, xlm: formatTokenAmount(stroops, token.decimals) };
+}
+
+async function main() {
+  const accountId = process.argv[2];
+  if (!accountId) {
+    console.error("Usage: npx tsx read-balance.ts <accountId>");
+    process.exitCode = 1;
+    return;
+  }
+
+  const reader = createRpcBalanceReader({
+    rpcUrl: TESTNET.rpcUrl,
+    networkPassphrase: TESTNET.networkPassphrase,
+  });
+  const token = nativeToken(TESTNET.networkPassphrase);
+
+  try {
+    const { stroops, xlm } = await readXlmBalance(reader, token, accountId);
+    console.log(`Account:  ${accountId}`);
+    console.log(`Balance:  ${stroops} stroops (${xlm} XLM)`);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    console.error(`Error reading balance: ${message}`);
+    process.exitCode = 1;
+  }
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main();
+}


### PR DESCRIPTION
## Summary
Four standalone examples under contrib/examples/, spanning mocked wallet creation, a real RPC balance read, a mock fee service, and a local policy-batch simulator.

closes #9
closes #11
closes #122
closes #132

## Changes
- **#9 — create-wallet-mock**: calls the real `createVellarWallet()` with a small in-file mocked `PasskeyKit` and backend (no real WebAuthn/network), prints the resulting session's `accountId`/`keyId`.
- **#11 — read-xlm-balance**: CLI script reading a native XLM balance via the SDK's RPC-backed reader (`vellar-sdk/rpc`, testnet), printing raw stroops and formatted XLM. Reader/token injected so the formatting logic is unit-testable without a live RPC call.
- **#122 — mock-fee-service**: `estimateFee(priority)` returning fixed sample fees (stroops) for `low`/`medium`/`high`, throwing `UnknownFeePriorityError` otherwise.
- **#132 — policy-simulation-batch-runner**: `runPolicySimulationBatch()` evaluates a batch of sample transactions against a candidate spending-limit policy's per-tx limit, contract allowlist, and cumulative daily limit (checked in that order), reporting pass/fail counts and a reason for each failure.

## Test plan
- Each example has a colocated `*.test.ts` (vitest) — 13 new tests, all passing. #11's tests inject a mock `BalanceReader` rather than hitting the live testnet RPC.
- Ran every script directly (`npx tsx ...`) and confirmed output matches each README exactly.
- `npm run typecheck`, `npm test` (150/150 passing), and `npm run build` all clean on top of this branch.
- All changes are confined to `contrib/examples/`; verified `git status` shows no files touched outside `contrib/`.