### PR TITLE
feat(examples): session key, public key derivation, contract id, and mainnet-info examples

### DIFF
--- a/contrib/examples/check-contract-id/README.md
+++ b/contrib/examples/check-contract-id/README.md
@@ -1,0 +1,43 @@
+# Check a contract id looks well-formed
+
+Checks whether a given string looks like a valid Stellar contract id: starts
+with `C`, is 56 characters, and passes `@stellar/stellar-sdk`'s `StrKey`
+checksum/encoding validation.
+
+## Example contract ids
+
+Valid:
+
+```
+CDFDULU2JWKGMIJW6FJWJJKNB3JIDQK54YTBDQUNPZTBYXCXCSO3MVZG
+```
+
+Invalid — wrong prefix (a classic `G...` account address, not a contract):
+
+```
+GDFDULU2JWKGMIJW6FJWJJKNB3JIDQK54YTBDQUNPZTBYXCXCSO3MVZG
+```
+
+Invalid — wrong length:
+
+```
+CTOOSHORT
+```
+
+Invalid — right shape, bad checksum (last character flipped):
+
+```
+CDFDULU2JWKGMIJW6FJWJJKNB3JIDQK54YTBDQUNPZTBYXCXCSO3MVZA
+```
+
+## Run it
+
+```sh
+npx tsx check-contract-id.ts <contractId>
+```
+
+## Tests
+
+```sh
+npx vitest run contrib/examples/check-contract-id
+```

--- a/contrib/examples/check-contract-id/check-contract-id.test.ts
+++ b/contrib/examples/check-contract-id/check-contract-id.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+import { checkContractId } from "./check-contract-id";
+
+const VALID_CONTRACT_ID = "CDFDULU2JWKGMIJW6FJWJJKNB3JIDQK54YTBDQUNPZTBYXCXCSO3MVZG";
+const BAD_CHECKSUM_CONTRACT_ID = "CDFDULU2JWKGMIJW6FJWJJKNB3JIDQK54YTBDQUNPZTBYXCXCSO3MVZA";
+
+describe("checkContractId", () => {
+  it("accepts a well-formed contract id", () => {
+    expect(checkContractId(VALID_CONTRACT_ID)).toEqual({ valid: true });
+  });
+
+  it("rejects a string not starting with C", () => {
+    const result = checkContractId("GDFDULU2JWKGMIJW6FJWJJKNB3JIDQK54YTBDQUNPZTBYXCXCSO3MVZG");
+    expect(result.valid).toBe(false);
+    expect(result.reason).toMatch(/must start with "C"/);
+  });
+
+  it("rejects a string of the wrong length", () => {
+    const result = checkContractId("CTOOSHORT");
+    expect(result.valid).toBe(false);
+    expect(result.reason).toMatch(/must be 56 characters/);
+  });
+
+  it("rejects a well-formed-looking string with a bad checksum", () => {
+    const result = checkContractId(BAD_CHECKSUM_CONTRACT_ID);
+    expect(result.valid).toBe(false);
+    expect(result.reason).toMatch(/checksum/);
+  });
+});

--- a/contrib/examples/check-contract-id/check-contract-id.ts
+++ b/contrib/examples/check-contract-id/check-contract-id.ts
@@ -1,0 +1,46 @@
+// Example: check whether a given string looks like a valid Stellar contract
+// id — starts with "C", the expected length, and passes StrKey's checksum
+// validation.
+//
+// Run with: npx tsx check-contract-id.ts <contractId>
+
+import { StrKey } from "@stellar/stellar-sdk";
+
+export interface ContractIdCheck {
+  valid: boolean;
+  reason?: string;
+}
+
+export function checkContractId(contractId: string): ContractIdCheck {
+  if (!contractId.startsWith("C")) {
+    return { valid: false, reason: `must start with "C", got "${contractId[0] ?? ""}"` };
+  }
+  if (contractId.length !== 56) {
+    return { valid: false, reason: `must be 56 characters, got ${contractId.length}` };
+  }
+  if (!StrKey.isValidContract(contractId)) {
+    return { valid: false, reason: "failed strkey checksum/encoding validation" };
+  }
+  return { valid: true };
+}
+
+function main() {
+  const contractId = process.argv[2];
+  if (!contractId) {
+    console.error("Usage: npx tsx check-contract-id.ts <contractId>");
+    process.exitCode = 1;
+    return;
+  }
+
+  const result = checkContractId(contractId);
+  if (result.valid) {
+    console.log(`VALID: ${contractId}`);
+  } else {
+    console.log(`INVALID: ${contractId} (${result.reason})`);
+    process.exitCode = 1;
+  }
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main();
+}

