### PR TITLE
feat(examples): session store, mock backend, batch balance, and tx-poll examples

### DIFF
--- a/contrib/examples/batch-balance-lookup/README.md
+++ b/contrib/examples/batch-balance-lookup/README.md
@@ -1,0 +1,28 @@
+# Batch balance lookup
+
+Resolves a batch of `{account, token}` balance lookups concurrently via
+`Promise.allSettled`, returning a same-length array of per-item results in
+input order. A single failing lookup is reported per-item — it never blocks
+or fails the other lookups in the batch.
+
+## Run it
+
+```sh
+npx tsx batch-balance-lookup.ts
+```
+
+Expected output (the mock reader intentionally fails only the USDC lookup):
+
+```
+GALICE (XLM): 500000000
+GBOB (USDC): FAILED — simulation failed for GBOB
+GCAROL (XLM): 500000000
+```
+
+## Tests
+
+Covers a batch with one intentionally failing lookup:
+
+```sh
+npx vitest run contrib/examples/batch-balance-lookup
+```

--- a/contrib/examples/batch-balance-lookup/batch-balance-lookup.test.ts
+++ b/contrib/examples/batch-balance-lookup/batch-balance-lookup.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+import type { BalanceReader, TokenInfo } from "../../../src/balances";
+import { batchLookupBalances } from "./batch-balance-lookup";
+
+describe("batchLookupBalances", () => {
+  const xlm: TokenInfo = { symbol: "XLM", contractId: "CNATIVE", decimals: 7 };
+  const usdc: TokenInfo = { symbol: "USDC", contractId: "CUSDC", decimals: 7 };
+
+  it("returns a same-length array of results in input order", async () => {
+    const reader: BalanceReader = { getTokenBalance: async () => 100n };
+    const results = await batchLookupBalances(reader, [
+      { account: "GA", token: xlm },
+      { account: "GB", token: usdc },
+    ]);
+    expect(results).toHaveLength(2);
+    expect(results[0]).toEqual({ account: "GA", token: xlm, ok: true, amount: 100n });
+    expect(results[1]).toEqual({ account: "GB", token: usdc, ok: true, amount: 100n });
+  });
+
+  it("reports one failing lookup per-item without blocking the others", async () => {
+    const reader: BalanceReader = {
+      async getTokenBalance(tokenContractId, holder) {
+        if (tokenContractId === "CUSDC") throw new Error(`simulation failed for ${holder}`);
+        return 250n;
+      },
+    };
+
+    const results = await batchLookupBalances(reader, [
+      { account: "GA", token: xlm },
+      { account: "GB", token: usdc },
+      { account: "GC", token: xlm },
+    ]);
+
+    expect(results[0]).toEqual({ account: "GA", token: xlm, ok: true, amount: 250n });
+    expect(results[1]).toEqual({
+      account: "GB",
+      token: usdc,
+      ok: false,
+      error: "simulation failed for GB",
+    });
+    expect(results[2]).toEqual({ account: "GC", token: xlm, ok: true, amount: 250n });
+  });
+
+  it("returns an empty array for an empty batch", async () => {
+    const reader: BalanceReader = { getTokenBalance: async () => 0n };
+    await expect(batchLookupBalances(reader, [])).resolves.toEqual([]);
+  });
+});

