### PR TITLE
feat(examples): debounce, address compare/truncate, and mock SAC balance examples

### DIFF
--- a/contrib/examples/compare-addresses/README.md
+++ b/contrib/examples/compare-addresses/README.md
@@ -1,0 +1,26 @@
+# Compare two Stellar addresses for equality
+
+Compares two address strings for equality after normalizing case. `null` or
+`undefined` inputs return `false` rather than throwing.
+
+## Examples
+
+| A | B | Result |
+| --- | --- | --- |
+| `GABC123DEF456` | `GABC123DEF456` | `true` |
+| `GABC123DEF456` | `gabc123def456` | `true` (case-insensitive) |
+| `GABC123DEF456` | `GDIFFERENT789` | `false` |
+| `null` | `GABC123DEF456` | `false` |
+| `undefined` | `undefined` | `false` |
+
+## Run it
+
+```sh
+npx tsx compare-addresses.ts
+```
+
+## Tests
+
+```sh
+npx vitest run contrib/examples/compare-addresses
+```

--- a/contrib/examples/compare-addresses/compare-addresses.test.ts
+++ b/contrib/examples/compare-addresses/compare-addresses.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+import { addressesEqual } from "./compare-addresses";
+
+describe("addressesEqual", () => {
+  it("returns true for identical addresses", () => {
+    expect(addressesEqual("GABC123DEF456", "GABC123DEF456")).toBe(true);
+  });
+
+  it("is case-insensitive", () => {
+    expect(addressesEqual("GABC123DEF456", "gabc123def456")).toBe(true);
+  });
+
+  it("returns false for different addresses", () => {
+    expect(addressesEqual("GABC123DEF456", "GDIFFERENT789")).toBe(false);
+  });
+
+  it("returns false rather than throwing when either input is null", () => {
+    expect(addressesEqual(null, "GABC123DEF456")).toBe(false);
+    expect(addressesEqual("GABC123DEF456", null)).toBe(false);
+  });
+
+  it("returns false rather than throwing when either input is undefined", () => {
+    expect(addressesEqual(undefined, "GABC123DEF456")).toBe(false);
+    expect(addressesEqual(undefined, undefined)).toBe(false);
+  });
+});

--- a/contrib/examples/compare-addresses/compare-addresses.ts
+++ b/contrib/examples/compare-addresses/compare-addresses.ts
@@ -1,0 +1,30 @@
+// Example: compare two Stellar address strings for equality after
+// normalizing case (Stellar strkey addresses are conventionally uppercase,
+// but comparisons should be case-insensitive against a source that isn't).
+//
+// Run with: npx tsx compare-addresses.ts
+
+export function addressesEqual(a: string | null | undefined, b: string | null | undefined): boolean {
+  if (a == null || b == null) {
+    return false;
+  }
+  return a.toUpperCase() === b.toUpperCase();
+}
+
+function main() {
+  const examples: [string | null | undefined, string | null | undefined][] = [
+    ["GABC123DEF456", "GABC123DEF456"],
+    ["GABC123DEF456", "gabc123def456"],
+    ["GABC123DEF456", "GDIFFERENT789"],
+    [null, "GABC123DEF456"],
+    [undefined, undefined],
+  ];
+
+  for (const [a, b] of examples) {
+    console.log(`${a ?? "(null)"} === ${b ?? "(null)"}  ->  ${addressesEqual(a, b)}`);
+  }
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main();
+}

--- a/contrib/examples/debounce-refresh/README.md
+++ b/contrib/examples/debounce-refresh/README.md
@@ -1,0 +1,35 @@
+# Debounce a balance refresh call
+
+Debounces repeated calls to a mock `refreshBalance` function so only the
+last call in a burst actually runs, after the burst goes quiet for
+`delayMs`.
+
+## Where this helps in a wallet UI
+
+A balance display that refetches on every relevant event (a poll tick, a
+websocket update, a tab regaining focus, a user hitting "refresh" a few
+times) can trigger a burst of near-simultaneous refresh calls. Debouncing
+collapses that burst into a single network request — instead of firing 5
+redundant balance reads for a single user action, only the last one runs.
+
+## Run it
+
+```sh
+npx tsx debounce-refresh.ts
+```
+
+Expected output (5 rapid calls collapse into 1 actual refresh):
+
+```
+Firing 5 rapid calls in a burst...
+refreshBalance called (call #1) for CACCOUNTSAMPLEADDRESSXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+Total actual refreshes: 1 (expected 1, despite 5 calls)
+```
+
+## Tests
+
+Uses vitest's fake timers, so the tests run instantly with no real delays:
+
+```sh
+npx vitest run contrib/examples/debounce-refresh
+```