--- a/contrib/examples/derive-public-key/README.md
+++ b/contrib/examples/derive-public-key/README.md
@@ -1,0 +1,34 @@
+# Derive a public key from a secret key
+
+Derives and prints the public key for a given ed25519 secret key using
+`@stellar/stellar-sdk`'s `Keypair.fromSecret`.
+
+> ⚠️ **Never use a real mainnet secret with this script.** Treat any secret
+> passed as a command-line argument as compromised — it's visible in your
+> shell history and process list. Testnet keys only.
+
+## Run it
+
+```sh
+npx tsx derive-public-key.ts <secretKey>
+```
+
+Example:
+
+```sh
+npx tsx derive-public-key.ts SBLSDBW6NOP5AA6P2M4ZOIRP3MCZEOGTHDFENNAMTES4TCSPJYR4MCT6
+# Public key: GAMKAXTK27YHSNPNEFBUGFJXKFQKSB32R6KVVNZP4V2DEWBIFPGPE4UG
+```
+
+A malformed secret key prints a clear error instead of a raw stack trace:
+
+```sh
+npx tsx derive-public-key.ts not-a-real-key
+# Error: "not-a-real-key" is not a valid ed25519 secret key (expected a 56-char string starting with "S")
+```
+
+## Tests
+
+```sh
+npx vitest run contrib/examples/derive-public-key
+```

--- a/contrib/examples/derive-public-key/derive-public-key.test.ts
+++ b/contrib/examples/derive-public-key/derive-public-key.test.ts
@@ -1,0 +1,20 @@
+import { Keypair } from "@stellar/stellar-sdk";
+import { describe, expect, it } from "vitest";
+import { derivePublicKey } from "./derive-public-key";
+
+describe("derivePublicKey", () => {
+  it("derives the matching public key for a valid secret", () => {
+    const keypair = Keypair.random();
+    expect(derivePublicKey(keypair.secret())).toBe(keypair.publicKey());
+  });
+
+  it("throws a clear error for a malformed secret key", () => {
+    expect(() => derivePublicKey("not-a-secret-key")).toThrow(
+      /is not a valid ed25519 secret key/,
+    );
+  });
+
+  it("throws a clear error for an empty string", () => {
+    expect(() => derivePublicKey("")).toThrow(/is not a valid ed25519 secret key/);
+  });
+});

--- a/contrib/examples/derive-public-key/derive-public-key.ts
+++ b/contrib/examples/derive-public-key/derive-public-key.ts
@@ -1,0 +1,42 @@
+// Example: derive and print the public key for a given ed25519 secret key.
+//
+// ⚠️  Never pass a real mainnet secret to this (or any) example script —
+// treat it as compromised the moment it touches a command line argument or
+// a script you didn't write yourself. Testnet keys only.
+//
+// Run with: npx tsx derive-public-key.ts <secretKey>
+
+import { Keypair } from "@stellar/stellar-sdk";
+
+export function derivePublicKey(secretKey: string): string {
+  let keypair: Keypair;
+  try {
+    keypair = Keypair.fromSecret(secretKey);
+  } catch {
+    throw new Error(
+      `"${secretKey}" is not a valid ed25519 secret key (expected a 56-char string starting with "S")`,
+    );
+  }
+  return keypair.publicKey();
+}
+
+function main() {
+  const secretKey = process.argv[2];
+  if (!secretKey) {
+    console.error("Usage: npx tsx derive-public-key.ts <secretKey>");
+    process.exitCode = 1;
+    return;
+  }
+
+  try {
+    console.log("Public key:", derivePublicKey(secretKey));
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    console.error(`Error: ${message}`);
+    process.exitCode = 1;
+  }
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main();
+}