--- a/contrib/examples/batch-balance-lookup/batch-balance-lookup.ts
+++ b/contrib/examples/batch-balance-lookup/batch-balance-lookup.ts
@@ -1,0 +1,73 @@
+// Example: resolve a batch of {account, token} balance lookups concurrently,
+// returning a same-length array of per-item results in order. One failing
+// lookup does not prevent the others from resolving.
+//
+// Run with: npx tsx batch-balance-lookup.ts
+
+import type { BalanceReader, TokenInfo } from "../../../src/balances";
+
+export interface BalanceLookup {
+  account: string;
+  token: TokenInfo;
+}
+
+export type BalanceLookupResult =
+  | { account: string; token: TokenInfo; ok: true; amount: bigint }
+  | { account: string; token: TokenInfo; ok: false; error: string };
+
+/**
+ * Resolves every lookup concurrently via Promise.allSettled, so a single
+ * rejected lookup is reported per-item rather than rejecting the whole
+ * batch or blocking the others.
+ */
+export async function batchLookupBalances(
+  reader: BalanceReader,
+  lookups: BalanceLookup[],
+): Promise<BalanceLookupResult[]> {
+  const settled = await Promise.allSettled(
+    lookups.map((lookup) => reader.getTokenBalance(lookup.token.contractId, lookup.account)),
+  );
+
+  return settled.map((result, i) => {
+    const { account, token } = lookups[i]!;
+    if (result.status === "fulfilled") {
+      return { account, token, ok: true, amount: result.value };
+    }
+    const error = result.reason instanceof Error ? result.reason.message : String(result.reason);
+    return { account, token, ok: false, error };
+  });
+}
+
+async function main() {
+  const xlm: TokenInfo = { symbol: "XLM", contractId: "CNATIVE", decimals: 7 };
+  const usdc: TokenInfo = { symbol: "USDC", contractId: "CUSDC", decimals: 7 };
+
+  // A mock reader: fails only for the CUSDC lookup, to demonstrate that one
+  // failure doesn't block the others.
+  const reader: BalanceReader = {
+    async getTokenBalance(tokenContractId, holder) {
+      if (tokenContractId === "CUSDC") {
+        throw new Error(`simulation failed for ${holder}`);
+      }
+      return 500_000_000n;
+    },
+  };
+
+  const results = await batchLookupBalances(reader, [
+    { account: "GALICE", token: xlm },
+    { account: "GBOB", token: usdc },
+    { account: "GCAROL", token: xlm },
+  ]);
+
+  for (const result of results) {
+    if (result.ok) {
+      console.log(`${result.account} (${result.token.symbol}): ${result.amount}`);
+    } else {
+      console.log(`${result.account} (${result.token.symbol}): FAILED — ${result.error}`);
+    }
+  }
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main();
+}

--- a/contrib/examples/memory-session-store/README.md
+++ b/contrib/examples/memory-session-store/README.md
@@ -1,0 +1,36 @@
+# In-memory session store
+
+A minimal in-memory store for a `WalletSession`, exposing `getSession()` and
+`setSession()` operating on a module-level variable.
+
+**For examples and tests only — not production.** A real app should persist
+sessions with `createWebStorageAdapter` (or a custom `SessionStorageAdapter`)
+from `vellar-sdk`'s `src/session.ts`. A plain module-level variable is lost on
+reload/restart and is shared globally across everything that imports this
+module — there is no per-user or per-tab isolation.
+
+## Run it
+
+```sh
+npx tsx memory-session-store.ts
+```
+
+Expected output:
+
+```
+Before setSession: null
+After setSession:  {
+  accountId: 'CABC123SAMPLEWALLETCONTRACTADDRESSXXXXXXXXXXXXXXXXXXXXXX',
+  network: 'testnet',
+  connected: true,
+  authMethod: 'passkey',
+  createdAt: '2026-01-15T09:30:00.000Z',
+  lastActiveAt: '2026-01-15T09:30:00.000Z'
+}
+```
+
+## Tests
+
+```sh
+npx vitest run contrib/examples/memory-session-store
+```

--- a/contrib/examples/memory-session-store/memory-session-store.test.ts
+++ b/contrib/examples/memory-session-store/memory-session-store.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+import { getSession, setSession, type WalletSession } from "./memory-session-store";
+
+const sample: WalletSession = {
+  accountId: "CTEST",
+  network: "testnet",
+  connected: true,
+  authMethod: "passkey",
+  createdAt: "2026-01-01T00:00:00.000Z",
+  lastActiveAt: "2026-01-01T00:00:00.000Z",
+};
+
+describe("memory session store", () => {
+  it("returns null before any session is set", () => {
+    expect(getSession()).toBeNull();
+  });
+
+  it("returns the session that was set", () => {
+    setSession(sample);
+    expect(getSession()).toEqual(sample);
+  });
+
+  it("overwrites the previous session on a second setSession call", () => {
+    setSession(sample);
+    const updated = { ...sample, accountId: "CTEST2" };
+    setSession(updated);
+    expect(getSession()).toEqual(updated);
+  });
+});

