### PR TITLE
feat(examples): x402 resource server, rate limiter, session file store, and policy gateway examples

### DIFF
--- a/contrib/examples/mock-policy-gateway/README.md
+++ b/contrib/examples/mock-policy-gateway/README.md
@@ -1,0 +1,31 @@
+# Mock policy API gateway
+
+A mock `fetch` implementation covering the policy API gateway's
+list-templates, generate, and simulate routes — wired into the SDK's real
+`createPolicyClient()` (`src/policy-client.ts`) via its injectable `fetch`
+option, for offline tests that don't need a live gateway.
+
+## Covered routes
+
+| Route | Response shape |
+| --- | --- |
+| `GET /policies/templates` | `PolicyTemplateInfo[]` |
+| `POST /policies/generate` | `{ policy: GeneratedPolicy }` |
+| `POST /policies/:id/simulate` | `SimulateResult` |
+
+Any other route returns a 404 with an explanatory error body.
+
+## Run it
+
+```sh
+npx tsx mock-policy-gateway.ts
+```
+
+Exercises all three covered routes through the real `PolicyClient` and
+prints each response.
+
+## Tests
+
+```sh
+npx vitest run contrib/examples/mock-policy-gateway
+```

--- a/contrib/examples/mock-policy-gateway/mock-policy-gateway.test.ts
+++ b/contrib/examples/mock-policy-gateway/mock-policy-gateway.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+import { createPolicyClient } from "../../../src/policy-client";
+import { mockPolicyGatewayFetch } from "./mock-policy-gateway";
+
+describe("mockPolicyGatewayFetch wired into createPolicyClient", () => {
+  const client = createPolicyClient({
+    apiUrl: "https://mock-gateway.example.com",
+    network: "testnet",
+    fetch: mockPolicyGatewayFetch,
+  });
+
+  it("listTemplates returns at least one template", async () => {
+    const templates = await client.listTemplates();
+    expect(templates.length).toBeGreaterThan(0);
+    expect(templates[0]).toHaveProperty("type");
+    expect(templates[0]).toHaveProperty("enforcement");
+  });
+
+  it("generate returns a GeneratedPolicy", async () => {
+    const policy = await client.generate({ version: "1", type: "spending-limit", owners: ["GOWNER"] });
+    expect(policy.id).toBeTruthy();
+    expect(policy.status).toBe("generated");
+  });
+
+  it("simulate returns a SimulateResult", async () => {
+    const result = await client.simulate("policy_mock123", "CWALLET");
+    expect(result.ok).toBe(true);
+  });
+
+  it("404s an unmocked route", async () => {
+    const res = await mockPolicyGatewayFetch("https://mock-gateway.example.com/policies/unknown-route");
+    expect(res.status).toBe(404);
+  });
+});

