### PR TITLE
feat(contrib): CLI send-payment tool, policy dry-run harness, x402 cost estimator

### DIFF
--- a/contrib/examples/cli-send-payment/README.md
+++ b/contrib/examples/cli-send-payment/README.md
@@ -1,0 +1,53 @@
+# CLI: send a test payment
+
+A small command-line tool that drives a real `createVellarWallet` handle —
+wired to fully in-memory mock `kit`, `sac`, and `backend` dependencies — through
+a create-then-pay sequence. No WebAuthn prompt, no RPC call, no relayer: it's a
+reference for exercising the wallet's `pay()` flow end to end from a script.
+
+## Usage
+
+```sh
+npx tsx cli-send-payment.ts --to <recipient> --amount <decimal> --token <USDC|XLM>
+```
+
+- `--to` — the recipient address (any non-empty string works against the mock;
+  the real SDK validates against actual Stellar address rules).
+- `--amount` — a decimal amount, e.g. `12.5`. Rejected if it has more
+  fractional digits than the token supports (7, for both mock tokens).
+- `--token` — `USDC` or `XLM` (case-insensitive). These map to fake contract
+  ids defined in `cli-send-payment.ts`'s `MOCK_TOKENS`.
+
+Flags may be given in any order.
+
+## Sample run
+
+```sh
+$ npx tsx cli-send-payment.ts --to GRECIPIENTXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX --amount 12.5 --token USDC
+Creating a mock wallet...
+Wallet created: CMOCKSMARTACCOUNTXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+Sending 12.5 USDC to GRECIPIENTXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX...
+Payment submitted. Transaction hash: mockhash1000000
+```
+
+## How the mocks are wired
+
+`createMockWallet` builds the three seams `createVellarWallet` needs
+(`PasskeyKitLike`, `WalletBackend & submitTransaction`, `SacClientLike`) as
+plain in-memory objects — `kit.sign` just prefixes the input with `signed:`,
+`sac.getSACClient(...).transfer` returns a placeholder unsigned-tx string, and
+`backend.submitTransaction` hands back an incrementing fake hash. This is the
+same shape a real integration wires (a real `PasskeyKit` instance, a real
+`SACClient`, and your app's backend), just swapped for deterministic fakes —
+useful as a starting point for scripting SDK flows or for integration tests
+that shouldn't touch a live network.
+
+## Tests
+
+```sh
+npx vitest run contrib/examples/cli-send-payment
+```
+
+Covers argument parsing (order-independence, missing flags/values), the full
+create-then-pay sequence producing a hash, an unknown `--token` being rejected
+before any payment is attempted, and an over-precise `--amount` being rejected.

--- a/contrib/examples/cli-send-payment/cli-send-payment.test.ts
+++ b/contrib/examples/cli-send-payment/cli-send-payment.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "vitest";
+import { createMockWallet, parseArgs, runSendPayment } from "./cli-send-payment";
+
+describe("parseArgs", () => {
+  it("parses all three required flags regardless of order", () => {
+    const args = parseArgs(["--amount", "10.5", "--to", "GRECIPIENT", "--token", "USDC"]);
+    expect(args).toEqual({ to: "GRECIPIENT", amount: "10.5", token: "USDC" });
+  });
+
+  it("throws naming every missing flag, not just the first", () => {
+    expect(() => parseArgs(["--to", "GRECIPIENT"])).toThrow(/--amount.*--token|--token.*--amount/);
+  });
+
+  it("throws when a flag is missing its value", () => {
+    expect(() => parseArgs(["--to", "--amount", "10"])).toThrow(/Missing value for --to/);
+  });
+});
+
+describe("runSendPayment", () => {
+  it("creates a wallet and submits a payment, returning a transaction hash", async () => {
+    const { wallet } = createMockWallet("testnet");
+    const logs: string[] = [];
+
+    const result = await runSendPayment(
+      { to: "GRECIPIENTXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX", amount: "12.5", token: "USDC" },
+      wallet,
+      (line) => logs.push(line),
+    );
+
+    expect(result.hash).toBeTruthy();
+    expect(logs.some((l) => l.includes("Wallet created"))).toBe(true);
+    expect(logs.some((l) => l.includes("Payment submitted"))).toBe(true);
+  });
+
+  it("rejects an unknown token before attempting to pay", async () => {
+    const { wallet } = createMockWallet("testnet");
+    await expect(
+      runSendPayment({ to: "GRECIPIENT", amount: "1", token: "DOGE" }, wallet),
+    ).rejects.toThrow(/Unknown --token/);
+  });
+
+  it("rejects an amount with too many decimal places", async () => {
+    const { wallet } = createMockWallet("testnet");
+    await expect(
+      runSendPayment({ to: "GRECIPIENT", amount: "1.12345678", token: "USDC" }, wallet),
+    ).rejects.toThrow(/at most 7 decimal places/);
+  });
+
+  it("produces a different hash for each payment submitted through the same mock wallet", async () => {
+    const { wallet } = createMockWallet("testnet");
+    await wallet.create();
+    const first = await wallet.pay({
+      to: "GRECIPIENT1",
+      amount: 1_0000000n,
+      token: { symbol: "USDC", contractId: "CUSDC", decimals: 7 },
+    });
+    const second = await wallet.pay({
+      to: "GRECIPIENT2",
+      amount: 2_0000000n,
+      token: { symbol: "USDC", contractId: "CUSDC", decimals: 7 },
+    });
+    expect(first.hash).not.toBe(second.hash);
+  });
+});

--- a/contrib/examples/cli-send-payment/cli-send-payment.ts
+++ b/contrib/examples/cli-send-payment/cli-send-payment.ts
@@ -1,0 +1,171 @@
+// Example: a command-line tool that sends a payment through a Vellar wallet
+// handle wired to mock kit/sac/backend dependencies, so it runs end to end
+// with no live network call.
+//
+// Run with:
+//   npx tsx cli-send-payment.ts --to GRECIPIENTXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX --amount 12.5 --token USDC
+
+import { createVellarWallet, type VellarWallet } from "../../../src/client";
+import type { PasskeyKitLike, WalletBackend } from "../../../src/passkeykit-connector";
+import type { SacClientLike, TokenContractClientLike } from "../../../src/payments-client";
+import type { Network } from "../../../src/types";
+import type { TokenInfo } from "../../../src/balances";
+
+/** The recognized `--token` values and the TokenInfo each maps to (contract ids
+ * are obviously fake — this tool never touches a real network). */
+const MOCK_TOKENS: Record<string, TokenInfo> = {
+  USDC: { symbol: "USDC", contractId: "CUSDCMOCKCONTRACTXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX", decimals: 7 },
+  XLM: { symbol: "XLM", contractId: "CXLMMOCKCONTRACTXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX", decimals: 7 },
+};
+
+export interface CliArgs {
+  to: string;
+  amount: string;
+  token: string;
+}
+
+/** Parses `--to <addr> --amount <decimal> --token <symbol>` (any order). Throws
+ * a descriptive Error naming every missing flag rather than failing on the first. */
+export function parseArgs(argv: string[]): CliArgs {
+  const flags: Record<string, string> = {};
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    if (arg?.startsWith("--")) {
+      const name = arg.slice(2);
+      const value = argv[i + 1];
+      if (value === undefined || value.startsWith("--")) {
+        throw new Error(`Missing value for --${name}`);
+      }
+      flags[name] = value;
+      i++;
+    }
+  }
+
+  const missing = ["to", "amount", "token"].filter((name) => !(name in flags));
+  if (missing.length > 0) {
+    throw new Error(`Missing required flag(s): ${missing.map((m) => `--${m}`).join(", ")}`);
+  }
+
+  return { to: flags.to!, amount: flags.amount!, token: flags.token! };
+}
+
+/** Builds a wallet handle wired to fully in-memory mock dependencies — no
+ * WebAuthn prompt, no RPC, no relayer. `sentAmount`/`sentTo` are captured on
+ * the mock SAC transfer call so a caller (or a test) can assert on them
+ * without depending on the fake XDR string. */
+export function createMockWallet(network: Network): {
+  wallet: VellarWallet;
+  submittedHashes: string[];
+} {
+  const submittedHashes: string[] = [];
+
+  const kit: PasskeyKitLike = {
+    async createWallet(_app, _user) {
+      return {
+        keyIdBase64: "mock-key-id",
+        contractId: "CMOCKSMARTACCOUNTXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+        signedTx: "mock-create-tx",
+      };
+    },
+    async connectWallet() {
+      return { keyIdBase64: "mock-key-id", contractId: "CMOCKSMARTACCOUNTXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX" };
+    },
+    async sign(tx: unknown) {
+      return typeof tx === "string" ? `signed:${tx}` : "signed:mock-payment-tx";
+    },
+  };
+
+  const backend: WalletBackend & {
+    submitTransaction(input: { signedXdr: string; network: Network }): Promise<{ hash: string }>;
+  } = {
+    async submitWalletCreation() {
+      return { sessionId: "mock-session-id" };
+    },
+    async lookupContractId() {
+      return undefined;
+    },
+    async submitTransaction() {
+      const hash = `mockhash${submittedHashes.length + 1}`.padEnd(16, "0");
+      submittedHashes.push(hash);
+      return { hash };
+    },
+  };
+
+  const sac: SacClientLike = {
+    getSACClient(tokenContractId: string): TokenContractClientLike {
+      return {
+        async transfer() {
+          // Simulated build; the actual "on-chain effect" is just returning a
+          // placeholder XDR-shaped payload for kit.sign to sign.
+          return `unsigned-transfer-tx:${tokenContractId}`;
+        },
+      };
+    },
+  };
+
+  const wallet = createVellarWallet({
+    network,
+    appName: "cli-send-payment example",
+    kit,
+    backend,
+    sac,
+    isValidAddress: (address: string) => address.length > 0 && !address.includes(" "),
+  });
+
+  return { wallet, submittedHashes };
+}
+
+/** Runs the full create-then-pay sequence for one CLI invocation, returning
+ * the submitted transaction hash. Separated from `main` so it's directly
+ * testable without touching `process.argv`. */
+export async function runSendPayment(
+  args: CliArgs,
+  wallet: VellarWallet,
+  log: (line: string) => void = console.log,
+): Promise<{ hash: string }> {
+  const token = MOCK_TOKENS[args.token.toUpperCase()];
+  if (!token) {
+    throw new Error(
+      `Unknown --token "${args.token}". Known tokens: ${Object.keys(MOCK_TOKENS).join(", ")}`,
+    );
+  }
+
+  log(`Creating a mock wallet...`);
+  const session = await wallet.create({ username: "cli-test-user" });
+  log(`Wallet created: ${session.accountId}`);
+
+  const amount = parseTokenAmountLoose(args.amount, token.decimals);
+  log(`Sending ${args.amount} ${token.symbol} to ${args.to}...`);
+  const result = await wallet.pay({ to: args.to, amount, token });
+  log(`Payment submitted. Transaction hash: ${result.hash}`);
+
+  return result;
+}
+
+/** Local decimal->base-units conversion so this example has no import-time
+ * dependency ordering on payments.ts beyond the type-only imports above;
+ * mirrors src/payments.ts's parseTokenAmount rules (no silent rounding). */
+function parseTokenAmountLoose(input: string, decimals: number): bigint {
+  const trimmed = input.trim();
+  if (!/^\d+(\.\d+)?$/.test(trimmed)) {
+    throw new Error(`"${input}" is not a valid amount`);
+  }
+  const [whole = "0", fraction = ""] = trimmed.split(".");
+  if (fraction.length > decimals) {
+    throw new Error(`Amount supports at most ${decimals} decimal places`);
+  }
+  return BigInt(whole) * 10n ** BigInt(decimals) + BigInt(fraction.padEnd(decimals, "0") || "0");
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const { wallet } = createMockWallet("testnet");
+  await runSendPayment(args, wallet);
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main().catch((err) => {
+    console.error(`Error: ${(err as Error).message}`);
+    process.exitCode = 1;
+  });
+}

