### PR TITLE
feat(examples): testnet info, error class reference, timeout, and retry examples

### DIFF
--- a/contrib/examples/fetch-with-timeout/README.md
+++ b/contrib/examples/fetch-with-timeout/README.md
@@ -1,0 +1,43 @@
+# Fetch with a timeout
+
+Wraps the global `fetch` function with a timeout using `AbortController`.
+Prints a clear timeout error if the request does not complete in time,
+instead of the default (and much less informative) `AbortError`.
+
+## How this applies to x402 retries
+
+`vellar-sdk`'s x402 client (`src/x402-client.ts`) accepts an injectable
+`fetchImpl: FetchLike` for every request it makes (the initial fetch, and the
+paid retry after a 402 challenge). Wrapping that injected fetch with a
+timeout — as this example does — prevents a hung facilitator or resource
+server from leaving an x402 payment flow stuck indefinitely; a caller that
+wants bounded retries around x402 requests can compose this wrapper with a
+retry loop (see the `simple-retry` example) around the same injected
+`fetchImpl`.
+
+## Run it
+
+```sh
+npx tsx fetch-with-timeout.ts <url> <timeoutMs>
+```
+
+Example:
+
+```sh
+npx tsx fetch-with-timeout.ts https://example.com 5000
+```
+
+A request that doesn't complete in time prints a clear error:
+
+```
+Error: Request to https://example.com did not complete within 1ms
+```
+
+## Tests
+
+Uses a mock fetch that respects the abort signal, so the tests run without
+depending on network timing:
+
+```sh
+npx vitest run contrib/examples/fetch-with-timeout
+```

--- a/contrib/examples/fetch-with-timeout/fetch-with-timeout.test.ts
+++ b/contrib/examples/fetch-with-timeout/fetch-with-timeout.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+import { FetchTimeoutError, fetchWithTimeout } from "./fetch-with-timeout";
+
+/** A mock fetch that resolves after `delayMs`, respecting the abort signal
+ * like a real fetch implementation would. */
+function createDelayedFetch(delayMs: number): typeof fetch {
+  return ((_url: string, init?: RequestInit) =>
+    new Promise((resolve, reject) => {
+      const timer = setTimeout(() => resolve(new Response("ok")), delayMs);
+      init?.signal?.addEventListener("abort", () => {
+        clearTimeout(timer);
+        reject(new DOMException("The operation was aborted", "AbortError"));
+      });
+    })) as typeof fetch;
+}
+
+describe("fetchWithTimeout", () => {
+  it("resolves normally when the request completes before the timeout", async () => {
+    const response = await fetchWithTimeout("https://example.com", 100, createDelayedFetch(10));
+    expect(response.status).toBe(200);
+  });
+
+  it("throws FetchTimeoutError when the request exceeds the timeout", async () => {
+    await expect(
+      fetchWithTimeout("https://example.com", 10, createDelayedFetch(1000)),
+    ).rejects.toThrow(FetchTimeoutError);
+  });
+
+  it("propagates a non-abort error unchanged", async () => {
+    const failingFetch: typeof fetch = (async () => {
+      throw new Error("DNS failure");
+    }) as typeof fetch;
+    await expect(fetchWithTimeout("https://example.com", 100, failingFetch)).rejects.toThrow(
+      "DNS failure",
+    );
+  });
+});

