### PR TITLE
feat(examples): payment build and x402 header encode/decode examples

### DIFF
--- a/contrib/examples/build-payment-only/README.md
+++ b/contrib/examples/build-payment-only/README.md
@@ -1,0 +1,39 @@
+# Build a payment without submitting it
+
+Builds (and simulates) a payment transaction using the real
+`createPaymentClient()`, prints the built XDR, and stops — the transaction is
+never signed or submitted.
+
+## The simulate step during build
+
+`preparePayment()` calls the SAC client's `transfer()`, which — for the real
+SAC client — **builds and simulates** the transfer transaction against the
+network in the same step (an `AssembledTransaction.build()`/simulate call).
+Simulation failures (e.g. insufficient balance, a bad recipient) surface
+right here, before any signature is ever requested. Only `confirm()` (which
+this example deliberately never calls) actually signs and submits.
+
+This example uses a mock SAC client instead of the real one, so it never
+touches the network — the "built XDR" it prints is a mock string built
+locally, not a real network-simulated transaction.
+
+## Run it
+
+```sh
+npx tsx build-payment.ts <to> <amount> <tokenContractId>
+```
+
+Example:
+
+```sh
+npx tsx build-payment.ts GRECIPIENT... 10.5 CTOKENCONTRACT...
+```
+
+The sender (`from`) is a hardcoded sample address — a real app would use
+`wallet.session.accountId`, not a CLI argument.
+
+## Tests
+
+```sh
+npx vitest run contrib/examples/build-payment-only
+```

--- a/contrib/examples/build-payment-only/build-payment.test.ts
+++ b/contrib/examples/build-payment-only/build-payment.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+import { createPaymentClient } from "../../../src/payments-client";
+import type { TokenInfo } from "../../../src/balances";
+import { createMockSacClient } from "./build-payment";
+
+describe("build-payment-only (mock SAC client)", () => {
+  it("builds and simulates a payment without ever submitting it", async () => {
+    const { sac, getLastBuilt } = createMockSacClient();
+    const paymentClient = createPaymentClient({
+      kit: { sign: async (tx: unknown) => tx },
+      sac,
+      backend: {
+        async submitTransaction() {
+          throw new Error("submitTransaction must never be called by this example");
+        },
+      },
+      network: "testnet",
+      isValidAddress: () => true,
+    });
+
+    const token: TokenInfo = { symbol: "TOKEN", contractId: "CTOKEN", decimals: 7 };
+    const prepared = await paymentClient.preparePayment({
+      from: "CFROM",
+      to: "GTO",
+      token,
+      amount: 105_000_000n,
+    });
+
+    expect(prepared.review).toEqual({
+      from: "CFROM",
+      to: "GTO",
+      token,
+      amount: 105_000_000n,
+      network: "testnet",
+    });
+    expect(getLastBuilt()?.toXDR()).toContain("CTOKEN");
+    expect(getLastBuilt()?.toXDR()).toContain("105000000");
+    // Deliberately never call prepared.confirm() — that's the whole point of
+    // this example, and the mock backend throws if it's ever reached.
+  });
+});

