### PR TITLE
feat(examples): retrying fetch, policy card/validation, and mock passkey kit examples

### DIFF
--- a/contrib/examples/mock-passkey-kit/README.md
+++ b/contrib/examples/mock-passkey-kit/README.md
@@ -1,0 +1,29 @@
+# Mock passkey kit for headless testing
+
+A mock `PasskeyKitLike` implementing `createWallet`, `connectWallet`, and
+`sign`, each returning a fixed, documented canned response — never a real
+WebAuthn ceremony or browser feature. Useful for headless tests that need to
+wire a kit into `createVellarWallet()`.
+
+## Canned responses
+
+| Method | Returns |
+| --- | --- |
+| `createWallet` | `{ keyIdBase64: CANNED_KEY_ID, contractId: CANNED_CONTRACT_ID, signedTx: "mock-signed-deployment-tx" }` |
+| `connectWallet` | `{ keyIdBase64: CANNED_KEY_ID, contractId: CANNED_CONTRACT_ID }` |
+| `sign` | the input transaction, unchanged (a no-op "signature") |
+
+## Run it
+
+```sh
+npx tsx mock-passkey-kit.ts
+```
+
+Wires the mock kit (plus a minimal mock backend) into the real
+`createVellarWallet()` and calls `create()`, printing the resulting session.
+
+## Tests
+
+```sh
+npx vitest run contrib/examples/mock-passkey-kit
+```

--- a/contrib/examples/mock-passkey-kit/mock-passkey-kit.test.ts
+++ b/contrib/examples/mock-passkey-kit/mock-passkey-kit.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+import { CANNED_CONTRACT_ID, CANNED_KEY_ID, createMockPasskeyKit } from "./mock-passkey-kit";
+
+describe("createMockPasskeyKit", () => {
+  it("createWallet returns the canned keyId, contractId, and a signed tx", async () => {
+    const kit = createMockPasskeyKit();
+    await expect(kit.createWallet("app", "user")).resolves.toEqual({
+      keyIdBase64: CANNED_KEY_ID,
+      contractId: CANNED_CONTRACT_ID,
+      signedTx: "mock-signed-deployment-tx",
+    });
+  });
+
+  it("connectWallet returns the same canned keyId and contractId", async () => {
+    const kit = createMockPasskeyKit();
+    await expect(kit.connectWallet()).resolves.toEqual({
+      keyIdBase64: CANNED_KEY_ID,
+      contractId: CANNED_CONTRACT_ID,
+    });
+  });
+
+  it("sign returns the input transaction unchanged", async () => {
+    const kit = createMockPasskeyKit();
+    const tx = { some: "transaction" };
+    await expect(kit.sign(tx)).resolves.toBe(tx);
+  });
+});

--- a/contrib/examples/mock-passkey-kit/mock-passkey-kit.ts
+++ b/contrib/examples/mock-passkey-kit/mock-passkey-kit.ts
@@ -1,0 +1,66 @@
+// Example: a mock PasskeyKitLike returning fixed, documented canned
+// responses for createWallet, connectWallet, and sign — for headless tests
+// that need a createVellarWallet() kit without a real WebAuthn ceremony or
+// browser feature.
+//
+// Run with: npx tsx mock-passkey-kit.ts
+
+import { createVellarWallet, type PasskeyKitLike } from "../../../src/index";
+
+export const CANNED_KEY_ID = "mock-keyid-canned";
+export const CANNED_CONTRACT_ID = "CMOCKPASSKEYKITCONTRACTADDRESSXXXXXXXXXXXXXXXXXXXXXXXXXX";
+
+/**
+ * A mock PasskeyKitLike for headless tests: every call resolves immediately
+ * with a fixed, documented response — never a real WebAuthn prompt or
+ * browser API.
+ *
+ *   - createWallet  → { keyIdBase64: CANNED_KEY_ID, contractId: CANNED_CONTRACT_ID, signedTx: "mock-signed-deployment-tx" }
+ *   - connectWallet → { keyIdBase64: CANNED_KEY_ID, contractId: CANNED_CONTRACT_ID }
+ *   - sign          → returns the input transaction unchanged (a no-op "signature")
+ */
+export function createMockPasskeyKit(): PasskeyKitLike {
+  return {
+    async createWallet() {
+      return {
+        keyIdBase64: CANNED_KEY_ID,
+        contractId: CANNED_CONTRACT_ID,
+        signedTx: "mock-signed-deployment-tx",
+      };
+    },
+    async connectWallet() {
+      return { keyIdBase64: CANNED_KEY_ID, contractId: CANNED_CONTRACT_ID };
+    },
+    async sign(tx: unknown) {
+      return tx;
+    },
+  };
+}
+
+async function main() {
+  const wallet = createVellarWallet({
+    network: "testnet",
+    appName: "vellar-example",
+    kit: createMockPasskeyKit(),
+    backend: {
+      async submitWalletCreation() {
+        return { sessionId: "mock-session-id" };
+      },
+      async lookupContractId() {
+        return undefined;
+      },
+      async submitTransaction() {
+        return { hash: "mock-tx-hash" };
+      },
+    },
+    sac: { getSACClient: () => ({ transfer: async () => "mock-tx" }) },
+    isValidAddress: () => true,
+  });
+
+  const session = await wallet.create({ username: "Headless Test User" });
+  console.log("Wired mock passkey kit into createVellarWallet(); session:", session);
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main();
+}