--- a/contrib/examples/policy-dry-run-harness/README.md
+++ b/contrib/examples/policy-dry-run-harness/README.md
@@ -1,0 +1,49 @@
+# Policy dry-run harness
+
+Evaluates a candidate `PolicyDefinition` against a list of sample
+transactions and reports pass/fail per transaction, with a human-readable
+reason for every failing check — useful for sanity-checking a policy body
+before it's ever deployed on-chain.
+
+## Checks applied
+
+For each transaction, in the order given:
+
+1. **Signer threshold** — `policy.threshold` vs. the transaction's `signerCount`.
+2. **Per-transaction limit** — `policy.spendingLimits.perTxXlm`.
+3. **Daily limit** — `policy.spendingLimits.dailyXlm`, tracked as a **running
+   total across the whole batch** in array order. A transaction that's fine
+   on its own can still fail here once earlier transactions in the batch have
+   used up the daily allowance.
+4. **Contract allowlist** — `policy.allowlistedContracts`, only checked when
+   the transaction has a `contractId` and the policy defines a non-empty list.
+
+A check that the policy doesn't define (e.g. no `threshold` field) is simply
+skipped. A transaction can fail more than one check at once — every failing
+reason is reported, not just the first.
+
+## Run it
+
+```sh
+npx tsx policy-dry-run-harness.ts
+```
+
+Expected output, against the sample policy (threshold 2, 200 XLM/tx, 500
+XLM/day, one allowlisted contract) and four sample transactions:
+
+```
+tx-1: PASS
+tx-2: FAIL
+  - Amount 250 XLM exceeds per-transaction limit of 200 XLM
+tx-3: FAIL
+  - Requires 2 signer(s); transaction has 1
+tx-4: FAIL
+  - Cumulative spend 680 XLM (including this transaction) exceeds daily limit of 500 XLM
+  - Contract CUNKNOWNCONTRACTXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX is not in the allowlist [CALLOWEDCONTRACTXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX]
+```
+
+## Tests
+
+```sh
+npx vitest run contrib/examples/policy-dry-run-harness
+```

