### PR TITLE
feat(contrib): policy comparison, config validator, mock docs lookup, lightweight logger

### DIFF
--- a/contrib/examples/compare-policies/README.md
+++ b/contrib/examples/compare-policies/README.md
@@ -1,0 +1,34 @@
+# Compare two policy definitions for equality
+
+`policiesEqual(a, b)` compares two `PolicyDefinition` objects field by field
+and reports whether they describe the same policy. Array-valued fields
+(`owners`, `allowlistedContracts`) are compared **as sets** — two policies
+listing the same owners in a different order are still equal.
+
+## Example input pairs
+
+| `a` | `b` | `policiesEqual(a, b)` | Why |
+| --- | --- | --- | --- |
+| `owners: ["GALICE", "GBOB"]` | `owners: ["GBOB", "GALICE"]` (all else identical) | `true` | Same owners, different order |
+| `threshold: 2` | `threshold: 1` (all else identical) | `false` | Different threshold |
+| `owners: ["GALICE", "GBOB"]` | `owners: ["GALICE", "GCAROL"]` | `false` | Different owner set, not just reordered |
+| `spendingLimits: { dailyXlm: "500" }` | `spendingLimits: { dailyXlm: "999" }` | `false` | Different spending limit |
+
+## Run it
+
+```sh
+npx tsx compare-policies.ts
+```
+
+Expected output:
+
+```
+policyA vs policyB (owners reordered): true
+policyA vs policyC (different threshold): false
+```
+
+## Tests
+
+```sh
+npx vitest run contrib/examples/compare-policies
+```

--- a/contrib/examples/compare-policies/compare-policies.test.ts
+++ b/contrib/examples/compare-policies/compare-policies.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest";
+import { policiesEqual } from "./compare-policies";
+import type { PolicyDefinition } from "../../../src/types";
+
+const base: PolicyDefinition = {
+  version: "1",
+  type: "spending-limit",
+  owners: ["GALICE", "GBOB"],
+  threshold: 2,
+  spendingLimits: { dailyXlm: "500", perTxXlm: "200" },
+  allowlistedContracts: ["CFIRST", "CSECOND"],
+  timelocks: { adminActionDelaySeconds: 3600 },
+};
+
+describe("policiesEqual", () => {
+  it("returns true for identical policies", () => {
+    expect(policiesEqual(base, { ...base })).toBe(true);
+  });
+
+  it("ignores owners order", () => {
+    const reordered = { ...base, owners: ["GBOB", "GALICE"] };
+    expect(policiesEqual(base, reordered)).toBe(true);
+  });
+
+  it("ignores allowlistedContracts order", () => {
+    const reordered = { ...base, allowlistedContracts: ["CSECOND", "CFIRST"] };
+    expect(policiesEqual(base, reordered)).toBe(true);
+  });
+
+  it("detects a different threshold", () => {
+    expect(policiesEqual(base, { ...base, threshold: 1 })).toBe(false);
+  });
+
+  it("detects a different owners set (not just reordered)", () => {
+    expect(policiesEqual(base, { ...base, owners: ["GALICE", "GCAROL"] })).toBe(false);
+  });
+
+  it("detects a different owners count", () => {
+    expect(policiesEqual(base, { ...base, owners: ["GALICE", "GBOB", "GCAROL"] })).toBe(false);
+  });
+
+  it("detects a different spendingLimits value", () => {
+    expect(
+      policiesEqual(base, { ...base, spendingLimits: { dailyXlm: "999", perTxXlm: "200" } }),
+    ).toBe(false);
+  });
+
+  it("detects a different timelocks value", () => {
+    expect(policiesEqual(base, { ...base, timelocks: { adminActionDelaySeconds: 60 } })).toBe(false);
+  });
+
+  it("treats missing optional fields on both sides as equal", () => {
+    const minimalA: PolicyDefinition = { version: "1", type: "none", owners: ["GALICE"] };
+    const minimalB: PolicyDefinition = { version: "1", type: "none", owners: ["GALICE"] };
+    expect(policiesEqual(minimalA, minimalB)).toBe(true);
+  });
+});