--- a/contrib/examples/generate-session-key/README.md
+++ b/contrib/examples/generate-session-key/README.md
@@ -1,0 +1,40 @@
+# Generate a random ed25519 session key pair
+
+Generates a random ed25519 keypair suitable for use as an x402 session key
+signer (`createSessionKeySigner` from `vellar-sdk`), and prints both the
+public key and the secret key.
+
+> ⚠️ **Testnet only.** The keypair printed by this script is generated fresh
+> on every run and holds no funds. Never fund a key generated this way on
+> mainnet, and never reuse a printed secret for anything real — treat every
+> run's output as disposable.
+
+## Using the keypair with createSessionKeySigner
+
+`createSessionKeySigner` (from `vellar-sdk`'s `src/x402-signer.ts`) takes the
+secret key plus the smart-account C-address it's authorized to sign for:
+
+```ts
+import { createSessionKeySigner } from "vellar-sdk";
+
+const signer = createSessionKeySigner({
+  address: "C...", // the wallet's smart-account contract id
+  secretKey: "S...", // the secret key this script printed
+});
+```
+
+The session key's spending authority is bounded on-chain by the
+spending-limit policy attached to it — this script only generates the raw
+keypair, it does not attach any policy.
+
+## Run it
+
+```sh
+npx tsx generate-session-key.ts
+```
+
+## Tests
+
+```sh
+npx vitest run contrib/examples/generate-session-key
+```

--- a/contrib/examples/generate-session-key/generate-session-key.test.ts
+++ b/contrib/examples/generate-session-key/generate-session-key.test.ts
@@ -1,0 +1,19 @@
+import { Keypair } from "@stellar/stellar-sdk";
+import { describe, expect, it } from "vitest";
+import { generateSessionKeyPair } from "./generate-session-key";
+
+describe("generateSessionKeyPair", () => {
+  it("returns a public/secret key pair that round-trips through Keypair.fromSecret", () => {
+    const { publicKey, secretKey } = generateSessionKeyPair();
+
+    expect(publicKey.startsWith("G")).toBe(true);
+    expect(secretKey.startsWith("S")).toBe(true);
+    expect(Keypair.fromSecret(secretKey).publicKey()).toBe(publicKey);
+  });
+
+  it("generates a different keypair on each call", () => {
+    const first = generateSessionKeyPair();
+    const second = generateSessionKeyPair();
+    expect(first.secretKey).not.toBe(second.secretKey);
+  });
+});

--- a/contrib/examples/generate-session-key/generate-session-key.ts
+++ b/contrib/examples/generate-session-key/generate-session-key.ts
@@ -1,0 +1,31 @@
+// Example: generate a random ed25519 keypair suitable for use as an x402
+// session key signer (vellar-sdk's createSessionKeySigner).
+//
+// ⚠️  TESTNET ONLY. The secret key printed here is generated fresh each run
+// and has no funds — never fund it on mainnet or reuse it for a real wallet.
+//
+// Run with: npx tsx generate-session-key.ts
+
+import { Keypair } from "@stellar/stellar-sdk";
+
+export interface SessionKeyPair {
+  publicKey: string;
+  secretKey: string;
+}
+
+export function generateSessionKeyPair(): SessionKeyPair {
+  const keypair = Keypair.random();
+  return { publicKey: keypair.publicKey(), secretKey: keypair.secret() };
+}
+
+function main() {
+  const { publicKey, secretKey } = generateSessionKeyPair();
+  console.log("Public key:", publicKey);
+  console.log("Secret key:", secretKey);
+  console.log();
+  console.log("⚠️  Testnet only — do not fund this key or reuse it on mainnet.");
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main();
+}

--- a/contrib/examples/mainnet-network-info/README.md
+++ b/contrib/examples/mainnet-network-info/README.md
@@ -1,0 +1,33 @@
+# Mainnet network info
+
+Prints the canonical Stellar mainnet network passphrase and its CAIP-2
+identifier. Pure constant lookup — no network calls.
+
+## Where this is used in the SDK
+
+- `MAINNET.networkPassphrase` (`src/config.ts`) is one of the SDK-verified
+  fields in the `MAINNET` / `mainnetConfig()` `NetworkConfig` — used to
+  construct `PasskeyKit`/`SACClient` and to sign/submit transactions on the
+  correct network.
+- The `stellar:pubnet` CAIP-2 identifier is how the SDK's x402 client
+  (`src/x402-client.ts`) tags mainnet payment requirements per the x402 v2
+  spec (`PaymentRequirements.network`, `src/x402-types.ts`).
+
+## Run it
+
+```sh
+npx tsx mainnet-network-info.ts
+```
+
+Expected output:
+
+```
+Network passphrase: Public Global Stellar Network ; September 2015
+CAIP-2 identifier:  stellar:pubnet
+```
+
+## Tests
+
+```sh
+npx vitest run contrib/examples/mainnet-network-info
+```

--- a/contrib/examples/mainnet-network-info/mainnet-network-info.test.ts
+++ b/contrib/examples/mainnet-network-info/mainnet-network-info.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from "vitest";
+import { MAINNET } from "../../../src/config";
+import { MAINNET_CAIP2 } from "./mainnet-network-info";
+
+describe("mainnet network info", () => {
+  it("exposes the canonical mainnet passphrase from src/config", () => {
+    expect(MAINNET.networkPassphrase).toBe("Public Global Stellar Network ; September 2015");
+  });
+
+  it("exposes the stellar:pubnet CAIP-2 identifier", () => {
+    expect(MAINNET_CAIP2).toBe("stellar:pubnet");
+  });
+});

--- a/contrib/examples/mainnet-network-info/mainnet-network-info.ts
+++ b/contrib/examples/mainnet-network-info/mainnet-network-info.ts
@@ -1,0 +1,21 @@
+// Example: print the canonical Stellar mainnet network passphrase and its
+// CAIP-2 identifier. Pure constant lookup — no network calls.
+//
+// Run with: npx tsx mainnet-network-info.ts
+
+import { MAINNET } from "../../../src/config";
+
+// The CAIP-2 identifier vellar-sdk's x402 client maps mainnet to internally
+// (src/x402-client.ts's CAIP2_BY_NETWORK / src/x402-types.ts's
+// PaymentRequirements.network doc) — not exported as a named constant, so
+// it's reproduced here as the same literal.
+export const MAINNET_CAIP2 = "stellar:pubnet";
+
+function main() {
+  console.log("Network passphrase:", MAINNET.networkPassphrase);
+  console.log("CAIP-2 identifier: ", MAINNET_CAIP2);
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main();
+}


### PR DESCRIPTION
## Summary
Four standalone example scripts under contrib/examples/, covering ed25519 session key generation, public-key derivation, contract-id validation, and a mainnet network-info constant lookup.

closes #26
closes #27
closes #28
closes #30

## Changes
- **#26 — generate-session-key**: generates a random ed25519 keypair (`Keypair.random()`) suitable for `createSessionKeySigner`, prints both keys with a testnet-only warning and a note on wiring the secret into the real signer.
- **#27 — derive-public-key**: CLI script deriving the public key for a given ed25519 secret via `Keypair.fromSecret`, with a clear error for malformed input and a warning against real mainnet secrets.
- **#28 — check-contract-id**: CLI script checking a string looks like a valid Stellar contract id — starts with `C`, 56 chars, and passes `StrKey.isValidContract` checksum validation — reporting which specific check failed.
- **#30 — mainnet-network-info**: prints `MAINNET.networkPassphrase` (`src/config.ts`) and the `stellar:pubnet` CAIP-2 identifier the SDK's x402 client uses internally. Pure constant lookup, no network calls.

## Test plan
- Each example has a colocated `*.test.ts` (vitest) — 11 new tests, all passing.
- Ran every script directly (`npx tsx ...`) and confirmed output matches each README exactly, including the malformed-input error paths for #27/#28.
- `npm run typecheck`, `npm test` (148/148 passing), and `npm run build` all clean on top of this branch.
- All changes are confined to `contrib/examples/`; verified `git status` shows no files touched outside `contrib/`.