--- a/contrib/examples/build-payment-only/build-payment.ts
+++ b/contrib/examples/build-payment-only/build-payment.ts
@@ -1,0 +1,90 @@
+// Example: build (and simulate) a payment transaction using the real
+// payments client, print the built XDR, and stop — the transaction is never
+// signed or submitted.
+//
+// Run with: npx tsx build-payment.ts <to> <amount> <tokenContractId>
+// Example:  npx tsx build-payment.ts GRECIPIENT... 10.5 CTOKENCONTRACT...
+
+import { createPaymentClient, type SacClientLike } from "../../../src/payments-client";
+import { parseTokenAmount } from "../../../src/payments";
+import type { TokenInfo } from "../../../src/balances";
+
+interface BuiltTx {
+  toXDR(): string;
+}
+
+/**
+ * A mock SAC client: "builds" a transfer by returning an object with a
+ * toXDR() method (the same shape the real SAC client's AssembledTransaction
+ * exposes), and remembers the last one built so the caller can inspect it —
+ * preparePayment()'s public API only exposes `review` and `confirm()`, not
+ * the built tx itself.
+ */
+export function createMockSacClient(): {
+  sac: SacClientLike;
+  getLastBuilt: () => BuiltTx | undefined;
+} {
+  let lastBuilt: BuiltTx | undefined;
+  const sac: SacClientLike = {
+    getSACClient(tokenContractId: string) {
+      return {
+        async transfer(args: { from: string; to: string; amount: bigint }) {
+          const tx: BuiltTx = {
+            toXDR: () =>
+              `MOCKXDR(contract=${tokenContractId},from=${args.from},to=${args.to},amount=${args.amount})`,
+          };
+          lastBuilt = tx;
+          return tx;
+        },
+      };
+    },
+  };
+  return { sac, getLastBuilt: () => lastBuilt };
+}
+
+export async function main() {
+  const [to, amountArg, tokenContractId] = process.argv.slice(2);
+  if (!to || !amountArg || !tokenContractId) {
+    console.error("Usage: npx tsx build-payment.ts <to> <amount> <tokenContractId>");
+    process.exitCode = 1;
+    return;
+  }
+
+  // A sample sender — a real app would use wallet.session.accountId, not a CLI arg.
+  const from = "CFROMSAMPLESENDERWALLETADDRESSXXXXXXXXXXXXXXXXXXXXXXXXXX";
+  const token: TokenInfo = { symbol: "TOKEN", contractId: tokenContractId, decimals: 7 };
+
+  let amount: bigint;
+  try {
+    amount = parseTokenAmount(amountArg, token.decimals);
+  } catch (err) {
+    console.error(`Error: ${err instanceof Error ? err.message : String(err)}`);
+    process.exitCode = 1;
+    return;
+  }
+
+  const { sac, getLastBuilt } = createMockSacClient();
+  const paymentClient = createPaymentClient({
+    kit: { sign: async (tx: unknown) => tx },
+    sac,
+    backend: {
+      async submitTransaction() {
+        throw new Error("submitTransaction should never be called — this example never confirms");
+      },
+    },
+    network: "testnet",
+    isValidAddress: () => true,
+  });
+
+  const prepared = await paymentClient.preparePayment({ from, to, token, amount });
+
+  console.log("Built payment (simulated during build; NOT signed or submitted):");
+  console.log("  XDR:   ", getLastBuilt()?.toXDR());
+  console.log("  Review:", prepared.review);
+  console.log();
+  console.log("This script deliberately never calls prepared.confirm() — no signature, no submission.");
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main();
+}

--- a/contrib/examples/build-payment-requirements/README.md
+++ b/contrib/examples/build-payment-requirements/README.md
@@ -1,0 +1,35 @@
+# Build an x402 payment requirements object
+
+Constructs a sample x402 `PaymentRequirements`-style object by hand and
+prints it as JSON, validating that `amount` is a plain digit string first.
+
+## Where this shape comes from
+
+This mirrors `PaymentRequirements` from `vellar-sdk`'s `src/x402-types.ts` —
+one accepted payment option in an x402 `PAYMENT-REQUIRED` challenge (x402 v2).
+`amount` is the token's base units as a decimal string (so an i128-range
+amount round-trips exactly; it's never a JS `number`).
+
+## Run it
+
+```sh
+npx tsx build-payment-requirements.ts
+```
+
+Expected output:
+
+```json
+{
+  "scheme": "exact",
+  "network": "stellar:testnet",
+  "asset": "CUSDCAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+  "amount": "2500000",
+  "payTo": "CPAYTOSAMPLEADDRESSXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
+}
+```
+
+## Tests
+
+```sh
+npx vitest run contrib/examples/build-payment-requirements
+```