--- a/contrib/examples/compare-policies/compare-policies.ts
+++ b/contrib/examples/compare-policies/compare-policies.ts
@@ -1,0 +1,73 @@
+// Example: compare two PolicyDefinition objects field by field and report
+// whether they are equivalent, ignoring the order of array-valued fields
+// (owners, allowlistedContracts) — two policies listing the same owners in
+// a different order are still the same policy.
+//
+// Run with: npx tsx compare-policies.ts
+
+import type { PolicyDefinition } from "../../../src/types";
+
+function sameStringSet(a: string[] = [], b: string[] = []): boolean {
+  if (a.length !== b.length) return false;
+  const sortedA = [...a].sort();
+  const sortedB = [...b].sort();
+  return sortedA.every((value, i) => value === sortedB[i]);
+}
+
+function sameSpendingLimits(
+  a?: PolicyDefinition["spendingLimits"],
+  b?: PolicyDefinition["spendingLimits"],
+): boolean {
+  return (a?.dailyXlm ?? undefined) === (b?.dailyXlm ?? undefined)
+    && (a?.perTxXlm ?? undefined) === (b?.perTxXlm ?? undefined);
+}
+
+function sameTimelocks(a?: PolicyDefinition["timelocks"], b?: PolicyDefinition["timelocks"]): boolean {
+  return (a?.adminActionDelaySeconds ?? undefined) === (b?.adminActionDelaySeconds ?? undefined);
+}
+
+/**
+ * Reports whether `a` and `b` describe the same policy: every scalar field
+ * matches exactly, and `owners`/`allowlistedContracts` match as sets (order
+ * doesn't matter, duplicates and length do).
+ */
+export function policiesEqual(a: PolicyDefinition, b: PolicyDefinition): boolean {
+  return (
+    a.version === b.version &&
+    a.type === b.type &&
+    a.threshold === b.threshold &&
+    sameStringSet(a.owners, b.owners) &&
+    sameStringSet(a.allowlistedContracts, b.allowlistedContracts) &&
+    sameSpendingLimits(a.spendingLimits, b.spendingLimits) &&
+    sameTimelocks(a.timelocks, b.timelocks)
+  );
+}
+
+function main() {
+  const policyA: PolicyDefinition = {
+    version: "1",
+    type: "spending-limit",
+    owners: ["GALICE", "GBOB"],
+    threshold: 2,
+    spendingLimits: { dailyXlm: "500", perTxXlm: "200" },
+  };
+
+  // Same policy, owners listed in the opposite order — still equal.
+  const policyB: PolicyDefinition = {
+    ...policyA,
+    owners: ["GBOB", "GALICE"],
+  };
+
+  // A genuinely different policy — different threshold.
+  const policyC: PolicyDefinition = {
+    ...policyA,
+    threshold: 1,
+  };
+
+  console.log(`policyA vs policyB (owners reordered): ${policiesEqual(policyA, policyB)}`);
+  console.log(`policyA vs policyC (different threshold): ${policiesEqual(policyA, policyC)}`);
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main();
+}

--- a/contrib/examples/config-validator/README.md
+++ b/contrib/examples/config-validator/README.md
@@ -1,0 +1,53 @@
+# Config validation helper
+
+`validateConfig(config, schema)` checks a plain configuration object against
+a schema of required field names and expected types (`string` | `number` |
+`boolean` | `object` | `array`). Returns a list of human-readable error
+messages instead of throwing on the first problem, so every issue can be
+shown at once.
+
+## Usage
+
+```ts
+import { validateConfig, type FieldSchema } from "./config-validator";
+
+const schema: FieldSchema[] = [
+  { name: "network", type: "string" },
+  { name: "enableX402", type: "boolean" },
+];
+
+validateConfig({ network: "testnet", enableX402: true }, schema);
+// -> [] (valid)
+
+validateConfig({ enableX402: "yes" }, schema);
+// -> [
+//   'Missing required field "network"',
+//   'Field "enableX402" expected type "boolean", got "string"',
+// ]
+```
+
+Fields present in the config but not listed in the schema are ignored —
+this validates required shape, not a strict allowlist.
+
+## Run it
+
+```sh
+npx tsx config-validator.ts
+```
+
+Expected output:
+
+```
+Valid config errors: []
+Broken config errors: [
+  'Missing required field "appName"',
+  'Field "rpcUrl" expected type "string", got "number"',
+  'Field "enableX402" expected type "boolean", got "string"'
+]
+```
+
+## Tests
+
+```sh
+npx vitest run contrib/examples/config-validator
+```