--- a/contrib/examples/policy-dry-run-harness/policy-dry-run-harness.test.ts
+++ b/contrib/examples/policy-dry-run-harness/policy-dry-run-harness.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from "vitest";
+import { dryRunPolicy, type SampleTransaction } from "./policy-dry-run-harness";
+import type { PolicyDefinition } from "../../../src/types";
+
+const basePolicy: PolicyDefinition = {
+  version: "1",
+  type: "spending-limit",
+  owners: ["GA", "GB"],
+  threshold: 2,
+  spendingLimits: { dailyXlm: "500", perTxXlm: "200" },
+  allowlistedContracts: ["CALLOWED"],
+};
+
+describe("dryRunPolicy", () => {
+  it("passes a transaction that satisfies every check", () => {
+    const [result] = dryRunPolicy(basePolicy, [
+      { id: "tx-1", amountXlm: "100", signerCount: 2, contractId: "CALLOWED" },
+    ]);
+    expect(result).toEqual({ transactionId: "tx-1", passed: true, reasons: [] });
+  });
+
+  it("reports a per-transaction limit violation with a clear reason", () => {
+    const [result] = dryRunPolicy(basePolicy, [{ id: "tx-1", amountXlm: "250", signerCount: 2 }]);
+    expect(result?.passed).toBe(false);
+    expect(result?.reasons).toEqual([
+      "Amount 250 XLM exceeds per-transaction limit of 200 XLM",
+    ]);
+  });
+
+  it("reports a signer-threshold violation", () => {
+    const [result] = dryRunPolicy(basePolicy, [{ id: "tx-1", amountXlm: "50", signerCount: 1 }]);
+    expect(result?.passed).toBe(false);
+    expect(result?.reasons).toEqual(["Requires 2 signer(s); transaction has 1"]);
+  });
+
+  it("reports a non-allowlisted contract", () => {
+    const [result] = dryRunPolicy(basePolicy, [
+      { id: "tx-1", amountXlm: "50", signerCount: 2, contractId: "CNOTALLOWED" },
+    ]);
+    expect(result?.passed).toBe(false);
+    expect(result?.reasons).toEqual(["Contract CNOTALLOWED is not in the allowlist [CALLOWED]"]);
+  });
+
+  it("accumulates a running daily total across the batch, in order", () => {
+    // No per-tx limit here, isolating the daily-accumulation behavior:
+    // each transaction is individually fine, but the third pushes the
+    // running total over the daily limit.
+    const policy: PolicyDefinition = { ...basePolicy, spendingLimits: { dailyXlm: "500" } };
+    const transactions: SampleTransaction[] = [
+      { id: "tx-1", amountXlm: "200", signerCount: 2 },
+      { id: "tx-2", amountXlm: "200", signerCount: 2 },
+      { id: "tx-3", amountXlm: "200", signerCount: 2 }, // cumulative 600 > 500 daily limit
+    ];
+    const results = dryRunPolicy(policy, transactions);
+    expect(results[0]?.passed).toBe(true);
+    expect(results[1]?.passed).toBe(true);
+    expect(results[2]?.passed).toBe(false);
+    expect(results[2]?.reasons).toEqual([
+      "Cumulative spend 600 XLM (including this transaction) exceeds daily limit of 500 XLM",
+    ]);
+  });
+
+  it("reports every failing check for a transaction, not just the first", () => {
+    const policy: PolicyDefinition = {
+      ...basePolicy,
+      spendingLimits: { dailyXlm: "10", perTxXlm: "5" },
+    };
+    const [result] = dryRunPolicy(policy, [
+      { id: "tx-1", amountXlm: "20", signerCount: 1, contractId: "CNOTALLOWED" },
+    ]);
+    expect(result?.passed).toBe(false);
+    expect(result?.reasons).toHaveLength(4);
+  });
+
+  it("skips checks the policy does not define", () => {
+    const permissive: PolicyDefinition = { version: "1", type: "none", owners: ["GA"] };
+    const [result] = dryRunPolicy(permissive, [
+      { id: "tx-1", amountXlm: "1000000", signerCount: 0, contractId: "CANYTHING" },
+    ]);
+    expect(result).toEqual({ transactionId: "tx-1", passed: true, reasons: [] });
+  });
+});