--- a/contrib/examples/policy-summary-card/README.md
+++ b/contrib/examples/policy-summary-card/README.md
@@ -1,0 +1,31 @@
+# Policy summary card
+
+Formats a policy record as a multi-line text summary suitable for printing
+in a terminal — e.g. a CLI listing a wallet's attached policies. Includes the
+policy id, type, limit, and window; a policy missing the optional `limit`
+and/or `window` fields (e.g. a `signer-limits` policy with no spending cap)
+omits those lines cleanly instead of printing them blank.
+
+## Run it
+
+```sh
+npx tsx policy-summary-card.ts
+```
+
+Expected output:
+
+```
+Policy ID: policy_7f3a9c2e
+Type:      spending-limit
+Limit:     100 XLM/day
+Window:    24h
+
+Policy ID: policy_a1b2c3d4
+Type:      signer-limits
+```
+
+## Tests
+
+```sh
+npx vitest run contrib/examples/policy-summary-card
+```

--- a/contrib/examples/policy-summary-card/policy-summary-card.test.ts
+++ b/contrib/examples/policy-summary-card/policy-summary-card.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+import { formatPolicySummaryCard } from "./policy-summary-card";
+
+describe("formatPolicySummaryCard", () => {
+  it("includes id, type, limit, and window when all are present", () => {
+    const card = formatPolicySummaryCard({
+      id: "policy_1",
+      type: "spending-limit",
+      limit: "100 XLM/day",
+      window: "24h",
+    });
+    expect(card).toBe(
+      ["Policy ID: policy_1", "Type:      spending-limit", "Limit:     100 XLM/day", "Window:    24h"].join("\n"),
+    );
+  });
+
+  it("omits the limit and window lines cleanly when absent", () => {
+    const card = formatPolicySummaryCard({ id: "policy_2", type: "signer-limits" });
+    expect(card).toBe("Policy ID: policy_2\nType:      signer-limits");
+    expect(card).not.toContain("Limit:");
+    expect(card).not.toContain("Window:");
+  });
+
+  it("omits only the window line when limit is present but window is not", () => {
+    const card = formatPolicySummaryCard({ id: "policy_3", type: "spending-limit", limit: "50 XLM/tx" });
+    expect(card).toContain("Limit:     50 XLM/tx");
+    expect(card).not.toContain("Window:");
+  });
+});