--- a/contrib/examples/config-validator/config-validator.test.ts
+++ b/contrib/examples/config-validator/config-validator.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+import { validateConfig, type FieldSchema } from "./config-validator";
+
+const schema: FieldSchema[] = [
+  { name: "network", type: "string" },
+  { name: "appName", type: "string" },
+  { name: "rpcUrl", type: "string" },
+  { name: "enableX402", type: "boolean" },
+];
+
+describe("validateConfig", () => {
+  it("returns no errors for a valid config", () => {
+    const config = { network: "testnet", appName: "My App", rpcUrl: "https://rpc.example", enableX402: true };
+    expect(validateConfig(config, schema)).toEqual([]);
+  });
+
+  it("reports a missing field", () => {
+    const config = { network: "testnet", rpcUrl: "https://rpc.example", enableX402: true };
+    expect(validateConfig(config, schema)).toEqual(['Missing required field "appName"']);
+  });
+
+  it("reports a type mismatch", () => {
+    const config = { network: "testnet", appName: "My App", rpcUrl: "https://rpc.example", enableX402: "yes" };
+    expect(validateConfig(config, schema)).toEqual([
+      'Field "enableX402" expected type "boolean", got "string"',
+    ]);
+  });
+
+  it("reports every issue, not just the first", () => {
+    const config = { network: "testnet", rpcUrl: 12345, enableX402: "yes" };
+    const errors = validateConfig(config, schema);
+    expect(errors).toEqual([
+      'Missing required field "appName"',
+      'Field "rpcUrl" expected type "string", got "number"',
+      'Field "enableX402" expected type "boolean", got "string"',
+    ]);
+  });
+
+  it("distinguishes array from object", () => {
+    const errors = validateConfig({ tags: [] }, [{ name: "tags", type: "object" }]);
+    expect(errors).toEqual(['Field "tags" expected type "object", got "array"']);
+  });
+
+  it("ignores fields in config that are not in the schema", () => {
+    const config = { network: "testnet", appName: "x", rpcUrl: "y", enableX402: false, extra: "unchecked" };
+    expect(validateConfig(config, schema)).toEqual([]);
+  });
+});

--- a/contrib/examples/config-validator/config-validator.ts
+++ b/contrib/examples/config-validator/config-validator.ts
@@ -1,0 +1,60 @@
+// Example: validate a plain configuration object against a small schema of
+// required field names and expected types, collecting every problem instead
+// of throwing on the first one.
+//
+// Run with: npx tsx config-validator.ts
+
+export type FieldType = "string" | "number" | "boolean" | "object" | "array";
+
+export interface FieldSchema {
+  name: string;
+  type: FieldType;
+}
+
+function actualType(value: unknown): string {
+  if (Array.isArray(value)) return "array";
+  if (value === null) return "null";
+  return typeof value;
+}
+
+/**
+ * Validates `config` against `schema`: every listed field must be present
+ * and match the declared type. Returns a list of human-readable error
+ * messages — empty when the config is valid. Every issue is reported, not
+ * just the first, so a caller can show a user all their mistakes at once.
+ */
+export function validateConfig(config: Record<string, unknown>, schema: FieldSchema[]): string[] {
+  const errors: string[] = [];
+
+  for (const field of schema) {
+    if (!(field.name in config)) {
+      errors.push(`Missing required field "${field.name}"`);
+      continue;
+    }
+    const found = actualType(config[field.name]);
+    if (found !== field.type) {
+      errors.push(`Field "${field.name}" expected type "${field.type}", got "${found}"`);
+    }
+  }
+
+  return errors;
+}
+
+function main() {
+  const schema: FieldSchema[] = [
+    { name: "network", type: "string" },
+    { name: "appName", type: "string" },
+    { name: "rpcUrl", type: "string" },
+    { name: "enableX402", type: "boolean" },
+  ];
+
+  const validConfig = { network: "testnet", appName: "My App", rpcUrl: "https://rpc.example", enableX402: true };
+  const brokenConfig = { network: "testnet", rpcUrl: 12345, enableX402: "yes" };
+
+  console.log("Valid config errors:", validateConfig(validConfig, schema));
+  console.log("Broken config errors:", validateConfig(brokenConfig, schema));
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main();
+}

