### PR TITLE
feat(examples): tx-hash, address validation, asset list, and stroops-parsing examples

### DIFF
--- a/contrib/examples/format-tx-hash/README.md
+++ b/contrib/examples/format-tx-hash/README.md
@@ -1,0 +1,25 @@
+# Format a transaction hash for display
+
+Formats a full transaction hash as a shortened display string (first six and
+last four characters), for showing in a UI without wrapping or truncation
+mid-layout.
+
+## Examples
+
+| Input | Output |
+| --- | --- |
+| `a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1b2` | `a1b2c3...a1b2` |
+| `shorthash123` | `shorth...h123` |
+| `abc` (shorter than 6+4) | `abc` (returned unchanged) |
+
+## Run it
+
+```sh
+npx tsx format-tx-hash.ts
+```
+
+## Tests
+
+```sh
+npx vitest run contrib/examples/format-tx-hash
+```

--- a/contrib/examples/format-tx-hash/format-tx-hash.test.ts
+++ b/contrib/examples/format-tx-hash/format-tx-hash.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+import { formatTxHash } from "./format-tx-hash";
+
+describe("formatTxHash", () => {
+  it("shortens a long hash to first 6 + last 4 characters", () => {
+    const hash = "a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1b2";
+    expect(formatTxHash(hash)).toBe("a1b2c3...a1b2");
+  });
+
+  it("returns a hash exactly at the head+tail length unchanged", () => {
+    expect(formatTxHash("1234567890")).toBe("1234567890"); // 10 chars = 6 + 4
+  });
+
+  it("returns a shorter hash unchanged without throwing", () => {
+    expect(formatTxHash("abc")).toBe("abc");
+    expect(formatTxHash("")).toBe("");
+  });
+
+  it("supports custom head/tail lengths", () => {
+    expect(formatTxHash("abcdefghijklmnop", 3, 2)).toBe("abc...op");
+  });
+});

--- a/contrib/examples/format-tx-hash/format-tx-hash.ts
+++ b/contrib/examples/format-tx-hash/format-tx-hash.ts
@@ -1,0 +1,31 @@
+// Example: format a full transaction hash as a shortened display string
+// (first six + last four characters), for showing in a UI without wrapping.
+//
+// Run with: npx tsx format-tx-hash.ts
+
+/**
+ * Shortens a hash to "<first 6>...<last 4>". A hash no longer than
+ * headLen + tailLen is returned unchanged rather than throwing or producing
+ * a nonsensical (or negative-length) slice.
+ */
+export function formatTxHash(hash: string, headLen = 6, tailLen = 4): string {
+  if (hash.length <= headLen + tailLen) {
+    return hash;
+  }
+  return `${hash.slice(0, headLen)}...${hash.slice(-tailLen)}`;
+}
+
+function main() {
+  const examples = [
+    "a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1b2",
+    "shorthash123",
+    "abc",
+  ];
+  for (const hash of examples) {
+    console.log(`${hash}  ->  ${formatTxHash(hash)}`);
+  }
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main();
+}

--- a/contrib/examples/list-testnet-assets/README.md
+++ b/contrib/examples/list-testnet-assets/README.md
@@ -1,0 +1,36 @@
+# List testnet asset codes
+
+Prints a fixed list of common testnet asset codes useful for manual testing,
+as a simple formatted table.
+
+> **This is a static reference list, not a live query.** The SDK has no
+> "list assets" endpoint, and testnet issuers/liquidity change over time —
+> verify an asset (and its issuer) still exists on testnet before relying on
+> it in a real test.
+
+## Run it
+
+```sh
+npx tsx list-testnet-assets.ts
+```
+
+Expected output:
+
+```
+CODE   DESCRIPTION
+------------------
+XLM    Native Stellar Lumens — no issuer, always available
+USDC   Circle's testnet USD Coin, widely used for payment demos
+yUSDC  Yield-bearing wrapped testnet USDC used in some DeFi demos
+SRT    Common StellarX testnet reward/test token
+TEST   Generic placeholder code many sample issuers mint for demos
+BTC    Testnet-issued synthetic Bitcoin-pegged asset used in anchor demos
+
+Static reference list — not a live query. Verify an asset/issuer still exists on testnet before use.
+```
+
+## Tests
+
+```sh
+npx vitest run contrib/examples/list-testnet-assets
+```