--- a/contrib/examples/policy-summary-card/policy-summary-card.ts
+++ b/contrib/examples/policy-summary-card/policy-summary-card.ts
@@ -1,0 +1,50 @@
+// Example: format a policy record as a multi-line text summary suitable for
+// printing in a terminal (e.g. a CLI listing a wallet's attached policies).
+//
+// Run with: npx tsx policy-summary-card.ts
+
+export interface PolicyRecord {
+  id: string;
+  type: string;
+  /** Human-readable spending limit, e.g. "100 XLM/day". Omitted if the
+   * policy has no spending limit (e.g. a signer-limits-only policy). */
+  limit?: string;
+  /** Human-readable rolling window, e.g. "24h". Omitted along with `limit`
+   * when there's no windowed limit to describe. */
+  window?: string;
+}
+
+/** Formats a policy record as a labelled multi-line card. Missing optional
+ * fields (limit, window) are omitted as whole lines, not printed blank. */
+export function formatPolicySummaryCard(policy: PolicyRecord): string {
+  const lines = [`Policy ID: ${policy.id}`, `Type:      ${policy.type}`];
+  if (policy.limit !== undefined) {
+    lines.push(`Limit:     ${policy.limit}`);
+  }
+  if (policy.window !== undefined) {
+    lines.push(`Window:    ${policy.window}`);
+  }
+  return lines.join("\n");
+}
+
+function main() {
+  const withLimits: PolicyRecord = {
+    id: "policy_7f3a9c2e",
+    type: "spending-limit",
+    limit: "100 XLM/day",
+    window: "24h",
+  };
+
+  const withoutLimits: PolicyRecord = {
+    id: "policy_a1b2c3d4",
+    type: "signer-limits",
+  };
+
+  console.log(formatPolicySummaryCard(withLimits));
+  console.log();
+  console.log(formatPolicySummaryCard(withoutLimits));
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main();
+}

--- a/contrib/examples/retrying-fetch/README.md
+++ b/contrib/examples/retrying-fetch/README.md
@@ -1,0 +1,27 @@
+# Retrying fetch wrapper
+
+Wraps `fetch` with a configurable number of retries on network failure (a
+thrown error), waiting a fixed delay between attempts. A resolved response —
+even a non-2xx one — is returned as-is on the first attempt; only a thrown
+error (e.g. DNS/connection failure) triggers a retry.
+
+## Run it
+
+```sh
+npx tsx retrying-fetch.ts
+```
+
+Uses a mock fetch that fails twice with a network error, then succeeds:
+
+```
+Succeeded after 3 attempts, status 200
+```
+
+## Tests
+
+Uses a mock fetch and an injected no-op `sleep`, so the tests run instantly
+with no real delays:
+
+```sh
+npx vitest run contrib/examples/retrying-fetch
+```