--- a/contrib/examples/debounce-refresh/debounce-refresh.test.ts
+++ b/contrib/examples/debounce-refresh/debounce-refresh.test.ts
@@ -1,0 +1,50 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { debounce } from "./debounce-refresh";
+
+describe("debounce", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("collapses a burst of calls into a single call", () => {
+    const fn = vi.fn();
+    const debounced = debounce(fn, 100);
+
+    debounced();
+    debounced();
+    debounced();
+    expect(fn).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(100);
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  it("calls the wrapped function with the arguments from the last call in the burst", () => {
+    const fn = vi.fn();
+    const debounced = debounce(fn, 100);
+
+    debounced("first");
+    debounced("second");
+    debounced("third");
+    vi.advanceTimersByTime(100);
+
+    expect(fn).toHaveBeenCalledExactlyOnceWith("third");
+  });
+
+  it("fires again for a call after the debounce window has elapsed", () => {
+    const fn = vi.fn();
+    const debounced = debounce(fn, 100);
+
+    debounced();
+    vi.advanceTimersByTime(100);
+    expect(fn).toHaveBeenCalledTimes(1);
+
+    debounced();
+    vi.advanceTimersByTime(100);
+    expect(fn).toHaveBeenCalledTimes(2);
+  });
+});

--- a/contrib/examples/debounce-refresh/debounce-refresh.ts
+++ b/contrib/examples/debounce-refresh/debounce-refresh.ts
@@ -1,0 +1,42 @@
+// Example: debounce repeated calls to a mock refreshBalance function so
+// only the last call in a burst actually runs.
+//
+// Run with: npx tsx debounce-refresh.ts
+
+export type DebouncedFn<Args extends unknown[]> = (...args: Args) => void;
+
+/** Wraps `fn` so that a burst of calls within `delayMs` of each other
+ * collapses into a single call — the last one, after the burst goes quiet. */
+export function debounce<Args extends unknown[]>(
+  fn: (...args: Args) => void,
+  delayMs: number,
+): DebouncedFn<Args> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  return (...args: Args) => {
+    clearTimeout(timer);
+    timer = setTimeout(() => fn(...args), delayMs);
+  };
+}
+
+async function main() {
+  let refreshCount = 0;
+  const refreshBalance = (accountId: string) => {
+    refreshCount++;
+    console.log(`refreshBalance called (call #${refreshCount}) for ${accountId}`);
+  };
+
+  const debouncedRefresh = debounce(refreshBalance, 100);
+
+  console.log("Firing 5 rapid calls in a burst...");
+  for (let i = 0; i < 5; i++) {
+    debouncedRefresh("CACCOUNTSAMPLEADDRESSXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX");
+  }
+
+  // Wait past the debounce window to let the last (and only) call fire.
+  await new Promise((resolve) => setTimeout(resolve, 200));
+  console.log(`Total actual refreshes: ${refreshCount} (expected 1, despite 5 calls)`);
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main();
+}