--- a/contrib/examples/policy-dry-run-harness/policy-dry-run-harness.ts
+++ b/contrib/examples/policy-dry-run-harness/policy-dry-run-harness.ts
@@ -1,0 +1,138 @@
+// Example: a dry-run harness that evaluates a candidate PolicyDefinition
+// against a list of sample transactions and reports pass/fail with a reason
+// per failing check — useful for testing a policy body before deploying it.
+//
+// Run with: npx tsx policy-dry-run-harness.ts
+
+import type { PolicyDefinition } from "../../../src/types";
+
+/** A simplified transaction shape sufficient to evaluate the policy checks
+ * this harness understands (signer threshold, per-tx and daily spending
+ * limits, contract allowlist). Not a real Stellar transaction. */
+export interface SampleTransaction {
+  id: string;
+  amountXlm: string;
+  contractId?: string;
+  signerCount: number;
+}
+
+export interface DryRunResult {
+  transactionId: string;
+  passed: boolean;
+  /** Empty when passed. One entry per failing check, human-readable. */
+  reasons: string[];
+}
+
+// XLM has 7 decimal places (stroops); comparisons/sums are done as bigint
+// stroops so this never suffers float rounding on amount comparisons.
+const XLM_SCALE = 7;
+
+function toStroops(decimal: string): bigint {
+  const trimmed = decimal.trim();
+  if (!/^\d+(\.\d+)?$/.test(trimmed)) {
+    throw new Error(`"${decimal}" is not a valid decimal XLM amount`);
+  }
+  const [whole = "0", fraction = ""] = trimmed.split(".");
+  if (fraction.length > XLM_SCALE) {
+    throw new Error(`"${decimal}" has more than ${XLM_SCALE} decimal places`);
+  }
+  return BigInt(whole) * 10n ** BigInt(XLM_SCALE) + BigInt(fraction.padEnd(XLM_SCALE, "0") || "0");
+}
+
+function fromStroops(stroops: bigint): string {
+  const scale = 10n ** BigInt(XLM_SCALE);
+  const whole = stroops / scale;
+  const frac = (stroops % scale).toString().padStart(XLM_SCALE, "0").replace(/0+$/, "");
+  return frac ? `${whole}.${frac}` : `${whole}`;
+}
+
+/**
+ * Evaluates `transactions` in order against `policy`. Checks applied per
+ * transaction:
+ *   - signer threshold (policy.threshold vs. tx.signerCount)
+ *   - per-transaction spending limit (policy.spendingLimits.perTxXlm)
+ *   - cumulative daily spending limit (policy.spendingLimits.dailyXlm) —
+ *     tracked as a running total across the array, in the given order, so
+ *     an individually-fine transaction can still fail once earlier ones in
+ *     the batch have used up the daily allowance
+ *   - contract allowlist (policy.allowlistedContracts), when the tx has a
+ *     contractId and the policy defines a non-empty allowlist
+ *
+ * A transaction can fail more than one check; every failing reason is
+ * reported, not just the first.
+ */
+export function dryRunPolicy(policy: PolicyDefinition, transactions: SampleTransaction[]): DryRunResult[] {
+  const dailyLimit = policy.spendingLimits?.dailyXlm;
+  let cumulative = 0n;
+
+  return transactions.map((tx) => {
+    const reasons: string[] = [];
+
+    if (policy.threshold !== undefined && tx.signerCount < policy.threshold) {
+      reasons.push(`Requires ${policy.threshold} signer(s); transaction has ${tx.signerCount}`);
+    }
+
+    const perTxLimit = policy.spendingLimits?.perTxXlm;
+    if (perTxLimit !== undefined && toStroops(tx.amountXlm) > toStroops(perTxLimit)) {
+      reasons.push(`Amount ${tx.amountXlm} XLM exceeds per-transaction limit of ${perTxLimit} XLM`);
+    }
+
+    cumulative += toStroops(tx.amountXlm);
+    if (dailyLimit !== undefined && cumulative > toStroops(dailyLimit)) {
+      reasons.push(
+        `Cumulative spend ${fromStroops(cumulative)} XLM (including this transaction) exceeds daily limit of ${dailyLimit} XLM`,
+      );
+    }
+
+    if (
+      tx.contractId &&
+      policy.allowlistedContracts &&
+      policy.allowlistedContracts.length > 0 &&
+      !policy.allowlistedContracts.includes(tx.contractId)
+    ) {
+      reasons.push(
+        `Contract ${tx.contractId} is not in the allowlist [${policy.allowlistedContracts.join(", ")}]`,
+      );
+    }
+
+    return { transactionId: tx.id, passed: reasons.length === 0, reasons };
+  });
+}
+
+function samplePolicy(): PolicyDefinition {
+  return {
+    version: "1",
+    type: "spending-limit",
+    owners: ["GOWNER1XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX", "GOWNER2XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"],
+    threshold: 2,
+    spendingLimits: { dailyXlm: "500", perTxXlm: "200" },
+    allowlistedContracts: ["CALLOWEDCONTRACTXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"],
+  };
+}
+
+function sampleTransactions(): SampleTransaction[] {
+  return [
+    { id: "tx-1", amountXlm: "100", signerCount: 2, contractId: "CALLOWEDCONTRACTXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX" },
+    { id: "tx-2", amountXlm: "250", signerCount: 2 }, // exceeds per-tx limit
+    { id: "tx-3", amountXlm: "150", signerCount: 1 }, // under threshold
+    { id: "tx-4", amountXlm: "180", signerCount: 2, contractId: "CUNKNOWNCONTRACTXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX" }, // not allowlisted, and pushes daily total over 500
+  ];
+}
+
+function main() {
+  const results = dryRunPolicy(samplePolicy(), sampleTransactions());
+  for (const result of results) {
+    if (result.passed) {
+      console.log(`${result.transactionId}: PASS`);
+    } else {
+      console.log(`${result.transactionId}: FAIL`);
+      for (const reason of result.reasons) {
+        console.log(`  - ${reason}`);
+      }
+    }
+  }
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main();
+}