--- a/contrib/examples/lightweight-logger/README.md
+++ b/contrib/examples/lightweight-logger/README.md
@@ -1,0 +1,43 @@
+# Lightweight logging wrapper
+
+A minimal `info`/`warn`/`error` logger with a global `setSilent` switch —
+useful for keeping test output clean without stripping log calls out of the
+code under test, or for a CLI's `--quiet` flag.
+
+## Usage
+
+```ts
+import { info, warn, error, setSilent } from "./lightweight-logger";
+
+info("Starting up");        // [INFO] Starting up
+warn("Cache miss");         // [WARN] Cache miss
+error("Request failed");    // [ERROR] Request failed
+
+setSilent(true);
+info("This produces no output at all");
+setSilent(false);
+```
+
+## Run it
+
+```sh
+npx tsx lightweight-logger.ts
+```
+
+Expected output:
+
+```
+[INFO] Starting up
+[WARN] Cache miss, falling back to network
+[ERROR] Request failed after 3 retries
+--- now silenced ---
+[INFO] Logging resumed
+```
+
+(Nothing prints between the `--- now silenced ---` line and `Logging resumed`.)
+
+## Tests
+
+```sh
+npx vitest run contrib/examples/lightweight-logger
+```

--- a/contrib/examples/lightweight-logger/lightweight-logger.test.ts
+++ b/contrib/examples/lightweight-logger/lightweight-logger.test.ts
@@ -1,0 +1,47 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { error, info, setSilent, warn } from "./lightweight-logger";
+
+describe("lightweight-logger", () => {
+  beforeEach(() => {
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    setSilent(false); // reset module-level state so tests don't leak into each other
+    vi.restoreAllMocks();
+  });
+
+  it("prefixes each level with a clear label", () => {
+    info("hello");
+    warn("careful");
+    error("broken");
+
+    expect(console.log).toHaveBeenCalledWith("[INFO] hello");
+    expect(console.warn).toHaveBeenCalledWith("[WARN] careful");
+    expect(console.error).toHaveBeenCalledWith("[ERROR] broken");
+  });
+
+  it("produces no output at all once silenced", () => {
+    setSilent(true);
+
+    info("hello");
+    warn("careful");
+    error("broken");
+
+    expect(console.log).not.toHaveBeenCalled();
+    expect(console.warn).not.toHaveBeenCalled();
+    expect(console.error).not.toHaveBeenCalled();
+  });
+
+  it("resumes logging after silence is turned back off", () => {
+    setSilent(true);
+    info("swallowed");
+    setSilent(false);
+    info("heard");
+
+    expect(console.log).toHaveBeenCalledTimes(1);
+    expect(console.log).toHaveBeenCalledWith("[INFO] heard");
+  });
+});

--- a/contrib/examples/lightweight-logger/lightweight-logger.ts
+++ b/contrib/examples/lightweight-logger/lightweight-logger.ts
@@ -1,0 +1,43 @@
+// Example: a minimal logging wrapper with info/warn/error levels that can
+// be silenced entirely — handy for keeping test output clean without
+// deleting the log calls from the code under test.
+//
+// Run with: npx tsx lightweight-logger.ts
+
+let silent = false;
+
+/** Suppresses all output from info/warn/error until called again with false. */
+export function setSilent(value: boolean): void {
+  silent = value;
+}
+
+export function info(message: string): void {
+  if (!silent) console.log(`[INFO] ${message}`);
+}
+
+export function warn(message: string): void {
+  if (!silent) console.warn(`[WARN] ${message}`);
+}
+
+export function error(message: string): void {
+  if (!silent) console.error(`[ERROR] ${message}`);
+}
+
+function main() {
+  info("Starting up");
+  warn("Cache miss, falling back to network");
+  error("Request failed after 3 retries");
+
+  console.log("--- now silenced ---");
+  setSilent(true);
+  info("This should not print");
+  warn("Neither should this");
+  error("Nor this");
+  setSilent(false);
+
+  info("Logging resumed");
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main();
+}