--- a/contrib/examples/mock-policy-gateway/mock-policy-gateway.ts
+++ b/contrib/examples/mock-policy-gateway/mock-policy-gateway.ts
@@ -1,0 +1,81 @@
+// Example: a mock fetch handler returning canned responses for the policy
+// API gateway's list-templates, generate, and simulate routes — for
+// offline tests that need to wire the real createPolicyClient() to
+// something other than a live gateway.
+//
+// Run with: npx tsx mock-policy-gateway.ts
+
+import { createPolicyClient } from "../../../src/policy-client";
+import type { GeneratedPolicy, PolicyTemplateInfo, SimulateResult } from "../../../src/policy-types";
+
+const MOCK_TEMPLATES: PolicyTemplateInfo[] = [
+  {
+    type: "spending-limit",
+    title: "Spending limit",
+    description: "A rolling-window daily spending cap enforced by a dedicated policy contract.",
+    enforcement: { kind: "policy-contract", wasmHash: "mock-wasm-hash" },
+  },
+  {
+    type: "none",
+    title: "No extra policy",
+    description: "Default single-owner behaviour.",
+    enforcement: { kind: "none" },
+  },
+];
+
+const MOCK_GENERATED_POLICY: GeneratedPolicy = {
+  id: "policy_mock123",
+  createdAt: "2026-01-01T00:00:00.000Z",
+  status: "generated",
+  definition: { version: "1", type: "spending-limit", owners: ["GOWNER"] },
+  policyHash: "mock-policy-hash",
+  manifest: {
+    template: "spending-limit",
+    enforcement: { kind: "policy-contract", wasmHash: "mock-wasm-hash" },
+    network: "testnet",
+  },
+};
+
+const MOCK_SIMULATE_RESULT: SimulateResult = { ok: true, minResourceFee: "100000" };
+
+/** A mock fetch implementation covering the policy gateway's
+ * templates/generate/simulate routes. Any other route 404s. */
+export const mockPolicyGatewayFetch: typeof fetch = (async (url: string | URL, init?: RequestInit) => {
+  const { pathname } = new URL(url);
+  const method = init?.method ?? "GET";
+
+  if (pathname === "/policies/templates" && method === "GET") {
+    return new Response(JSON.stringify(MOCK_TEMPLATES), { status: 200 });
+  }
+  if (pathname === "/policies/generate" && method === "POST") {
+    return new Response(JSON.stringify({ policy: MOCK_GENERATED_POLICY }), { status: 200 });
+  }
+  if (pathname.endsWith("/simulate") && method === "POST") {
+    return new Response(JSON.stringify(MOCK_SIMULATE_RESULT), { status: 200 });
+  }
+
+  return new Response(JSON.stringify({ error: `mock gateway: no route for ${method} ${pathname}` }), {
+    status: 404,
+  });
+}) as typeof fetch;
+
+async function main() {
+  const client = createPolicyClient({
+    apiUrl: "https://mock-gateway.example.com",
+    network: "testnet",
+    fetch: mockPolicyGatewayFetch,
+  });
+
+  console.log("listTemplates():", await client.listTemplates());
+  console.log();
+  console.log(
+    "generate():",
+    await client.generate({ version: "1", type: "spending-limit", owners: ["GOWNER"] }),
+  );
+  console.log();
+  console.log("simulate():", await client.simulate("policy_mock123", "CWALLET"));
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main();
+}

--- a/contrib/examples/mock-x402-resource/README.md
+++ b/contrib/examples/mock-x402-resource/README.md
@@ -1,0 +1,24 @@
+# Mock x402 resource server
+
+A minimal in-process mock of an x402-protected resource. Returns a mock
+`PAYMENT-REQUIRED`-style payload (HTTP 402, base64 JSON) until a
+`PAYMENT-SIGNATURE` header is present on the request, then returns the
+protected resource. This mock never validates the header's actual
+signature — a real facilitator would.
+
+## Run it
+
+```sh
+npx tsx mock-x402-resource.ts
+```
+
+Demonstrates both cases: an unpaid request (402 + `PAYMENT-REQUIRED` header)
+and a paid request (200 + resource body).
+
+## Tests
+
+Covers the unpaid and the paid request case:
+
+```sh
+npx vitest run contrib/examples/mock-x402-resource
+```

--- a/contrib/examples/mock-x402-resource/mock-x402-resource.test.ts
+++ b/contrib/examples/mock-x402-resource/mock-x402-resource.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+import { handleResourceRequest } from "./mock-x402-resource";
+
+describe("handleResourceRequest", () => {
+  it("returns 402 with a PAYMENT-REQUIRED header when no payment header is present", () => {
+    const response = handleResourceRequest({ headers: {} });
+    expect(response.status).toBe(402);
+    expect(response.headers["PAYMENT-REQUIRED"]).toBeTruthy();
+
+    const decoded = JSON.parse(atob(response.headers["PAYMENT-REQUIRED"]!));
+    expect(decoded.x402Version).toBe(2);
+    expect(decoded.accepts[0].scheme).toBe("exact");
+  });
+
+  it("returns 200 with the resource when a payment header is present", () => {
+    const response = handleResourceRequest({
+      headers: { "PAYMENT-SIGNATURE": "mock-signature-value" },
+    });
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual({ data: "the protected resource content" });
+  });
+
+  it("accepts a lowercase header name", () => {
+    const response = handleResourceRequest({
+      headers: { "payment-signature": "mock-signature-value" },
+    });
+    expect(response.status).toBe(200);
+  });
+});