--- a/contrib/examples/x402-cost-estimator/README.md
+++ b/contrib/examples/x402-cost-estimator/README.md
@@ -1,0 +1,55 @@
+# x402 payment cost estimator
+
+Estimates the total cost of a series of *planned* x402 payments (see
+`src/x402-types.ts` for the real `PaymentRequirements` shape this mirrors)
+against a mock price feed, converted to a single reference currency — before
+any of the payments are actually made. Useful for an agent to budget-check a
+batch of planned requests up front, e.g. against an
+`x402-budget-tracker`-style allowance.
+
+## Usage
+
+```ts
+import { estimateCost } from "./x402-cost-estimator";
+
+const estimate = estimateCost([
+  { asset: "USDC", amount: "5" },
+  { asset: "XLM", amount: "100" },
+]);
+
+estimate.totalReferenceCost; // "17" (5 USDC @ $1.00 + 100 XLM @ $0.12)
+```
+
+An asset with no entry in the rate table throws rather than silently costing
+$0 — the whole point of a cost estimator is a trustworthy number.
+
+## Run it
+
+```sh
+npx tsx x402-cost-estimator.ts
+```
+
+Expected output:
+
+```
+Itemized cost:
+  5 USDC -> 5 USD
+  2.5 USDC -> 2.5 USD
+  100 XLM -> 12 USD
+  10 EURC -> 10.8 USD
+Total estimated cost: 30.3 USD
+```
+
+## Notes on precision
+
+Amounts and rates are multiplied as fixed-point integers (6 decimal places),
+never as floats, so the totals never suffer float rounding — the same reason
+`src/payments.ts`'s `parseTokenAmount` avoids floats for money. This example
+treats every asset at the same fixed scale for simplicity; a real integration
+should use each asset's actual on-chain decimals.
+
+## Tests
+
+```sh
+npx vitest run contrib/examples/x402-cost-estimator
+```