--- a/contrib/examples/mock-docs-lookup/README.md
+++ b/contrib/examples/mock-docs-lookup/README.md
@@ -1,0 +1,35 @@
+# Mock docs page lookup
+
+`getDocPage(slug)` is a small in-memory stand-in for the docs site's page
+registry — same shape (`{ slug, title }`), no dependency on the real
+website content. Useful in tests of tooling that consumes a doc-page lookup
+(e.g. a link checker or a "related docs" widget) without needing the real
+site built.
+
+## Usage
+
+```ts
+import { getDocPage } from "./mock-docs-lookup";
+
+getDocPage("passkeys"); // { slug: "passkeys", title: "Passkeys & Smart Accounts" }
+getDocPage("does-not-exist"); // undefined — never throws
+```
+
+## Run it
+
+```sh
+npx tsx mock-docs-lookup.ts
+```
+
+Expected output:
+
+```
+Known page: { slug: 'passkeys', title: 'Passkeys & Smart Accounts' }
+Unknown page: undefined
+```
+
+## Tests
+
+```sh
+npx vitest run contrib/examples/mock-docs-lookup
+```

--- a/contrib/examples/mock-docs-lookup/mock-docs-lookup.test.ts
+++ b/contrib/examples/mock-docs-lookup/mock-docs-lookup.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "vitest";
+import { getDocPage } from "./mock-docs-lookup";
+
+describe("getDocPage", () => {
+  it("returns the page for a known slug", () => {
+    expect(getDocPage("passkeys")).toEqual({ slug: "passkeys", title: "Passkeys & Smart Accounts" });
+  });
+
+  it("returns undefined for an unknown slug rather than throwing", () => {
+    expect(getDocPage("does-not-exist")).toBeUndefined();
+  });
+
+  it("has at least three sample pages", () => {
+    expect(getDocPage("getting-started")).toBeDefined();
+    expect(getDocPage("passkeys")).toBeDefined();
+    expect(getDocPage("x402-payments")).toBeDefined();
+  });
+});

--- a/contrib/examples/mock-docs-lookup/mock-docs-lookup.ts
+++ b/contrib/examples/mock-docs-lookup/mock-docs-lookup.ts
@@ -1,0 +1,35 @@
+// Example: a small mock docs registry lookup, similar in shape to the docs
+// site's getDocPage, for use in tests of tooling that consumes such a
+// lookup without depending on the real website content.
+//
+// Run with: npx tsx mock-docs-lookup.ts
+
+export interface DocPage {
+  slug: string;
+  title: string;
+}
+
+const PAGES: DocPage[] = [
+  { slug: "getting-started", title: "Getting Started" },
+  { slug: "passkeys", title: "Passkeys & Smart Accounts" },
+  { slug: "x402-payments", title: "x402 Agentic Payments" },
+  { slug: "policies", title: "Programmable Account Policies" },
+];
+
+/**
+ * Returns the DocPage for `slug`, or `undefined` for an unknown slug —
+ * never throws, so a caller can treat a miss as "no such page" rather than
+ * handling an exception.
+ */
+export function getDocPage(slug: string): DocPage | undefined {
+  return PAGES.find((page) => page.slug === slug);
+}
+
+function main() {
+  console.log("Known page:", getDocPage("passkeys"));
+  console.log("Unknown page:", getDocPage("does-not-exist"));
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main();
+}


### PR DESCRIPTION
## Summary

Four small, self-contained utility examples under contrib/examples/, each with its own README and vitest suite.

closes #116
closes #117
closes #118
closes #119

## Changes

- **#116 — Compare policies** (`contrib/examples/compare-policies/`): `policiesEqual(a, b)` compares two `PolicyDefinition` objects field by field, treating `owners` and `allowlistedContracts` as order-independent sets while every other field must match exactly.

- **#117 — Config validator** (`contrib/examples/config-validator/`): `validateConfig(config, schema)` checks a plain object against a schema of required field names and expected types, returning every validation error rather than throwing on the first one.

- **#118 — Mock docs lookup** (`contrib/examples/mock-docs-lookup/`): `getDocPage(slug)` — a 4-page in-memory stand-in for the docs site's page registry, returning `undefined` for an unknown slug rather than throwing.

- **#119 — Lightweight logger** (`contrib/examples/lightweight-logger/`): `info`/`warn`/`error` each prefix their message with a clear level label; `setSilent(true)` suppresses all three entirely until turned back off.

## Test plan

- `npm run typecheck`, `npm test`, and `npm run build` all pass clean at the repo root (56 test files / 287 tests, including these 15 new ones and every pre-existing example).
- Each example's script was run directly (`npx tsx <file>`) and its output verified against the README's documented sample output.

All work is inside `contrib/`; no files outside it were touched.