--- a/contrib/examples/mock-x402-resource/mock-x402-resource.ts
+++ b/contrib/examples/mock-x402-resource/mock-x402-resource.ts
@@ -1,0 +1,71 @@
+// Example: a minimal in-process mock of an x402-protected resource server.
+// Returns a mock PAYMENT-REQUIRED-style payload (402) until a payment header
+// is present on the request, then returns the resource.
+//
+// Run with: npx tsx mock-x402-resource.ts
+
+export interface MockRequest {
+  headers: Record<string, string>;
+}
+
+export interface MockResponse {
+  status: number;
+  headers: Record<string, string>;
+  body: unknown;
+}
+
+// Browser-safe base64, matching src/x402-client.ts's utf8ToBase64 (this
+// package targets bundlers/browsers, no Buffer).
+function utf8ToBase64(s: string): string {
+  const bytes = new TextEncoder().encode(s);
+  let bin = "";
+  for (const b of bytes) bin += String.fromCharCode(b);
+  return btoa(bin);
+}
+
+const PAYMENT_HEADER = "PAYMENT-SIGNATURE";
+
+const PAYMENT_REQUIRED_PAYLOAD = {
+  x402Version: 2,
+  accepts: [
+    {
+      scheme: "exact",
+      network: "stellar:testnet",
+      asset: "CUSDCAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+      amount: "1000000",
+      payTo: "CPAYTOSAMPLEADDRESSXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+    },
+  ],
+};
+
+/** Handles a request to a protected resource: 402 without a payment header,
+ * 200 with the resource once one is present (this mock never validates the
+ * header's actual signature — a real facilitator would). */
+export function handleResourceRequest(request: MockRequest): MockResponse {
+  const paymentHeader = request.headers[PAYMENT_HEADER] ?? request.headers[PAYMENT_HEADER.toLowerCase()];
+
+  if (!paymentHeader) {
+    return {
+      status: 402,
+      headers: {
+        "PAYMENT-REQUIRED": utf8ToBase64(JSON.stringify(PAYMENT_REQUIRED_PAYLOAD)),
+      },
+      body: { error: "Payment required" },
+    };
+  }
+
+  return { status: 200, headers: {}, body: { data: "the protected resource content" } };
+}
+
+function main() {
+  console.log("Unpaid request:");
+  console.log(handleResourceRequest({ headers: {} }));
+
+  console.log();
+  console.log("Paid request (payment header present):");
+  console.log(handleResourceRequest({ headers: { "PAYMENT-SIGNATURE": "mock-signature-value" } }));
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main();
+}

--- a/contrib/examples/session-file-store/README.md
+++ b/contrib/examples/session-file-store/README.md
@@ -1,0 +1,42 @@
+# Wallet session file store
+
+Saves and loads a wallet session to/from a local JSON file, for node-based
+tooling (a CLI, a headless agent) that needs to persist a session between
+runs without a real browser `Storage` API.
+
+**For examples and tests only — not production.** A real app should use
+`createWebStorageAdapter` (or a custom `SessionStorageAdapter`) from
+`vellar-sdk`'s `src/session.ts`; a plain JSON file has no encryption and no
+concurrent-write protection.
+
+## Run it
+
+```sh
+npx tsx session-file-store.ts
+```
+
+Expected output:
+
+```
+Load before save: null
+Saved session to /tmp/vellar-example-session.json
+Load after save:  {
+  accountId: 'CABC123SAMPLEWALLETCONTRACTADDRESSXXXXXXXXXXXXXXXXXXXXXX',
+  network: 'testnet',
+  connected: true,
+  authMethod: 'passkey',
+  createdAt: '2026-01-15T09:30:00.000Z',
+  lastActiveAt: '2026-01-15T09:30:00.000Z'
+}
+```
+
+A missing file on `loadSession()` returns `null` rather than throwing — a
+fresh run with no prior saved session is a normal case.
+
+## Tests
+
+Uses a temporary directory per test, cleaned up afterward:
+
+```sh
+npx vitest run contrib/examples/session-file-store
+```

--- a/contrib/examples/session-file-store/session-file-store.test.ts
+++ b/contrib/examples/session-file-store/session-file-store.test.ts
@@ -1,0 +1,44 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { loadSession, saveSession, type WalletSession } from "./session-file-store";
+
+const sample: WalletSession = {
+  accountId: "CTEST",
+  network: "testnet",
+  connected: true,
+  authMethod: "passkey",
+  createdAt: "2026-01-01T00:00:00.000Z",
+  lastActiveAt: "2026-01-01T00:00:00.000Z",
+};
+
+describe("session file store", () => {
+  let dir: string;
+  let filePath: string;
+
+  beforeEach(async () => {
+    dir = await mkdtemp(join(tmpdir(), "vellar-session-store-test-"));
+    filePath = join(dir, "session.json");
+  });
+
+  afterEach(async () => {
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  it("returns null when the file does not exist", async () => {
+    await expect(loadSession(filePath)).resolves.toBeNull();
+  });
+
+  it("loads back exactly what was saved", async () => {
+    await saveSession(filePath, sample);
+    await expect(loadSession(filePath)).resolves.toEqual(sample);
+  });
+
+  it("overwrites the file on a second save", async () => {
+    await saveSession(filePath, sample);
+    const updated = { ...sample, accountId: "CTEST2" };
+    await saveSession(filePath, updated);
+    await expect(loadSession(filePath)).resolves.toEqual(updated);
+  });
+});

--- a/contrib/examples/session-file-store/session-file-store.ts
+++ b/contrib/examples/session-file-store/session-file-store.ts
@@ -1,0 +1,59 @@
+// Example: save and load a wallet session to/from a local JSON file, for
+// node-based tooling (a CLI, a headless agent) that needs to persist a
+// session between runs without a real browser Storage API.
+//
+// Run with: npx tsx session-file-store.ts
+
+import { readFile, writeFile } from "node:fs/promises";
+
+export interface WalletSession {
+  accountId: string;
+  network: "testnet" | "mainnet";
+  connected: boolean;
+  authMethod: "passkey";
+  createdAt: string;
+  lastActiveAt: string;
+}
+
+/** Persists `session` as pretty-printed JSON at `filePath`. */
+export async function saveSession(filePath: string, session: WalletSession): Promise<void> {
+  await writeFile(filePath, JSON.stringify(session, null, 2), "utf8");
+}
+
+/** Loads a session from `filePath`. Returns null (rather than throwing) if
+ * the file doesn't exist — a fresh CLI run with no prior saved session is a
+ * normal case, not an error. */
+export async function loadSession(filePath: string): Promise<WalletSession | null> {
+  try {
+    const raw = await readFile(filePath, "utf8");
+    return JSON.parse(raw) as WalletSession;
+  } catch (err) {
+    if (err instanceof Error && "code" in err && (err as NodeJS.ErrnoException).code === "ENOENT") {
+      return null;
+    }
+    throw err;
+  }
+}
+
+async function main() {
+  const filePath = "/tmp/vellar-example-session.json";
+
+  console.log("Load before save:", await loadSession(filePath));
+
+  const sample: WalletSession = {
+    accountId: "CABC123SAMPLEWALLETCONTRACTADDRESSXXXXXXXXXXXXXXXXXXXXXX",
+    network: "testnet",
+    connected: true,
+    authMethod: "passkey",
+    createdAt: "2026-01-15T09:30:00.000Z",
+    lastActiveAt: "2026-01-15T09:30:00.000Z",
+  };
+  await saveSession(filePath, sample);
+  console.log(`Saved session to ${filePath}`);
+
+  console.log("Load after save: ", await loadSession(filePath));
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main();
+}

--- a/contrib/examples/simple-rate-limiter/README.md
+++ b/contrib/examples/simple-rate-limiter/README.md
@@ -1,0 +1,33 @@
+# Simple in-memory rate limiter
+
+A fixed-window rate limiter keyed by a string id, tracking counts in memory.
+Accepts a `limit` and a window length (`windowMs`) at construction; a call
+past the limit within the current window is rejected. A new window (and a
+fresh count) begins once `windowMs` has elapsed since the current window
+started.
+
+## Run it
+
+```sh
+npx tsx simple-rate-limiter.ts
+```
+
+Expected output (limit=3, calling the same key 5 times):
+
+```
+Calling with key 'user-1' 5 times (limit=3, window=1000ms):
+  call 1: allowed
+  call 2: allowed
+  call 3: allowed
+  call 4: rejected
+  call 5: rejected
+```
+
+## Tests
+
+An injectable clock lets the tests advance time deterministically instead of
+depending on real delays:
+
+```sh
+npx vitest run contrib/examples/simple-rate-limiter
+```

--- a/contrib/examples/simple-rate-limiter/simple-rate-limiter.test.ts
+++ b/contrib/examples/simple-rate-limiter/simple-rate-limiter.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+import { SimpleRateLimiter } from "./simple-rate-limiter";
+
+describe("SimpleRateLimiter", () => {
+  it("allows calls up to the limit within a window, then rejects", () => {
+    let now = 0;
+    const limiter = new SimpleRateLimiter(3, 1000, () => now);
+
+    expect(limiter.isAllowed("user-1")).toBe(true);
+    expect(limiter.isAllowed("user-1")).toBe(true);
+    expect(limiter.isAllowed("user-1")).toBe(true);
+    expect(limiter.isAllowed("user-1")).toBe(false); // 4th call within the window
+  });
+
+  it("tracks separate keys independently", () => {
+    let now = 0;
+    const limiter = new SimpleRateLimiter(1, 1000, () => now);
+
+    expect(limiter.isAllowed("user-1")).toBe(true);
+    expect(limiter.isAllowed("user-1")).toBe(false);
+    expect(limiter.isAllowed("user-2")).toBe(true); // different key, own window
+  });
+
+  it("resets the count once a new window begins", () => {
+    let now = 0;
+    const limiter = new SimpleRateLimiter(2, 1000, () => now);
+
+    expect(limiter.isAllowed("user-1")).toBe(true);
+    expect(limiter.isAllowed("user-1")).toBe(true);
+    expect(limiter.isAllowed("user-1")).toBe(false);
+
+    now = 1000; // window elapses
+    expect(limiter.isAllowed("user-1")).toBe(true);
+  });
+});

--- a/contrib/examples/simple-rate-limiter/simple-rate-limiter.ts
+++ b/contrib/examples/simple-rate-limiter/simple-rate-limiter.ts
@@ -1,0 +1,56 @@
+// Example: a fixed-window rate limiter keyed by a string id, tracking
+// counts in memory.
+//
+// Run with: npx tsx simple-rate-limiter.ts
+
+interface WindowState {
+  count: number;
+  windowStart: number;
+}
+
+export class SimpleRateLimiter {
+  #limit: number;
+  #windowMs: number;
+  #state = new Map<string, WindowState>();
+  #now: () => number;
+
+  constructor(limit: number, windowMs: number, now: () => number = Date.now) {
+    this.#limit = limit;
+    this.#windowMs = windowMs;
+    this.#now = now;
+  }
+
+  /** Returns true and records the call if `key` is under its limit for the
+   * current window; returns false without recording if over. A new window
+   * starts (and the count resets) once windowMs has elapsed since the
+   * window began. */
+  isAllowed(key: string): boolean {
+    const now = this.#now();
+    const state = this.#state.get(key);
+
+    if (!state || now - state.windowStart >= this.#windowMs) {
+      this.#state.set(key, { count: 1, windowStart: now });
+      return true;
+    }
+
+    if (state.count >= this.#limit) {
+      return false;
+    }
+
+    state.count++;
+    return true;
+  }
+}
+
+function main() {
+  const limiter = new SimpleRateLimiter(3, 1000);
+
+  console.log("Calling with key 'user-1' 5 times (limit=3, window=1000ms):");
+  for (let i = 1; i <= 5; i++) {
+    console.log(`  call ${i}: ${limiter.isAllowed("user-1") ? "allowed" : "rejected"}`);
+  }
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main();
+}


### PR DESCRIPTION
## Summary
Four standalone examples under contrib/examples/, covering a mock x402 resource server, an in-memory rate limiter, a session file store for node tooling, and a mock policy API gateway.

closes #51
closes #54
closes #56
closes #57

## Changes
- **#51 — mock-x402-resource**: `handleResourceRequest()` returns a mock `PAYMENT-REQUIRED` payload (402) until a `PAYMENT-SIGNATURE` header is present, then returns the protected resource. Never validates the header's actual signature — a real facilitator would.
- **#54 — simple-rate-limiter**: `SimpleRateLimiter` tracks a fixed-window count per key in memory, rejecting calls past the configured limit until the window elapses. Injectable clock keeps the tests deterministic.
- **#56 — session-file-store**: `saveSession`/`loadSession` persist a `WalletSession` to/from a local JSON file for node-based tooling; `loadSession` returns `null` (not a throw) when the file doesn't exist yet.
- **#57 — mock-policy-gateway**: `mockPolicyGatewayFetch` covers the templates/generate/simulate routes with documented sample responses, wired into the real `createPolicyClient()` via its injectable `fetch` option.

## Test plan
- Each example has a colocated `*.test.ts` (vitest) — 13 new tests, all passing.
- Ran every script directly (`npx tsx ...`) and confirmed output matches each README exactly.
- `npm run typecheck`, `npm test` (279/279 passing on top of `drips`, which now includes the previously-merged batch), and `npm run build` all clean on top of this branch.
- All changes are confined to `contrib/examples/`; verified `git status` shows no files touched outside `contrib/`.