--- a/contrib/examples/x402-cost-estimator/x402-cost-estimator.test.ts
+++ b/contrib/examples/x402-cost-estimator/x402-cost-estimator.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+import { estimateCost, MOCK_RATE_TABLE, type PlannedPayment } from "./x402-cost-estimator";
+
+describe("estimateCost", () => {
+  it("converts each payment to the reference currency and sums the total", () => {
+    const payments: PlannedPayment[] = [
+      { asset: "USDC", amount: "5" },
+      { asset: "USDC", amount: "2.5" },
+      { asset: "XLM", amount: "100" },
+      { asset: "EURC", amount: "10" },
+    ];
+
+    const estimate = estimateCost(payments);
+
+    expect(estimate.items).toEqual([
+      { asset: "USDC", amount: "5", referenceCost: "5" },
+      { asset: "USDC", amount: "2.5", referenceCost: "2.5" },
+      { asset: "XLM", amount: "100", referenceCost: "12" },
+      { asset: "EURC", amount: "10", referenceCost: "10.8" },
+    ]);
+    expect(estimate.totalReferenceCost).toBe("30.3");
+    expect(estimate.referenceCurrency).toBe("USD");
+  });
+
+  it("throws a clear error for an asset missing from the rate table", () => {
+    expect(() => estimateCost([{ asset: "DOGE", amount: "1" }])).toThrow(
+      /No rate available for asset "DOGE"/,
+    );
+  });
+
+  it("returns a zero total for an empty payment list", () => {
+    const estimate = estimateCost([]);
+    expect(estimate.items).toEqual([]);
+    expect(estimate.totalReferenceCost).toBe("0");
+  });
+
+  it("accepts a custom rate table instead of the default mock one", () => {
+    const estimate = estimateCost([{ asset: "GOLD", amount: "2" }], { GOLD: "2000" });
+    expect(estimate.totalReferenceCost).toBe("4000");
+  });
+
+  it("does not mutate the default MOCK_RATE_TABLE export", () => {
+    const before = { ...MOCK_RATE_TABLE };
+    estimateCost([{ asset: "USDC", amount: "1" }]);
+    expect(MOCK_RATE_TABLE).toEqual(before);
+  });
+});