--- a/contrib/examples/fetch-with-timeout/fetch-with-timeout.ts
+++ b/contrib/examples/fetch-with-timeout/fetch-with-timeout.ts
@@ -1,0 +1,53 @@
+// Example: wrap the global fetch function with a timeout using
+// AbortController.
+//
+// Run with: npx tsx fetch-with-timeout.ts <url> <timeoutMs>
+
+export class FetchTimeoutError extends Error {
+  constructor(url: string, timeoutMs: number) {
+    super(`Request to ${url} did not complete within ${timeoutMs}ms`);
+    this.name = "FetchTimeoutError";
+  }
+}
+
+export async function fetchWithTimeout(
+  url: string,
+  timeoutMs: number,
+  fetchImpl: typeof fetch = fetch,
+): Promise<Response> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+
+  try {
+    return await fetchImpl(url, { signal: controller.signal });
+  } catch (err) {
+    if (err instanceof Error && err.name === "AbortError") {
+      throw new FetchTimeoutError(url, timeoutMs);
+    }
+    throw err;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+async function main() {
+  const [url, timeoutArg] = process.argv.slice(2);
+  if (!url || !timeoutArg) {
+    console.error("Usage: npx tsx fetch-with-timeout.ts <url> <timeoutMs>");
+    process.exitCode = 1;
+    return;
+  }
+  const timeoutMs = Number(timeoutArg);
+
+  try {
+    const response = await fetchWithTimeout(url, timeoutMs);
+    console.log(`Response: ${response.status} ${response.statusText}`);
+  } catch (err) {
+    console.error(`Error: ${err instanceof Error ? err.message : String(err)}`);
+    process.exitCode = 1;
+  }
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main();
+}

--- a/contrib/examples/list-error-classes/README.md
+++ b/contrib/examples/list-error-classes/README.md
@@ -1,0 +1,37 @@
+# List the SDK's typed error classes
+
+Prints the SDK's typed error class names with a one-line description of when
+each is thrown — a quick reference for `try`/`catch` handling without
+digging through the source.
+
+> **This list is hardcoded and must be kept in sync with the SDK source
+> manually.** It is not generated or validated against `src/` — if a new
+> error class is added, or an existing one renamed, this list will drift
+> until someone updates it by hand.
+
+## Run it
+
+```sh
+npx tsx list-error-classes.ts
+```
+
+Expected output (10 entries):
+
+```
+WalletNotReadyError: wallet.pay()/wallet.policies used before create() or connect()
+WalletNetworkMismatchError: the connector is configured for one network but asked to operate on another
+InvalidRecipientError: a payment recipient is invalid or equals the sender
+InvalidAmountError: a payment/token amount string is malformed, zero, or negative
+WalletApiError: an HTTP call to the wallet gateway (create/connect/submit) returned a non-2xx response
+PolicyApiError: an HTTP call to the policy API gateway returned a non-2xx response
+TransactionTimeoutError: waitForTransaction() polled past its timeout without a final status
+MaxAmountExceededError: an x402 server requested more than the caller's maxAmount
+DisallowedAssetError: an x402 server requested an asset not in the caller's allowedAssets
+X402NotConfiguredError: wallet.x402 was used without x402 config in createVellarWallet
+```
+
+## Tests
+
+```sh
+npx vitest run contrib/examples/list-error-classes
+```

--- a/contrib/examples/list-error-classes/list-error-classes.test.ts
+++ b/contrib/examples/list-error-classes/list-error-classes.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+import { SDK_ERROR_CLASSES } from "./list-error-classes";
+
+describe("SDK_ERROR_CLASSES", () => {
+  it("lists at least 6 error classes", () => {
+    expect(SDK_ERROR_CLASSES.length).toBeGreaterThanOrEqual(6);
+  });
+
+  it("gives every entry a non-empty name and description", () => {
+    for (const entry of SDK_ERROR_CLASSES) {
+      expect(entry.name.length).toBeGreaterThan(0);
+      expect(entry.description.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("every name ends in Error, matching the SDK's class naming convention", () => {
+    for (const entry of SDK_ERROR_CLASSES) {
+      expect(entry.name.endsWith("Error")).toBe(true);
+    }
+  });
+
+  it("has no duplicate class names", () => {
+    const names = SDK_ERROR_CLASSES.map((e) => e.name);
+    expect(new Set(names).size).toBe(names.length);
+  });
+});

--- a/contrib/examples/list-error-classes/list-error-classes.ts
+++ b/contrib/examples/list-error-classes/list-error-classes.ts
@@ -1,0 +1,33 @@
+// Example: list the SDK's typed error classes with a one-line description
+// of when each is thrown. Hardcoded — kept in sync with the SDK source
+// manually (see the README note).
+//
+// Run with: npx tsx list-error-classes.ts
+
+export interface ErrorClassInfo {
+  name: string;
+  description: string;
+}
+
+export const SDK_ERROR_CLASSES: ErrorClassInfo[] = [
+  { name: "WalletNotReadyError", description: "wallet.pay()/wallet.policies used before create() or connect()" },
+  { name: "WalletNetworkMismatchError", description: "the connector is configured for one network but asked to operate on another" },
+  { name: "InvalidRecipientError", description: "a payment recipient is invalid or equals the sender" },
+  { name: "InvalidAmountError", description: "a payment/token amount string is malformed, zero, or negative" },
+  { name: "WalletApiError", description: "an HTTP call to the wallet gateway (create/connect/submit) returned a non-2xx response" },
+  { name: "PolicyApiError", description: "an HTTP call to the policy API gateway returned a non-2xx response" },
+  { name: "TransactionTimeoutError", description: "waitForTransaction() polled past its timeout without a final status" },
+  { name: "MaxAmountExceededError", description: "an x402 server requested more than the caller's maxAmount" },
+  { name: "DisallowedAssetError", description: "an x402 server requested an asset not in the caller's allowedAssets" },
+  { name: "X402NotConfiguredError", description: "wallet.x402 was used without x402 config in createVellarWallet" },
+];
+
+function main() {
+  for (const { name, description } of SDK_ERROR_CLASSES) {
+    console.log(`${name}: ${description}`);
+  }
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main();
+}

--- a/contrib/examples/simple-retry/README.md
+++ b/contrib/examples/simple-retry/README.md
@@ -1,0 +1,42 @@
+# Simple fixed-count retry
+
+Wraps an async function call with a simple fixed-count retry loop: try
+again immediately, up to `maxAttempts` times, logging each attempt number.
+
+## Run it
+
+```sh
+npx tsx simple-retry.ts
+```
+
+Runs against a function that fails on the first two calls and succeeds on
+the third:
+
+```
+Attempt 1/5
+Attempt 2/5
+Attempt 3/5
+Result: success
+```
+
+## Simple retry vs. exponential backoff
+
+This wrapper retries **immediately**, with no delay between attempts — fine
+for a quick, cheap operation, or when the caller wants to fail fast after a
+bounded number of tries. It has no concept of a delay, jitter, or a growing
+wait time.
+
+Exponential backoff (see e.g. the `retrying-fetch` example) waits
+progressively longer between attempts (`delay * 2^attempt`, often with
+jitter). That's the right choice against a real network call or a shared
+service that might be rate-limiting or momentarily overloaded — retrying
+instantly in a tight loop can make things worse, not better. Reach for this
+simple version only when you know the failure is likely to clear
+immediately (e.g. a transient in-memory race) rather than a network or
+service-level issue.
+
+## Tests
+
+```sh
+npx vitest run contrib/examples/simple-retry
+```

--- a/contrib/examples/simple-retry/simple-retry.test.ts
+++ b/contrib/examples/simple-retry/simple-retry.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it, vi } from "vitest";
+import { simpleRetry } from "./simple-retry";
+
+describe("simpleRetry", () => {
+  it("succeeds on the first attempt with no retries needed", async () => {
+    const fn = vi.fn(async () => "ok");
+    await expect(simpleRetry(fn, 3)).resolves.toBe("ok");
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  it("retries a fixed number of times, then succeeds", async () => {
+    let calls = 0;
+    const fn = async () => {
+      calls++;
+      if (calls < 3) throw new Error(`fail ${calls}`);
+      return "success";
+    };
+    await expect(simpleRetry(fn, 5)).resolves.toBe("success");
+    expect(calls).toBe(3);
+  });
+
+  it("throws the last error once maxAttempts is exhausted", async () => {
+    const fn = vi.fn(async () => {
+      throw new Error("always fails");
+    });
+    await expect(simpleRetry(fn, 3)).rejects.toThrow("always fails");
+    expect(fn).toHaveBeenCalledTimes(3);
+  });
+});

--- a/contrib/examples/simple-retry/simple-retry.ts
+++ b/contrib/examples/simple-retry/simple-retry.ts
@@ -1,0 +1,37 @@
+// Example: wrap an async function call with a simple fixed-count retry loop
+// — no delay, no backoff, just "try again immediately, up to maxAttempts
+// times". See the README for how this differs from exponential backoff.
+//
+// Run with: npx tsx simple-retry.ts
+
+export async function simpleRetry<T>(fn: () => Promise<T>, maxAttempts: number): Promise<T> {
+  let lastError: unknown;
+  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+    console.log(`Attempt ${attempt}/${maxAttempts}`);
+    try {
+      return await fn();
+    } catch (err) {
+      lastError = err;
+    }
+  }
+  throw lastError;
+}
+
+async function main() {
+  // A function that fails twice, then succeeds on the third attempt.
+  let calls = 0;
+  const flaky = async () => {
+    calls++;
+    if (calls < 3) {
+      throw new Error(`simulated failure on attempt ${calls}`);
+    }
+    return "success";
+  };
+
+  const result = await simpleRetry(flaky, 5);
+  console.log(`Result: ${result}`);
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main();
+}

--- a/contrib/examples/testnet-network-info/README.md
+++ b/contrib/examples/testnet-network-info/README.md
@@ -1,0 +1,32 @@
+# Testnet network info
+
+Prints the canonical Stellar testnet network passphrase and its CAIP-2
+identifier. Pure constant lookup — no network calls.
+
+## Where this is used in the SDK
+
+- `TESTNET.networkPassphrase` (`src/config.ts`) is one of the fields in the
+  `TESTNET` `NetworkConfig` — used to construct `PasskeyKit`/`SACClient` and
+  to sign/submit transactions on the correct network.
+- The `stellar:testnet` CAIP-2 identifier is how the SDK's x402 client
+  (`src/x402-client.ts`) tags testnet payment requirements per the x402 v2
+  spec (`PaymentRequirements.network`, `src/x402-types.ts`).
+
+## Run it
+
+```sh
+npx tsx testnet-network-info.ts
+```
+
+Expected output:
+
+```
+Network passphrase: Test SDF Network ; September 2015
+CAIP-2 identifier:  stellar:testnet
+```
+
+## Tests
+
+```sh
+npx vitest run contrib/examples/testnet-network-info
+```

--- a/contrib/examples/testnet-network-info/testnet-network-info.test.ts
+++ b/contrib/examples/testnet-network-info/testnet-network-info.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from "vitest";
+import { TESTNET } from "../../../src/config";
+import { TESTNET_CAIP2 } from "./testnet-network-info";
+
+describe("testnet network info", () => {
+  it("exposes the canonical testnet passphrase from src/config", () => {
+    expect(TESTNET.networkPassphrase).toBe("Test SDF Network ; September 2015");
+  });
+
+  it("exposes the stellar:testnet CAIP-2 identifier", () => {
+    expect(TESTNET_CAIP2).toBe("stellar:testnet");
+  });
+});

--- a/contrib/examples/testnet-network-info/testnet-network-info.ts
+++ b/contrib/examples/testnet-network-info/testnet-network-info.ts
@@ -1,0 +1,21 @@
+// Example: print the canonical Stellar testnet network passphrase and its
+// CAIP-2 identifier. Pure constant lookup — no network calls.
+//
+// Run with: npx tsx testnet-network-info.ts
+
+import { TESTNET } from "../../../src/config";
+
+// The CAIP-2 identifier vellar-sdk's x402 client maps testnet to internally
+// (src/x402-client.ts's CAIP2_BY_NETWORK / src/x402-types.ts's
+// PaymentRequirements.network doc) — not exported as a named constant, so
+// it's reproduced here as the same literal.
+export const TESTNET_CAIP2 = "stellar:testnet";
+
+function main() {
+  console.log("Network passphrase:", TESTNET.networkPassphrase);
+  console.log("CAIP-2 identifier: ", TESTNET_CAIP2);
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main();
+}


### PR DESCRIPTION
## Summary
Four standalone example scripts under contrib/examples/, covering a testnet constant lookup, an error-class reference list, a timeout-wrapped fetch, and a simple fixed-count retry loop.

closes #29
closes #31
closes #32
closes #33

## Changes
- **#29 — testnet-network-info**: prints `TESTNET.networkPassphrase` (`src/config.ts`) and the `stellar:testnet` CAIP-2 identifier the SDK's x402 client uses internally. Pure constant lookup, no network calls.
- **#31 — list-error-classes**: hardcoded reference list of 10 SDK typed error classes with a one-line description of when each is thrown. Every class name verified against the source (`grep`'d each one). README notes the list must be kept in sync manually.
- **#32 — fetch-with-timeout**: `fetchWithTimeout()` wraps fetch with `AbortController`, throwing a clear `FetchTimeoutError` instead of the raw `AbortError`. README notes how this composes with x402's injectable `fetchImpl`.
- **#33 — simple-retry**: `simpleRetry()` wraps an async function in a fixed-count, no-delay retry loop, logging each attempt. README explains when this is appropriate vs. exponential backoff (see #44's `retrying-fetch` example).

## Test plan
- Each example has a colocated `*.test.ts` (vitest) — 12 new tests, all passing. #32's tests use a mock fetch that respects the abort signal, so they don't depend on real network timing.
- Ran every script directly (`npx tsx ...`) and confirmed output matches each README exactly.
- `npm run typecheck`, `npm test` (149/149 passing), and `npm run build` all clean on top of this branch.
- All changes are confined to `contrib/examples/`; verified `git status` shows no files touched outside `contrib/`.