--- a/contrib/examples/build-payment-requirements/build-payment-requirements.test.ts
+++ b/contrib/examples/build-payment-requirements/build-payment-requirements.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+import { buildPaymentRequirements } from "./build-payment-requirements";
+
+describe("buildPaymentRequirements", () => {
+  it("builds a scheme=exact requirements object", () => {
+    expect(
+      buildPaymentRequirements({
+        network: "stellar:testnet",
+        asset: "CUSDC",
+        amount: "2500000",
+        payTo: "CPAYTO",
+      }),
+    ).toEqual({
+      scheme: "exact",
+      network: "stellar:testnet",
+      asset: "CUSDC",
+      amount: "2500000",
+      payTo: "CPAYTO",
+    });
+  });
+
+  it("rejects a non-digit amount", () => {
+    expect(() =>
+      buildPaymentRequirements({ network: "stellar:testnet", asset: "CUSDC", amount: "2.5", payTo: "CPAYTO" }),
+    ).toThrow(/must be a plain digit string/);
+  });
+
+  it("rejects an empty amount", () => {
+    expect(() =>
+      buildPaymentRequirements({ network: "stellar:testnet", asset: "CUSDC", amount: "", payTo: "CPAYTO" }),
+    ).toThrow(/must be a plain digit string/);
+  });
+});