--- a/contrib/examples/mock-sac-client/README.md
+++ b/contrib/examples/mock-sac-client/README.md
@@ -1,0 +1,29 @@
+# Mock SAC client for balance reads
+
+A mock `BalanceReader` (`src/balances.ts`) — the interface the SDK's real
+RPC-backed SAC balance reads (`createRpcBalanceReader`, `vellar-sdk/rpc`)
+implement — returning a fixed, configurable balance for any token/account
+pair. Useful for offline tests that need a balance reader without a real RPC
+call.
+
+## Run it
+
+```sh
+npx tsx mock-sac-client.ts
+```
+
+Expected output (all three accounts get the same fixed balance):
+
+```
+GALICE: 500000000 (fixed, regardless of token or account)
+GBOB: 500000000 (fixed, regardless of token or account)
+CCONTRACTHOLDERXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX: 500000000 (fixed, regardless of token or account)
+```
+
+## Tests
+
+Also demonstrates wiring the mock into the real `createBalanceService`:
+
+```sh
+npx vitest run contrib/examples/mock-sac-client
+```

--- a/contrib/examples/mock-sac-client/mock-sac-client.test.ts
+++ b/contrib/examples/mock-sac-client/mock-sac-client.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+import { createBalanceService } from "../../../src/balances";
+import { createMockBalanceReader } from "./mock-sac-client";
+
+describe("createMockBalanceReader", () => {
+  it("returns the configured fixed balance for any account", async () => {
+    const reader = createMockBalanceReader(1_000n);
+    await expect(reader.getTokenBalance("CTOKEN", "GALICE")).resolves.toBe(1_000n);
+    await expect(reader.getTokenBalance("CTOKEN", "GBOB")).resolves.toBe(1_000n);
+  });
+
+  it("returns the same fixed balance regardless of the token contract queried", async () => {
+    const reader = createMockBalanceReader(42n);
+    await expect(reader.getTokenBalance("CTOKEN_A", "GALICE")).resolves.toBe(42n);
+    await expect(reader.getTokenBalance("CTOKEN_B", "GALICE")).resolves.toBe(42n);
+  });
+
+  it("wires cleanly into the real createBalanceService", async () => {
+    const reader = createMockBalanceReader(250n);
+    const xlm = { symbol: "XLM", contractId: "CNATIVE", decimals: 7 };
+    const service = createBalanceService(reader, [xlm]);
+
+    await expect(service.getBalances("GALICE")).resolves.toEqual([{ ...xlm, amount: 250n }]);
+  });
+});

--- a/contrib/examples/mock-sac-client/mock-sac-client.ts
+++ b/contrib/examples/mock-sac-client/mock-sac-client.ts
@@ -1,0 +1,35 @@
+// Example: a mock SacClientLike (BalanceReader) returning a fixed balance
+// for any token/account pair, configured at construction time — for use in
+// offline tests that need a balance reader without a real RPC call.
+//
+// Run with: npx tsx mock-sac-client.ts
+
+import type { BalanceReader } from "../../../src/balances";
+
+/**
+ * A mock BalanceReader: getTokenBalance always resolves with the same
+ * fixed balance, regardless of which token contract or holder is asked
+ * for — useful as the reader passed to createBalanceService (src/balances.ts)
+ * in offline tests.
+ */
+export function createMockBalanceReader(fixedBalance: bigint): BalanceReader {
+  return {
+    async getTokenBalance(_tokenContractId: string, _holder: string) {
+      return fixedBalance;
+    },
+  };
+}
+
+async function main() {
+  const reader = createMockBalanceReader(500_000_000n);
+
+  const accounts = ["GALICE", "GBOB", "CCONTRACTHOLDERXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"];
+  for (const account of accounts) {
+    const balance = await reader.getTokenBalance("CANYTOKENCONTRACT", account);
+    console.log(`${account}: ${balance} (fixed, regardless of token or account)`);
+  }
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main();
+}

--- a/contrib/examples/truncate-address/README.md
+++ b/contrib/examples/truncate-address/README.md
@@ -1,0 +1,25 @@
+# Truncate an address for display
+
+Shortens a long Stellar address to a display-friendly form: the first six
+and last four characters, joined by dots. Returns the original string
+unchanged if it's already short enough.
+
+## Examples
+
+| Input | Output |
+| --- | --- |
+| `GABC123DEF456GHI789JKL012MNO345PQR678STU901VWX234YZ` | `GABC12...34YZ` |
+| `CDFDULU2JWKGMIJW6FJWJJKNB3JIDQK54YTBDQUNPZTBYXCXCSO3MVZG` | `CDFDUL...MVZG` |
+| `GSHORT` (shorter than 6+4) | `GSHORT` (returned unchanged) |
+
+## Run it
+
+```sh
+npx tsx truncate-address.ts
+```
+
+## Tests
+
+```sh
+npx vitest run contrib/examples/truncate-address
+```