--- a/contrib/examples/memory-session-store/memory-session-store.ts
+++ b/contrib/examples/memory-session-store/memory-session-store.ts
@@ -1,0 +1,47 @@
+// Example: a minimal in-memory store for a wallet session, with getSession
+// and setSession operating on a module-level variable.
+//
+// NOTE: for examples and tests only — not production. A real app persists
+// sessions with createWebStorageAdapter (or similar) from vellar-sdk's
+// src/session.ts, not a plain module variable, which is lost on reload and
+// shared across everything that imports this module.
+//
+// Run with: npx tsx memory-session-store.ts
+
+export interface WalletSession {
+  accountId: string;
+  network: "testnet" | "mainnet";
+  connected: boolean;
+  authMethod: "passkey";
+  createdAt: string;
+  lastActiveAt: string;
+}
+
+let currentSession: WalletSession | null = null;
+
+export function setSession(session: WalletSession): void {
+  currentSession = session;
+}
+
+export function getSession(): WalletSession | null {
+  return currentSession;
+}
+
+function main() {
+  console.log("Before setSession:", getSession());
+
+  setSession({
+    accountId: "CABC123SAMPLEWALLETCONTRACTADDRESSXXXXXXXXXXXXXXXXXXXXXX",
+    network: "testnet",
+    connected: true,
+    authMethod: "passkey",
+    createdAt: "2026-01-15T09:30:00.000Z",
+    lastActiveAt: "2026-01-15T09:30:00.000Z",
+  });
+
+  console.log("After setSession: ", getSession());
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main();
+}

--- a/contrib/examples/mock-wallet-backend/README.md
+++ b/contrib/examples/mock-wallet-backend/README.md
@@ -1,0 +1,29 @@
+# Mock wallet backend for offline testing
+
+A mock `WalletBackend` implementing `submitWalletCreation`, `lookupContractId`,
+and `submitTransaction`, each returning a fixed, documented canned response
+instead of a real network call — useful for offline tests that need to wire
+a backend into `createVellarWallet()`.
+
+## Canned responses
+
+| Method | Returns |
+| --- | --- |
+| `submitWalletCreation` | `{ sessionId: CANNED_SESSION_ID }` |
+| `lookupContractId` | `{ contractId: CANNED_CONTRACT_ID, sessionId: CANNED_SESSION_ID }` |
+| `submitTransaction` | `{ hash: CANNED_TX_HASH }` |
+
+## Run it
+
+```sh
+npx tsx mock-wallet-backend.ts
+```
+
+Wires the mock backend (plus a minimal mock passkey kit) into the real
+`createVellarWallet()` and calls `create()`, printing the resulting session.
+
+## Tests
+
+```sh
+npx vitest run contrib/examples/mock-wallet-backend
+```

--- a/contrib/examples/mock-wallet-backend/mock-wallet-backend.test.ts
+++ b/contrib/examples/mock-wallet-backend/mock-wallet-backend.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+import {
+  CANNED_CONTRACT_ID,
+  CANNED_SESSION_ID,
+  CANNED_TX_HASH,
+  createMockWalletBackend,
+} from "./mock-wallet-backend";
+
+describe("createMockWalletBackend", () => {
+  it("submitWalletCreation returns the canned session id", async () => {
+    const backend = createMockWalletBackend();
+    await expect(
+      backend.submitWalletCreation({
+        keyId: "any",
+        contractId: "any",
+        network: "testnet",
+        signedTx: "any",
+      }),
+    ).resolves.toEqual({ sessionId: CANNED_SESSION_ID });
+  });
+
+  it("lookupContractId returns the canned contract and session id", async () => {
+    const backend = createMockWalletBackend();
+    await expect(backend.lookupContractId({ keyId: "any", network: "testnet" })).resolves.toEqual({
+      contractId: CANNED_CONTRACT_ID,
+      sessionId: CANNED_SESSION_ID,
+    });
+  });
+
+  it("submitTransaction returns the canned tx hash", async () => {
+    const backend = createMockWalletBackend();
+    await expect(
+      backend.submitTransaction({ signedXdr: "any", network: "testnet" }),
+    ).resolves.toEqual({ hash: CANNED_TX_HASH });
+  });
+});