--- a/contrib/examples/build-payment-requirements/build-payment-requirements.ts
+++ b/contrib/examples/build-payment-requirements/build-payment-requirements.ts
@@ -1,0 +1,38 @@
+// Example: construct a sample x402 PaymentRequirements-shaped object by
+// hand and print it as JSON.
+//
+// Run with: npx tsx build-payment-requirements.ts
+
+export interface PaymentRequirements {
+  scheme: string;
+  network: string;
+  asset: string;
+  amount: string;
+  payTo: string;
+}
+
+export function buildPaymentRequirements(input: {
+  network: string;
+  asset: string;
+  amount: string;
+  payTo: string;
+}): PaymentRequirements {
+  if (!/^\d+$/.test(input.amount)) {
+    throw new Error(`amount must be a plain digit string (base units), got "${input.amount}"`);
+  }
+  return { scheme: "exact", network: input.network, asset: input.asset, amount: input.amount, payTo: input.payTo };
+}
+
+function main() {
+  const requirements = buildPaymentRequirements({
+    network: "stellar:testnet",
+    asset: "CUSDCAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+    amount: "2500000",
+    payTo: "CPAYTOSAMPLEADDRESSXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+  });
+  console.log(JSON.stringify(requirements, null, 2));
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main();
+}

--- a/contrib/examples/decode-payment-required/README.md
+++ b/contrib/examples/decode-payment-required/README.md
@@ -1,0 +1,48 @@
+# Decode a mock PAYMENT-REQUIRED header
+
+Decodes a base64-encoded JSON string as a mock x402 `PAYMENT-REQUIRED`
+header value. x402 v2 carries payment requirements in the 402 response's
+`PAYMENT-REQUIRED` header as base64 JSON — see `vellar-sdk`'s
+`decodePaymentRequired` in `src/x402-client.ts` (this example reimplements
+the same base64-decode step, standalone, for a raw string instead of a
+`Response` object).
+
+## Example
+
+Encoded value:
+
+```
+eyJ4NDAyVmVyc2lvbiI6MiwiYWNjZXB0cyI6W3sic2NoZW1lIjoiZXhhY3QiLCJuZXR3b3JrIjoic3RlbGxhcjp0ZXN0bmV0IiwiYXNzZXQiOiJDVVNEQyIsImFtb3VudCI6IjI1MDAwMDAiLCJwYXlUbyI6IkNQQVlUTyJ9XX0=
+```
+
+Decoded output:
+
+```json
+{
+  "x402Version": 2,
+  "accepts": [
+    {
+      "scheme": "exact",
+      "network": "stellar:testnet",
+      "asset": "CUSDC",
+      "amount": "2500000",
+      "payTo": "CPAYTO"
+    }
+  ]
+}
+```
+
+## Run it
+
+```sh
+npx tsx decode-payment-required.ts <base64String>
+```
+
+A string that isn't valid base64, or that decodes to something that isn't
+valid JSON, prints a clear error instead of a raw exception.
+
+## Tests
+
+```sh
+npx vitest run contrib/examples/decode-payment-required
+```

--- a/contrib/examples/decode-payment-required/decode-payment-required.test.ts
+++ b/contrib/examples/decode-payment-required/decode-payment-required.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+import { decodePaymentRequiredHeader } from "./decode-payment-required";
+
+describe("decodePaymentRequiredHeader", () => {
+  it("decodes a valid base64 JSON payload", () => {
+    const sample = { x402Version: 2, accepts: [{ scheme: "exact" }] };
+    const encoded = btoa(JSON.stringify(sample));
+    expect(decodePaymentRequiredHeader(encoded)).toEqual(sample);
+  });
+
+  it("throws a clear error for a string that is not valid base64", () => {
+    expect(() => decodePaymentRequiredHeader("not-valid-base64!!!")).toThrow(
+      /not valid base64/,
+    );
+  });
+
+  it("throws a clear error when the decoded content is not valid JSON", () => {
+    const notJson = btoa("this is not json");
+    expect(() => decodePaymentRequiredHeader(notJson)).toThrow(/not valid JSON/);
+  });
+});

--- a/contrib/examples/decode-payment-required/decode-payment-required.ts
+++ b/contrib/examples/decode-payment-required/decode-payment-required.ts
@@ -1,0 +1,49 @@
+// Example: decode a base64-encoded JSON string as a mock x402
+// PAYMENT-REQUIRED header value (x402 v2 carries payment requirements this
+// way — see vellar-sdk's src/x402-client.ts decodePaymentRequired).
+//
+// Run with: npx tsx decode-payment-required.ts <base64String>
+
+// Browser-safe base64 helpers, matching src/x402-client.ts's utf8ToBase64 /
+// base64ToUtf8 (this package targets bundlers/browsers, no Buffer).
+function base64ToUtf8(b64: string): string {
+  const bin = atob(b64);
+  const bytes = new Uint8Array(bin.length);
+  for (let i = 0; i < bin.length; i++) bytes[i] = bin.charCodeAt(i);
+  return new TextDecoder().decode(bytes);
+}
+
+export function decodePaymentRequiredHeader(base64: string): unknown {
+  let json: string;
+  try {
+    json = base64ToUtf8(base64);
+  } catch {
+    throw new Error(`"${base64}" is not valid base64`);
+  }
+  try {
+    return JSON.parse(json);
+  } catch {
+    throw new Error(`Decoded base64 is not valid JSON: ${json}`);
+  }
+}
+
+function main() {
+  const base64 = process.argv[2];
+  if (!base64) {
+    console.error("Usage: npx tsx decode-payment-required.ts <base64String>");
+    process.exitCode = 1;
+    return;
+  }
+
+  try {
+    const decoded = decodePaymentRequiredHeader(base64);
+    console.log(JSON.stringify(decoded, null, 2));
+  } catch (err) {
+    console.error(`Error: ${err instanceof Error ? err.message : String(err)}`);
+    process.exitCode = 1;
+  }
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main();
+}

--- a/contrib/examples/encode-payment-signature/README.md
+++ b/contrib/examples/encode-payment-signature/README.md
@@ -1,0 +1,34 @@
+# Encode a mock PAYMENT-SIGNATURE header
+
+Encodes a JSON object describing a payment as a base64 string suitable for
+an x402 `PAYMENT-SIGNATURE` request header — the same shape `vellar-sdk`'s
+`buildSignedPayment` produces internally (`src/x402-client.ts`):
+`{ x402Version, accepted, payload: { transaction } }`.
+
+## How a server decodes this value
+
+The server reverses the same encoding: base64-decode the header value to a
+UTF-8 string, then `JSON.parse` it. In this SDK that's
+`decodePaymentRequired`'s `base64ToUtf8` step in `src/x402-client.ts` (used
+there for the `PAYMENT-REQUIRED` header, but the same decode logic applies to
+`PAYMENT-SIGNATURE`).
+
+## Run it
+
+With the hardcoded sample payload:
+
+```sh
+npx tsx encode-payment-signature.ts
+```
+
+Or with your own JSON (as a single quoted argument):
+
+```sh
+npx tsx encode-payment-signature.ts '{"x402Version":2,"accepted":{"scheme":"exact"}}'
+```
+
+## Tests
+
+```sh
+npx vitest run contrib/examples/encode-payment-signature
+```

--- a/contrib/examples/encode-payment-signature/encode-payment-signature.test.ts
+++ b/contrib/examples/encode-payment-signature/encode-payment-signature.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from "vitest";
+import { encodePaymentSignature } from "./encode-payment-signature";
+
+describe("encodePaymentSignature", () => {
+  it("base64-encodes the JSON payload, decodable back to the original", () => {
+    const payload = { x402Version: 2, accepted: { scheme: "exact" } };
+    const encoded = encodePaymentSignature(payload);
+    expect(JSON.parse(atob(encoded))).toEqual(payload);
+  });
+
+  it("produces a stable encoding for the same input", () => {
+    const payload = { a: 1, b: "two" };
+    expect(encodePaymentSignature(payload)).toBe(encodePaymentSignature(payload));
+  });
+});

--- a/contrib/examples/encode-payment-signature/encode-payment-signature.ts
+++ b/contrib/examples/encode-payment-signature/encode-payment-signature.ts
@@ -1,0 +1,52 @@
+// Example: encode a small JSON object describing a payment as a base64
+// string suitable for an x402 PAYMENT-SIGNATURE request header (the shape
+// vellar-sdk's src/x402-client.ts buildSignedPayment produces).
+//
+// Run with: npx tsx encode-payment-signature.ts ['<json>']
+// If no argument is given, a hardcoded sample payload is used.
+
+// Browser-safe base64 helper, matching src/x402-client.ts's utf8ToBase64
+// (this package targets bundlers/browsers, no Buffer).
+function utf8ToBase64(s: string): string {
+  const bytes = new TextEncoder().encode(s);
+  let bin = "";
+  for (const b of bytes) bin += String.fromCharCode(b);
+  return btoa(bin);
+}
+
+export function encodePaymentSignature(payload: unknown): string {
+  return utf8ToBase64(JSON.stringify(payload));
+}
+
+const SAMPLE_PAYLOAD = {
+  x402Version: 2,
+  accepted: {
+    scheme: "exact",
+    network: "stellar:testnet",
+    asset: "CUSDCAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+    amount: "2500000",
+    payTo: "CPAYTOSAMPLEADDRESSXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+  },
+  payload: { transaction: "MOCKXDRTRANSACTIONBASE64==" },
+};
+
+function main() {
+  const jsonArg = process.argv[2];
+  let payload: unknown = SAMPLE_PAYLOAD;
+
+  if (jsonArg) {
+    try {
+      payload = JSON.parse(jsonArg);
+    } catch {
+      console.error(`Error: "${jsonArg}" is not valid JSON`);
+      process.exitCode = 1;
+      return;
+    }
+  }
+
+  console.log(encodePaymentSignature(payload));
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main();
+}


### PR DESCRIPTION
## Summary
Four standalone examples under contrib/examples/, covering building a payment without submitting it, and the x402 payment-requirements/header encode-decode round trip.

closes #13
closes #23
closes #24
closes #25

## Changes
- **#13 — build-payment-only**: builds and simulates a payment via the real `createPaymentClient` with a mock SAC client, prints the built XDR, and deliberately never calls `prepared.confirm()` (the mock backend throws if reached, proving it's never called).
- **#23 — build-payment-requirements**: constructs a sample x402 `PaymentRequirements` object by hand (`scheme`/`network`/`asset`/`amount`/`payTo`), validating `amount` is a plain digit string, prints as JSON.
- **#24 — decode-payment-required**: CLI script decoding a base64 JSON string as a mock `PAYMENT-REQUIRED` header value, matching the decode step in `src/x402-client.ts`'s `decodePaymentRequired`. Clear errors for invalid base64 or non-JSON content.
- **#25 — encode-payment-signature**: encodes a JSON payment payload as base64 for a `PAYMENT-SIGNATURE` header, matching `src/x402-client.ts`'s `buildSignedPayment` encoding. Accepts an inline JSON arg or a hardcoded sample.

## Test plan
- Each example has a colocated `*.test.ts` (vitest) — 9 new tests, all passing.
- Ran every script directly (`npx tsx ...`) and confirmed output matches each README, including the round trip: #25's encoded output decodes back via #24's logic to the original object.
- `npm run typecheck`, `npm test` (146/146 passing), and `npm run build` all clean on top of this branch.
- All changes are confined to `contrib/examples/`; verified `git status` shows no files touched outside `contrib/`.