--- a/contrib/examples/retrying-fetch/retrying-fetch.test.ts
+++ b/contrib/examples/retrying-fetch/retrying-fetch.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it, vi } from "vitest";
+import { createRetryingFetch, type FetchLike } from "./retrying-fetch";
+
+const noSleep = vi.fn(async () => {});
+
+describe("createRetryingFetch", () => {
+  it("succeeds on the first attempt with no retries needed", async () => {
+    const mockFetch: FetchLike = vi.fn(async () => new Response("ok"));
+    const retryingFetch = createRetryingFetch(mockFetch, { maxRetries: 3, delayMs: 10, sleep: noSleep });
+
+    await retryingFetch("https://example.com");
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("retries after a fixed number of failures, then succeeds", async () => {
+    let calls = 0;
+    const mockFetch: FetchLike = async () => {
+      calls++;
+      if (calls < 3) throw new Error("network error");
+      return new Response("ok");
+    };
+
+    const retryingFetch = createRetryingFetch(mockFetch, { maxRetries: 3, delayMs: 10, sleep: noSleep });
+    const response = await retryingFetch("https://example.com");
+
+    expect(calls).toBe(3);
+    expect(response.status).toBe(200);
+  });
+
+  it("does not retry a resolved non-2xx response", async () => {
+    const mockFetch: FetchLike = vi.fn(async () => new Response("not found", { status: 404 }));
+    const retryingFetch = createRetryingFetch(mockFetch, { maxRetries: 3, delayMs: 10, sleep: noSleep });
+
+    const response = await retryingFetch("https://example.com");
+    expect(response.status).toBe(404);
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("re-throws the last error once retries are exhausted", async () => {
+    const mockFetch: FetchLike = vi.fn(async () => {
+      throw new Error("always fails");
+    });
+    const retryingFetch = createRetryingFetch(mockFetch, { maxRetries: 2, delayMs: 10, sleep: noSleep });
+
+    await expect(retryingFetch("https://example.com")).rejects.toThrow("always fails");
+    expect(mockFetch).toHaveBeenCalledTimes(3); // initial attempt + 2 retries
+  });
+});

--- a/contrib/examples/retrying-fetch/retrying-fetch.ts
+++ b/contrib/examples/retrying-fetch/retrying-fetch.ts
@@ -1,0 +1,60 @@
+// Example: wrap fetch with a configurable number of retries on network
+// failure (a thrown error — e.g. DNS/connection failure), waiting a fixed
+// delay between attempts. Does NOT retry on a successful response, even a
+// non-2xx one — only a thrown error is treated as retryable.
+//
+// Run with: npx tsx retrying-fetch.ts
+
+export type FetchLike = (url: string, init?: RequestInit) => Promise<Response>;
+
+export interface RetryingFetchOptions {
+  maxRetries: number;
+  delayMs: number;
+  /** Injectable sleep, so tests can run without real delays. */
+  sleep?: (ms: number) => Promise<void>;
+}
+
+/**
+ * Wraps `fetchImpl`, retrying up to `maxRetries` additional times if it
+ * throws (a network-level failure). A response that resolves — even a 4xx
+ * or 5xx — is returned as-is on the first attempt; only a rejection
+ * triggers a retry. Re-throws the last error once retries are exhausted.
+ */
+export function createRetryingFetch(fetchImpl: FetchLike, options: RetryingFetchOptions): FetchLike {
+  const sleep = options.sleep ?? ((ms) => new Promise<void>((resolve) => setTimeout(resolve, ms)));
+
+  return async (url, init) => {
+    let lastError: unknown;
+    for (let attempt = 0; attempt <= options.maxRetries; attempt++) {
+      try {
+        return await fetchImpl(url, init);
+      } catch (err) {
+        lastError = err;
+        if (attempt < options.maxRetries) {
+          await sleep(options.delayMs);
+        }
+      }
+    }
+    throw lastError;
+  };
+}
+
+async function main() {
+  // A mock fetch that fails twice with a network error, then succeeds.
+  let calls = 0;
+  const mockFetch: FetchLike = async () => {
+    calls++;
+    if (calls < 3) {
+      throw new Error("network error (mock)");
+    }
+    return new Response("ok", { status: 200 });
+  };
+
+  const retryingFetch = createRetryingFetch(mockFetch, { maxRetries: 3, delayMs: 100 });
+  const response = await retryingFetch("https://example.com");
+  console.log(`Succeeded after ${calls} attempts, status ${response.status}`);
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main();
+}

--- a/contrib/examples/validate-policy-body/README.md
+++ b/contrib/examples/validate-policy-body/README.md
@@ -1,0 +1,38 @@
+# Validate a policy body before generate
+
+Locally validates a spending-limit policy body (`{ limit, windowSeconds }`)
+before it would be sent to a generate endpoint, catching obvious mistakes
+early. Returns a list of every validation error found, rather than throwing
+on the first one, so a caller can show all the problems at once.
+
+## Checks
+
+- `limit` must be a finite, positive number.
+- `windowSeconds` must be an integer between 1 and 2,592,000 (30 days) — a
+  window longer than that isn't a meaningful rolling window for a spending
+  limit, and usually signals the value is in the wrong unit (e.g.
+  milliseconds instead of seconds).
+
+## Run it
+
+```sh
+npx tsx validate-policy-body.ts
+```
+
+Expected output:
+
+```
+Valid body errors:   []
+Invalid body errors: [
+  'limit must be a positive number, got -5',
+  'windowSeconds must be between 1 and 2592000 (30 days), got 99999999'
+]
+```
+
+## Tests
+
+Covers a valid body and a body with multiple issues:
+
+```sh
+npx vitest run contrib/examples/validate-policy-body
+```

--- a/contrib/examples/validate-policy-body/validate-policy-body.test.ts
+++ b/contrib/examples/validate-policy-body/validate-policy-body.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+import { validatePolicyBody } from "./validate-policy-body";
+
+describe("validatePolicyBody", () => {
+  it("returns no errors for a valid body", () => {
+    expect(validatePolicyBody({ limit: 100, windowSeconds: 86_400 })).toEqual([]);
+  });
+
+  it("returns every issue for a body with multiple problems, not just the first", () => {
+    const errors = validatePolicyBody({ limit: -5, windowSeconds: 99_999_999 });
+    expect(errors).toHaveLength(2);
+    expect(errors[0]).toMatch(/limit must be a positive number/);
+    expect(errors[1]).toMatch(/windowSeconds must be between/);
+  });
+
+  it("rejects a zero limit", () => {
+    expect(validatePolicyBody({ limit: 0, windowSeconds: 86_400 })).toEqual([
+      "limit must be a positive number, got 0",
+    ]);
+  });
+
+  it("rejects a non-integer windowSeconds", () => {
+    const errors = validatePolicyBody({ limit: 100, windowSeconds: 86_400.5 });
+    expect(errors).toEqual(["windowSeconds must be an integer, got 86400.5"]);
+  });
+
+  it("rejects a windowSeconds below the minimum", () => {
+    const errors = validatePolicyBody({ limit: 100, windowSeconds: 0 });
+    expect(errors[0]).toMatch(/must be between 1 and/);
+  });
+});

--- a/contrib/examples/validate-policy-body/validate-policy-body.ts
+++ b/contrib/examples/validate-policy-body/validate-policy-body.ts
@@ -1,0 +1,47 @@
+// Example: locally validate a spending-limit policy body before it would be
+// sent to a generate endpoint, catching obvious mistakes early. Returns a
+// list of every problem found, rather than throwing on the first one, so a
+// caller can show all the issues at once.
+//
+// Run with: npx tsx validate-policy-body.ts
+
+export interface PolicyBody {
+  limit: number;
+  windowSeconds: number;
+}
+
+// A window longer than 30 days isn't a meaningful "rolling window" for a
+// spending limit — treat it as a sign the value is probably in the wrong
+// unit (e.g. milliseconds instead of seconds).
+const MAX_WINDOW_SECONDS = 30 * 24 * 60 * 60;
+const MIN_WINDOW_SECONDS = 1;
+
+export function validatePolicyBody(body: PolicyBody): string[] {
+  const errors: string[] = [];
+
+  if (!Number.isFinite(body.limit) || body.limit <= 0) {
+    errors.push(`limit must be a positive number, got ${body.limit}`);
+  }
+
+  if (!Number.isFinite(body.windowSeconds) || !Number.isInteger(body.windowSeconds)) {
+    errors.push(`windowSeconds must be an integer, got ${body.windowSeconds}`);
+  } else if (body.windowSeconds < MIN_WINDOW_SECONDS || body.windowSeconds > MAX_WINDOW_SECONDS) {
+    errors.push(
+      `windowSeconds must be between ${MIN_WINDOW_SECONDS} and ${MAX_WINDOW_SECONDS} (30 days), got ${body.windowSeconds}`,
+    );
+  }
+
+  return errors;
+}
+
+function main() {
+  const valid: PolicyBody = { limit: 100, windowSeconds: 86_400 };
+  const invalid: PolicyBody = { limit: -5, windowSeconds: 99_999_999 };
+
+  console.log("Valid body errors:  ", validatePolicyBody(valid));
+  console.log("Invalid body errors:", validatePolicyBody(invalid));
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main();
+}


### PR DESCRIPTION
## Summary
Four standalone examples under contrib/examples/, covering a retrying fetch wrapper, a policy summary formatter, local policy-body validation, and a mock passkey kit for headless testing.

closes #44
closes #45
closes #46
closes #48

## Changes
- **#44 — retrying-fetch**: `createRetryingFetch()` wraps fetch with a configurable `maxRetries`/`delayMs`, retrying only on a thrown network error — a resolved response (even non-2xx) is never retried. Re-throws the last error once retries are exhausted.
- **#45 — policy-summary-card**: `formatPolicySummaryCard()` formats a policy record's id/type/limit/window as a labelled multi-line card, omitting the limit and/or window lines cleanly when those optional fields are absent.
- **#46 — validate-policy-body**: `validatePolicyBody()` checks `limit` is a positive number and `windowSeconds` is within a sane range (1 second to 30 days), returning every validation error found rather than throwing on the first one.
- **#48 — mock-passkey-kit**: `createMockPasskeyKit()` implements `createWallet`/`connectWallet`/`sign` with fixed, documented canned responses, never touching a real WebAuthn API. Wired into the real `createVellarWallet()` and exercised via `create()`.

## Test plan
- Each example has a colocated `*.test.ts` (vitest) — 15 new tests, all passing. #44's tests inject a no-op `sleep` so they run with no real delays.
- Ran every script directly (`npx tsx ...`) and confirmed output matches each README exactly.
- `npm run typecheck`, `npm test` (152/152 passing), and `npm run build` all clean on top of this branch.
- All changes are confined to `contrib/examples/`; verified `git status` shows no files touched outside `contrib/`.