--- a/contrib/examples/truncate-address/truncate-address.test.ts
+++ b/contrib/examples/truncate-address/truncate-address.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+import { truncateAddress } from "./truncate-address";
+
+describe("truncateAddress", () => {
+  it("shortens a long address to first 6 + last 4 characters", () => {
+    expect(truncateAddress("CDFDULU2JWKGMIJW6FJWJJKNB3JIDQK54YTBDQUNPZTBYXCXCSO3MVZG")).toBe(
+      "CDFDUL...MVZG",
+    );
+  });
+
+  it("returns an address exactly at the head+tail length unchanged", () => {
+    expect(truncateAddress("1234567890")).toBe("1234567890"); // 10 chars = 6 + 4
+  });
+
+  it("returns a shorter address unchanged", () => {
+    expect(truncateAddress("GSHORT")).toBe("GSHORT");
+  });
+
+  it("supports custom head/tail lengths", () => {
+    expect(truncateAddress("ABCDEFGHIJKLMNOP", 3, 2)).toBe("ABC...OP");
+  });
+});

--- a/contrib/examples/truncate-address/truncate-address.ts
+++ b/contrib/examples/truncate-address/truncate-address.ts
@@ -1,0 +1,28 @@
+// Example: shorten a long Stellar address to a display-friendly form — the
+// first six and last four characters, joined by dots.
+//
+// Run with: npx tsx truncate-address.ts
+
+/** Truncates an address to "<first 6>...<last 4>". An address no longer
+ * than headLen + tailLen is returned unchanged. */
+export function truncateAddress(address: string, headLen = 6, tailLen = 4): string {
+  if (address.length <= headLen + tailLen) {
+    return address;
+  }
+  return `${address.slice(0, headLen)}...${address.slice(-tailLen)}`;
+}
+
+function main() {
+  const examples = [
+    "GABC123DEF456GHI789JKL012MNO345PQR678STU901VWX234YZ",
+    "CDFDULU2JWKGMIJW6FJWJJKNB3JIDQK54YTBDQUNPZTBYXCXCSO3MVZG",
+    "GSHORT",
+  ];
+  for (const address of examples) {
+    console.log(`${address}  ->  ${truncateAddress(address)}`);
+  }
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main();
+}


### PR DESCRIPTION
## Summary
Four standalone examples under contrib/examples/, covering debouncing a balance refresh, address comparison, address display truncation, and a mock SAC-style balance reader.

closes #34
closes #37
closes #38
closes #40

## Changes
- **#34 — debounce-refresh**: `debounce()` collapses a burst of rapid `refreshBalance` calls into a single call after the burst goes quiet for `delayMs`. README notes where this helps in a wallet UI (poll ticks, websocket updates, tab focus, repeated manual refresh).
- **#37 — compare-addresses**: `addressesEqual()` compares two address strings case-insensitively, returning `false` rather than throwing when either input is `null`/`undefined`.
- **#38 — truncate-address**: `truncateAddress()` shortens a long address to `first6...last4` for display, returning the original string unchanged when it's already short enough.
- **#40 — mock-sac-client**: `createMockBalanceReader()` returns a fixed, configurable balance for any token/account pair, implementing the real `BalanceReader` interface (`src/balances.ts`) — demonstrated wired into the SDK's own `createBalanceService`.

## Test plan
- Each example has a colocated `*.test.ts` (vitest) — 15 new tests, all passing. #34's tests use vitest's fake timers so they run with no real delays.
- Ran every script directly (`npx tsx ...`) and confirmed output matches each README exactly.
- `npm run typecheck`, `npm test` (152/152 passing), and `npm run build` all clean on top of this branch.
- All changes are confined to `contrib/examples/`; verified `git status` shows no files touched outside `contrib/`.