--- a/contrib/examples/x402-cost-estimator/x402-cost-estimator.ts
+++ b/contrib/examples/x402-cost-estimator/x402-cost-estimator.ts
@@ -1,0 +1,111 @@
+// Example: estimate the total cost of a series of planned x402 payments
+// (see src/x402-types.ts for the real PaymentRequirements/X402PayOptions
+// shapes this mirrors) against a mock price feed, before any of them are
+// actually made — useful for an agent to budget-check a batch of planned
+// requests up front.
+//
+// Run with: npx tsx x402-cost-estimator.ts
+
+/** One planned payment: an asset symbol and a decimal amount in that
+ * asset's own units (not base/stroop units — this is a display-level
+ * estimate, not the on-chain payment itself). */
+export interface PlannedPayment {
+  asset: string;
+  amount: string;
+}
+
+export interface ItemizedCost {
+  asset: string;
+  amount: string;
+  referenceCost: string;
+}
+
+export interface CostEstimate {
+  items: ItemizedCost[];
+  totalReferenceCost: string;
+  referenceCurrency: string;
+}
+
+/** Mock rate table: asset symbol -> price in USD, as a decimal string (a
+ * real integration would read this from a price oracle). */
+export const MOCK_RATE_TABLE: Record<string, string> = {
+  USDC: "1.00",
+  EURC: "1.08",
+  XLM: "0.12",
+};
+
+// Fixed-point arithmetic at 6 decimal places (micro-units) so rate
+// multiplication never suffers float rounding — the same reasoning as
+// src/payments.ts's parseTokenAmount avoiding floats for money. This is a
+// simplification for a reference example: a real integration would use each
+// asset's actual on-chain decimals rather than a single shared scale.
+const SCALE = 6;
+
+function toMicroUnits(decimal: string): bigint {
+  const trimmed = decimal.trim();
+  if (!/^\d+(\.\d+)?$/.test(trimmed)) {
+    throw new Error(`"${decimal}" is not a valid decimal amount`);
+  }
+  const [whole = "0", fraction = ""] = trimmed.split(".");
+  if (fraction.length > SCALE) {
+    throw new Error(`"${decimal}" has more than ${SCALE} decimal places`);
+  }
+  return BigInt(whole) * 10n ** BigInt(SCALE) + BigInt(fraction.padEnd(SCALE, "0") || "0");
+}
+
+function fromMicroUnits(micro: bigint): string {
+  const scale = 10n ** BigInt(SCALE);
+  const whole = micro / scale;
+  const frac = (micro % scale).toString().padStart(SCALE, "0").replace(/0+$/, "");
+  return frac ? `${whole}.${frac}` : `${whole}`;
+}
+
+/**
+ * Estimates the total cost of `payments` in `referenceCurrency` (always
+ * "USD" for this example's mock table), using `rateTable` to convert each
+ * asset. Throws if any planned asset has no entry in the rate table — an
+ * unpriced payment silently reported as $0 would be worse than failing
+ * loudly, since the whole point is a trustworthy budget check.
+ */
+export function estimateCost(
+  payments: PlannedPayment[],
+  rateTable: Record<string, string> = MOCK_RATE_TABLE,
+): CostEstimate {
+  const items: ItemizedCost[] = [];
+  let totalMicro = 0n;
+
+  for (const payment of payments) {
+    const rate = rateTable[payment.asset];
+    if (rate === undefined) {
+      throw new Error(
+        `No rate available for asset "${payment.asset}". Known assets: ${Object.keys(rateTable).join(", ")}`,
+      );
+    }
+    const referenceMicro = (toMicroUnits(payment.amount) * toMicroUnits(rate)) / 10n ** BigInt(SCALE);
+    totalMicro += referenceMicro;
+    items.push({ asset: payment.asset, amount: payment.amount, referenceCost: fromMicroUnits(referenceMicro) });
+  }
+
+  return { items, totalReferenceCost: fromMicroUnits(totalMicro), referenceCurrency: "USD" };
+}
+
+function main() {
+  const plannedPayments: PlannedPayment[] = [
+    { asset: "USDC", amount: "5" },
+    { asset: "USDC", amount: "2.5" },
+    { asset: "XLM", amount: "100" },
+    { asset: "EURC", amount: "10" },
+  ];
+
+  const estimate = estimateCost(plannedPayments);
+
+  console.log("Itemized cost:");
+  for (const item of estimate.items) {
+    console.log(`  ${item.amount} ${item.asset} -> ${item.referenceCost} ${estimate.referenceCurrency}`);
+  }
+  console.log(`Total estimated cost: ${estimate.totalReferenceCost} ${estimate.referenceCurrency}`);
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main();
+}