--- a/contrib/examples/list-testnet-assets/list-testnet-assets.test.ts
+++ b/contrib/examples/list-testnet-assets/list-testnet-assets.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+import { TESTNET_ASSETS } from "./list-testnet-assets";
+
+describe("TESTNET_ASSETS", () => {
+  it("lists at least 5 sample asset codes", () => {
+    expect(TESTNET_ASSETS.length).toBeGreaterThanOrEqual(5);
+  });
+
+  it("gives every asset a non-empty code and description", () => {
+    for (const asset of TESTNET_ASSETS) {
+      expect(asset.code.length).toBeGreaterThan(0);
+      expect(asset.description.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("includes the native XLM asset", () => {
+    expect(TESTNET_ASSETS.some((a) => a.code === "XLM")).toBe(true);
+  });
+
+  it("has no duplicate asset codes", () => {
+    const codes = TESTNET_ASSETS.map((a) => a.code);
+    expect(new Set(codes).size).toBe(codes.length);
+  });
+});

--- a/contrib/examples/list-testnet-assets/list-testnet-assets.ts
+++ b/contrib/examples/list-testnet-assets/list-testnet-assets.ts
@@ -1,0 +1,40 @@
+// Example: print a fixed list of common testnet asset codes useful for
+// manual testing. This is a static reference list, NOT a live query — the
+// SDK has no "list assets" endpoint, and testnet issuers/liquidity change
+// over time, so verify an asset still exists before relying on it.
+//
+// Run with: npx tsx list-testnet-assets.ts
+
+export interface TestnetAsset {
+  code: string;
+  description: string;
+}
+
+export const TESTNET_ASSETS: TestnetAsset[] = [
+  { code: "XLM", description: "Native Stellar Lumens — no issuer, always available" },
+  { code: "USDC", description: "Circle's testnet USD Coin, widely used for payment demos" },
+  { code: "yUSDC", description: "Yield-bearing wrapped testnet USDC used in some DeFi demos" },
+  { code: "SRT", description: "Common StellarX testnet reward/test token" },
+  { code: "TEST", description: "Generic placeholder code many sample issuers mint for demos" },
+  { code: "BTC", description: "Testnet-issued synthetic Bitcoin-pegged asset used in anchor demos" },
+];
+
+function printTable(assets: TestnetAsset[]): void {
+  const codeWidth = Math.max(...assets.map((a) => a.code.length), "CODE".length);
+  const header = `${"CODE".padEnd(codeWidth)}  DESCRIPTION`;
+  console.log(header);
+  console.log("-".repeat(header.length));
+  for (const asset of assets) {
+    console.log(`${asset.code.padEnd(codeWidth)}  ${asset.description}`);
+  }
+}
+
+function main() {
+  printTable(TESTNET_ASSETS);
+  console.log();
+  console.log("Static reference list — not a live query. Verify an asset/issuer still exists on testnet before use.");
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main();
+}

--- a/contrib/examples/parse-to-stroops/README.md
+++ b/contrib/examples/parse-to-stroops/README.md
@@ -1,0 +1,28 @@
+# Parse a human-readable amount into stroops
+
+Converts a human-readable XLM amount string into raw stroops as a `bigint`
+(1 XLM = 10,000,000 stroops). A thin wrapper over `vellar-sdk`'s own
+`parseTokenAmount` (`src/payments.ts`), fixed to XLM's 7 decimal places —
+reuses the SDK's exact parsing/validation rules rather than reimplementing
+them.
+
+## Examples
+
+| Input | Output |
+| --- | --- |
+| `10` | `100000000` stroops |
+| `10.5` | `105000000` stroops |
+| `0.0000001` | `1` stroop |
+| `1.12345678` (8 decimal places) | rejected — `Amount supports at most 7 decimal places` |
+
+## Run it
+
+```sh
+npx tsx parse-to-stroops.ts <amount>
+```
+
+## Tests
+
+```sh
+npx vitest run contrib/examples/parse-to-stroops
+```

--- a/contrib/examples/parse-to-stroops/parse-to-stroops.test.ts
+++ b/contrib/examples/parse-to-stroops/parse-to-stroops.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+import { parseToStroops } from "./parse-to-stroops";
+
+describe("parseToStroops", () => {
+  it("converts a whole XLM amount to stroops", () => {
+    expect(parseToStroops("10")).toBe(100_000_000n);
+  });
+
+  it("converts a fractional XLM amount to stroops", () => {
+    expect(parseToStroops("10.5")).toBe(105_000_000n);
+  });
+
+  it("converts the smallest unit (1 stroop)", () => {
+    expect(parseToStroops("0.0000001")).toBe(1n);
+  });
+
+  it("rejects an amount with more than 7 decimal places", () => {
+    expect(() => parseToStroops("1.12345678")).toThrow(/at most 7 decimal places/);
+  });
+
+  it("rejects a zero amount", () => {
+    expect(() => parseToStroops("0")).toThrow();
+  });
+});

--- a/contrib/examples/parse-to-stroops/parse-to-stroops.ts
+++ b/contrib/examples/parse-to-stroops/parse-to-stroops.ts
@@ -1,0 +1,33 @@
+// Example: convert a human-readable XLM amount string into raw stroops as a
+// bigint (1 XLM = 10,000,000 stroops, XLM's 7 decimal places).
+//
+// Run with: npx tsx parse-to-stroops.ts <amount>
+
+import { parseTokenAmount } from "../../../src/payments";
+
+const XLM_DECIMALS = 7;
+
+/** Thin wrapper over the SDK's parseTokenAmount, fixed to XLM's 7 decimals. */
+export function parseToStroops(amount: string): bigint {
+  return parseTokenAmount(amount, XLM_DECIMALS);
+}
+
+function main() {
+  const amount = process.argv[2];
+  if (!amount) {
+    console.error("Usage: npx tsx parse-to-stroops.ts <amount>");
+    process.exitCode = 1;
+    return;
+  }
+
+  try {
+    console.log(`${amount} XLM = ${parseToStroops(amount)} stroops`);
+  } catch (err) {
+    console.error(`Error: ${err instanceof Error ? err.message : String(err)}`);
+    process.exitCode = 1;
+  }
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main();
+}

--- a/contrib/examples/validate-recipient/README.md
+++ b/contrib/examples/validate-recipient/README.md
@@ -1,0 +1,46 @@
+# Validate a payment recipient address
+
+Validates a Stellar address using an `isValidAddress`-style check before
+treating it as a valid payment recipient — the same kind of check
+`createVellarWallet`'s `isValidAddress` config option performs, and that the
+payments client (`src/payments-client.ts`) runs before ever building a
+transaction. A Vellar wallet's recipients may be either a classic account
+(`G...`) or a contract (`C...`), so both are accepted.
+
+## Example addresses
+
+Valid classic account:
+
+```
+GCFNFDLMAQB5J6LV65KG7GNAVGBREUVB2BWSLY6U46ACK4RDZG3SO3SH
+```
+
+Valid contract:
+
+```
+CDFDULU2JWKGMIJW6FJWJJKNB3JIDQK54YTBDQUNPZTBYXCXCSO3MVZG
+```
+
+Invalid — bad checksum (last character flipped):
+
+```
+GCFNFDLMAQB5J6LV65KG7GNAVGBREUVB2BWSLY6U46ACK4RDZG3SO3SA
+```
+
+Invalid — unrecognized prefix:
+
+```
+XCFNFDLMAQB5J6LV65KG7GNAVGBREUVB2BWSLY6U46ACK4RDZG3SO3SH
+```
+
+## Run it
+
+```sh
+npx tsx validate-recipient.ts <address>
+```
+
+## Tests
+
+```sh
+npx vitest run contrib/examples/validate-recipient
+```

--- a/contrib/examples/validate-recipient/validate-recipient.test.ts
+++ b/contrib/examples/validate-recipient/validate-recipient.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+import { validateRecipient } from "./validate-recipient";
+
+const VALID_ACCOUNT = "GCFNFDLMAQB5J6LV65KG7GNAVGBREUVB2BWSLY6U46ACK4RDZG3SO3SH";
+const VALID_CONTRACT = "CDFDULU2JWKGMIJW6FJWJJKNB3JIDQK54YTBDQUNPZTBYXCXCSO3MVZG";
+const BAD_CHECKSUM_ACCOUNT = "GCFNFDLMAQB5J6LV65KG7GNAVGBREUVB2BWSLY6U46ACK4RDZG3SO3SA";
+
+describe("validateRecipient", () => {
+  it("accepts a valid classic account address (G...)", () => {
+    expect(validateRecipient(VALID_ACCOUNT)).toEqual({ valid: true });
+  });
+
+  it("accepts a valid contract address (C...)", () => {
+    expect(validateRecipient(VALID_CONTRACT)).toEqual({ valid: true });
+  });
+
+  it("rejects a well-formed-looking address with a bad checksum", () => {
+    const result = validateRecipient(BAD_CHECKSUM_ACCOUNT);
+    expect(result.valid).toBe(false);
+    expect(result.reason).toMatch(/checksum/);
+  });
+
+  it("rejects an address with an unexpected prefix", () => {
+    const result = validateRecipient("XCFNFDLMAQB5J6LV65KG7GNAVGBREUVB2BWSLY6U46ACK4RDZG3SO3SH");
+    expect(result.valid).toBe(false);
+    expect(result.reason).toMatch(/must start with "G"/);
+  });
+
+  it("rejects an empty string", () => {
+    const result = validateRecipient("");
+    expect(result.valid).toBe(false);
+    expect(result.reason).toBe("address is empty");
+  });
+});

--- a/contrib/examples/validate-recipient/validate-recipient.ts
+++ b/contrib/examples/validate-recipient/validate-recipient.ts
@@ -1,0 +1,58 @@
+// Example: validate a Stellar address before treating it as a valid payment
+// recipient — an isValidAddress-style check, as required by
+// createVellarWallet's config (VellarWalletConfig.isValidAddress) and used
+// internally by the payments client to reject a bad recipient before ever
+// building a transaction.
+//
+// A Vellar wallet's recipients may be either a classic account (G...) or a
+// contract (C...), so both are accepted.
+//
+// Run with: npx tsx validate-recipient.ts <address>
+
+import { StrKey } from "@stellar/stellar-sdk";
+
+export interface AddressCheck {
+  valid: boolean;
+  reason?: string;
+}
+
+export function validateRecipient(address: string): AddressCheck {
+  if (StrKey.isValidEd25519PublicKey(address)) {
+    return { valid: true };
+  }
+  if (StrKey.isValidContract(address)) {
+    return { valid: true };
+  }
+  if (!address) {
+    return { valid: false, reason: "address is empty" };
+  }
+  const prefix = address[0];
+  if (prefix !== "G" && prefix !== "C") {
+    return {
+      valid: false,
+      reason: `must start with "G" (account) or "C" (contract), got "${prefix}"`,
+    };
+  }
+  return { valid: false, reason: "failed strkey checksum/encoding validation" };
+}
+
+function main() {
+  const address = process.argv[2];
+  if (!address) {
+    console.error("Usage: npx tsx validate-recipient.ts <address>");
+    process.exitCode = 1;
+    return;
+  }
+
+  const result = validateRecipient(address);
+  if (result.valid) {
+    console.log(`VALID: ${address}`);
+  } else {
+    console.log(`INVALID: ${address} (${result.reason})`);
+    process.exitCode = 1;
+  }
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main();
+}


### PR DESCRIPTION
## Summary
Four standalone example scripts under contrib/examples/, covering display formatting for tx hashes, recipient address validation, a static testnet asset reference table, and human-readable-to-stroops parsing.

closes #14
closes #15
closes #16
closes #22

## Changes
- **#14 — format-tx-hash**: `formatTxHash()` shortens a hash to `first6...last4` for display; hashes no longer than head+tail length are returned unchanged rather than throwing.
- **#15 — validate-recipient**: CLI script validating a Stellar address (classic `G...` or contract `C...`) before treating it as a payment recipient, mirroring the `isValidAddress` check `createVellarWallet`'s config requires.
- **#16 — list-testnet-assets**: prints a fixed reference table of 6 common testnet asset codes with descriptions. Both the script output and README note this is a static list, not a live query.
- **#22 — parse-to-stroops**: `parseToStroops()` converts a human-readable XLM string to raw stroops as a thin wrapper over the SDK's own `parseTokenAmount` (fixed to 7 decimals) — reuses its exact validation rather than reimplementing it.

## Test plan
- Each example has a colocated `*.test.ts` (vitest) — 18 new tests, all passing.
- Ran every script directly (`npx tsx ...`) and confirmed output matches each README exactly, including valid/invalid address and hash edge cases.
- `npm run typecheck`, `npm test` (155/155 passing), and `npm run build` all clean on top of this branch.
- All changes are confined to `contrib/examples/`; verified `git status` shows no files touched outside `contrib/`.