--- a/contrib/examples/mock-wallet-backend/mock-wallet-backend.ts
+++ b/contrib/examples/mock-wallet-backend/mock-wallet-backend.ts
@@ -1,0 +1,75 @@
+// Example: a mock WalletBackend returning fixed, documented canned responses
+// for create, connect, and submit — for offline tests that need a
+// createVellarWallet() backend without a real gateway.
+//
+// Run with: npx tsx mock-wallet-backend.ts
+
+import { createVellarWallet, type PasskeyKitLike, type WalletBackend } from "../../../src/index";
+
+export const CANNED_SESSION_ID = "mock-session-id-canned";
+export const CANNED_CONTRACT_ID = "CMOCKBACKENDCONTRACTADDRESSXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX";
+export const CANNED_TX_HASH = "mock-tx-hash-canned";
+
+/**
+ * A mock WalletBackend for offline tests: every call resolves immediately
+ * with a fixed, documented response instead of making a network request.
+ *
+ *   - submitWalletCreation → { sessionId: CANNED_SESSION_ID }
+ *   - lookupContractId     → { contractId: CANNED_CONTRACT_ID, sessionId: CANNED_SESSION_ID }
+ *   - submitTransaction    → { hash: CANNED_TX_HASH }
+ */
+export function createMockWalletBackend(): WalletBackend & {
+  submitTransaction(input: {
+    signedXdr: string;
+    network: "testnet" | "mainnet";
+  }): Promise<{ hash: string }>;
+} {
+  return {
+    async submitWalletCreation() {
+      return { sessionId: CANNED_SESSION_ID };
+    },
+    async lookupContractId() {
+      return { contractId: CANNED_CONTRACT_ID, sessionId: CANNED_SESSION_ID };
+    },
+    async submitTransaction() {
+      return { hash: CANNED_TX_HASH };
+    },
+  };
+}
+
+/** A minimal PasskeyKit stand-in, just enough to drive create()/connect(). */
+function createMockPasskeyKit(): PasskeyKitLike {
+  return {
+    async createWallet(_app: string, user: string) {
+      return {
+        keyIdBase64: `mock-keyid-${user.toLowerCase().replace(/\s+/g, "-")}`,
+        contractId: CANNED_CONTRACT_ID,
+        signedTx: "mock-signed-deployment-tx",
+      };
+    },
+    async connectWallet() {
+      return { keyIdBase64: "mock-keyid-reconnect", contractId: CANNED_CONTRACT_ID };
+    },
+    async sign(tx: unknown) {
+      return tx;
+    },
+  };
+}
+
+async function main() {
+  const wallet = createVellarWallet({
+    network: "testnet",
+    appName: "vellar-example",
+    kit: createMockPasskeyKit(),
+    backend: createMockWalletBackend(),
+    sac: { getSACClient: () => ({ transfer: async () => "mock-tx" }) },
+    isValidAddress: () => true,
+  });
+
+  const session = await wallet.create({ username: "Offline Test User" });
+  console.log("Wired mock backend into createVellarWallet(); session:", session);
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main();
+}

--- a/contrib/examples/poll-until-final/README.md
+++ b/contrib/examples/poll-until-final/README.md
@@ -1,0 +1,27 @@
+# Poll a transaction hash until finality
+
+Polls a status function for a transaction hash on an interval until it
+reports `"success"` or `"failed"`, or rejects with `PollTimeoutError` once a
+maximum number of attempts is exhausted.
+
+## Run it
+
+```sh
+npx tsx poll-until-final.ts
+```
+
+Uses a mock status function that reports `"pending"` for the first two calls
+and `"success"` on the third:
+
+```
+Final status after 3 calls: success
+```
+
+## Tests
+
+Uses a mock status function and an injected no-op `sleep`, so the tests run
+instantly with no real delays:
+
+```sh
+npx vitest run contrib/examples/poll-until-final
+```

--- a/contrib/examples/poll-until-final/poll-until-final.test.ts
+++ b/contrib/examples/poll-until-final/poll-until-final.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it, vi } from "vitest";
+import { PollTimeoutError, pollUntilFinal, type StatusFn } from "./poll-until-final";
+
+const noSleep = vi.fn(async () => {});
+
+describe("pollUntilFinal", () => {
+  it("resolves as soon as a non-pending status is seen", async () => {
+    let calls = 0;
+    const getStatus: StatusFn = async () => {
+      calls++;
+      return calls < 3 ? "pending" : "success";
+    };
+
+    const result = await pollUntilFinal(getStatus, "hash", {
+      intervalMs: 10,
+      maxAttempts: 5,
+      sleep: noSleep,
+    });
+
+    expect(result).toBe("success");
+    expect(calls).toBe(3);
+  });
+
+  it("resolves with 'failed' when that's the reported status", async () => {
+    const getStatus: StatusFn = async () => "failed";
+    await expect(
+      pollUntilFinal(getStatus, "hash", { intervalMs: 10, maxAttempts: 3, sleep: noSleep }),
+    ).resolves.toBe("failed");
+  });
+
+  it("rejects with PollTimeoutError once attempts are exhausted", async () => {
+    const getStatus: StatusFn = async () => "pending";
+    await expect(
+      pollUntilFinal(getStatus, "hash", { intervalMs: 10, maxAttempts: 3, sleep: noSleep }),
+    ).rejects.toThrow(PollTimeoutError);
+  });
+
+  it("calls getStatus exactly maxAttempts times when never final", async () => {
+    let calls = 0;
+    const getStatus: StatusFn = async () => {
+      calls++;
+      return "pending";
+    };
+    await expect(
+      pollUntilFinal(getStatus, "hash", { intervalMs: 10, maxAttempts: 4, sleep: noSleep }),
+    ).rejects.toThrow();
+    expect(calls).toBe(4);
+  });
+
+  it("does not sleep after the final attempt", async () => {
+    const sleep = vi.fn(async () => {});
+    const getStatus: StatusFn = async () => "pending";
+    await expect(
+      pollUntilFinal(getStatus, "hash", { intervalMs: 10, maxAttempts: 3, sleep }),
+    ).rejects.toThrow();
+    expect(sleep).toHaveBeenCalledTimes(2);
+  });
+});