### PR DESCRIPTION
## Summary

Three self-contained reference examples under contrib/examples/, each with its own README and vitest suite.

closes #82
closes #83
closes #92

## Changes

- **#82 — CLI send-payment tool** (`contrib/examples/cli-send-payment/`): a command-line tool that drives a real `createVellarWallet` handle through a create-then-pay sequence, wired to fully in-memory mock `kit`/`sac`/`backend` dependencies (no WebAuthn prompt, RPC call, or relayer). Accepts `--to`/`--amount`/`--token` in any order; rejects an unknown token or an over-precise amount before attempting payment.

- **#83 — Policy dry-run harness** (`contrib/examples/policy-dry-run-harness/`): evaluates a `PolicyDefinition` against a list of sample transactions and reports pass/fail per transaction with a reason per failing check — signer threshold, per-transaction limit, cumulative daily limit (tracked as a running total across the batch in array order), and contract allowlist. A transaction can fail more than one check; every reason is reported, not just the first.

- **#92 — x402 cost estimator** (`contrib/examples/x402-cost-estimator/`): estimates the total cost of a series of planned x402 payments against a mock rate table, converted to a single reference currency, before any payment is made. Throws for an asset missing from the rate table rather than silently reporting $0. Fixed-point arithmetic (6 decimal places) avoids float rounding on the totals, matching `src/payments.ts`'s own avoidance of floats for money.

## Test plan

- `npm run typecheck`, `npm test`, and `npm run build` all pass clean at the repo root (55 test files / 285 tests, including these 15 new ones and every pre-existing example).
- Each example's script was run directly (`npx tsx <file>`) and its output verified against the README's documented sample output.

All work is inside `contrib/`; no files outside it were touched.