--- a/contrib/examples/poll-until-final/poll-until-final.ts
+++ b/contrib/examples/poll-until-final/poll-until-final.ts
@@ -1,0 +1,63 @@
+// Example: poll a status function for a transaction hash on an interval
+// until it reports a final ("success" | "failed") status, or reject once a
+// maximum number of attempts is exhausted.
+//
+// Run with: npx tsx poll-until-final.ts
+
+export type TxStatus = "pending" | "success" | "failed";
+export type StatusFn = (hash: string) => Promise<TxStatus>;
+
+export class PollTimeoutError extends Error {
+  constructor(hash: string, maxAttempts: number) {
+    super(`Transaction ${hash} was still pending after ${maxAttempts} attempts`);
+    this.name = "PollTimeoutError";
+  }
+}
+
+export interface PollOptions {
+  intervalMs: number;
+  maxAttempts: number;
+  /** Injectable sleep, so tests can run without real delays. */
+  sleep?: (ms: number) => Promise<void>;
+}
+
+/**
+ * Calls `getStatus(hash)` up to `maxAttempts` times, waiting `intervalMs`
+ * between attempts. Resolves as soon as a non-pending status is seen;
+ * rejects with PollTimeoutError if every attempt returns "pending".
+ */
+export async function pollUntilFinal(
+  getStatus: StatusFn,
+  hash: string,
+  options: PollOptions,
+): Promise<"success" | "failed"> {
+  const sleep = options.sleep ?? ((ms) => new Promise<void>((resolve) => setTimeout(resolve, ms)));
+
+  for (let attempt = 1; attempt <= options.maxAttempts; attempt++) {
+    const status = await getStatus(hash);
+    if (status !== "pending") return status;
+    if (attempt < options.maxAttempts) {
+      await sleep(options.intervalMs);
+    }
+  }
+  throw new PollTimeoutError(hash, options.maxAttempts);
+}
+
+async function main() {
+  // A mock status function: pending for the first two calls, then success.
+  let calls = 0;
+  const mockGetStatus: StatusFn = async () => {
+    calls++;
+    return calls < 3 ? "pending" : "success";
+  };
+
+  const result = await pollUntilFinal(mockGetStatus, "mock-tx-hash", {
+    intervalMs: 50,
+    maxAttempts: 5,
+  });
+  console.log(`Final status after ${calls} calls: ${result}`);
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main();
+}


### PR DESCRIPTION
## Summary
Four standalone examples under contrib/examples/, covering an in-memory session store, a mock WalletBackend, concurrent batch balance lookups, and polling a transaction to finality.

closes #36
closes #39
closes #42
closes #43

## Changes
- **#36 — memory-session-store**: minimal `getSession`/`setSession` pair on a module-level variable. README notes this is for examples/tests only, not production (real apps should use `createWebStorageAdapter` from `src/session.ts`).
- **#39 — mock-wallet-backend**: `createMockWalletBackend()` implements `submitWalletCreation`/`lookupContractId`/`submitTransaction` with fixed, documented canned responses; wired into the real `createVellarWallet()` and exercised via `create()`.
- **#42 — batch-balance-lookup**: `batchLookupBalances()` resolves an array of `{account, token}` pairs concurrently via `Promise.allSettled`, returning a same-length, in-order result array — one failing lookup is reported per-item without blocking the others.
- **#43 — poll-until-final**: `pollUntilFinal()` polls a status function on an interval up to a max attempt count, resolving on the first non-pending status or rejecting with `PollTimeoutError` once attempts are exhausted.

## Test plan
- Each example has a colocated `*.test.ts` (vitest) — 14 new tests, all passing. #43's tests inject a no-op `sleep` so they run with no real delays.
- Ran every script directly (`npx tsx ...`) and confirmed output matches each README.
- `npm run typecheck`, `npm test` (151/151 passing), and `npm run build` all clean on top of this branch.
- All changes are confined to `contrib/examples/`; verified `git status` shows no files touched outside `contrib/`.