### PR TITLE
feat(examples): SEP-41 balance, wallet defaults, tx table, and address book examples

### DIFF
--- a/contrib/examples/address-book/README.md
+++ b/contrib/examples/address-book/README.md
@@ -1,0 +1,31 @@
+# Wallet address book
+
+A simple in-memory address book mapping friendly names to Stellar addresses,
+with `add`, `remove`, and `lookup` functions. Adding a name that's already in
+use throws `DuplicateNameError`; looking up an unknown name returns
+`undefined` rather than throwing.
+
+## Run it
+
+```sh
+npx tsx address-book.ts
+```
+
+Expected output:
+
+```
+Added Alice.
+Lookup Alice: GALICEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF
+Lookup Unknown: undefined
+Adding duplicate name rejected: An address book entry named "Alice" already exists
+Lookup Alice after remove: undefined
+```
+
+## Tests
+
+Covers add, lookup, remove, and the duplicate-name and unknown-name edge
+cases:
+
+```sh
+npx vitest run contrib/examples/address-book
+```

--- a/contrib/examples/address-book/address-book.test.ts
+++ b/contrib/examples/address-book/address-book.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+import { AddressBook, DuplicateNameError } from "./address-book";
+
+describe("AddressBook", () => {
+  it("adds and looks up an entry", () => {
+    const book = new AddressBook();
+    book.add("Alice", "GALICE");
+    expect(book.lookup("Alice")).toBe("GALICE");
+  });
+
+  it("returns undefined for an unknown name rather than throwing", () => {
+    const book = new AddressBook();
+    expect(book.lookup("Nobody")).toBeUndefined();
+  });
+
+  it("rejects adding a duplicate name with a clear error", () => {
+    const book = new AddressBook();
+    book.add("Alice", "GALICE");
+    expect(() => book.add("Alice", "GDIFFERENT")).toThrow(DuplicateNameError);
+  });
+
+  it("removes an entry, after which lookup returns undefined", () => {
+    const book = new AddressBook();
+    book.add("Alice", "GALICE");
+    book.remove("Alice");
+    expect(book.lookup("Alice")).toBeUndefined();
+  });
+
+  it("allows re-adding a name after it was removed", () => {
+    const book = new AddressBook();
+    book.add("Alice", "GALICE");
+    book.remove("Alice");
+    expect(() => book.add("Alice", "GNEWADDRESS")).not.toThrow();
+    expect(book.lookup("Alice")).toBe("GNEWADDRESS");
+  });
+
+  it("removing an unknown name is a no-op", () => {
+    const book = new AddressBook();
+    expect(() => book.remove("Nobody")).not.toThrow();
+  });
+});

--- a/contrib/examples/address-book/address-book.ts
+++ b/contrib/examples/address-book/address-book.ts
@@ -1,0 +1,57 @@
+// Example: a simple in-memory address book mapping friendly names to
+// Stellar addresses, with add, remove, and lookup functions.
+//
+// Run with: npx tsx address-book.ts
+
+export class DuplicateNameError extends Error {
+  constructor(name: string) {
+    super(`An address book entry named "${name}" already exists`);
+    this.name = "DuplicateNameError";
+  }
+}
+
+export class AddressBook {
+  #entries = new Map<string, string>();
+
+  /** Adds a name -> address mapping. Throws DuplicateNameError if the name
+   * is already in use — callers must remove() it first to replace it. */
+  add(name: string, address: string): void {
+    if (this.#entries.has(name)) {
+      throw new DuplicateNameError(name);
+    }
+    this.#entries.set(name, address);
+  }
+
+  /** Looks up an address by name. Returns undefined for an unknown name
+   * rather than throwing — a lookup miss is a normal, expected case. */
+  lookup(name: string): string | undefined {
+    return this.#entries.get(name);
+  }
+
+  /** Removes an entry. A no-op if the name doesn't exist. */
+  remove(name: string): void {
+    this.#entries.delete(name);
+  }
+}
+
+function main() {
+  const book = new AddressBook();
+
+  book.add("Alice", "GALICEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF");
+  console.log("Added Alice.");
+  console.log("Lookup Alice:", book.lookup("Alice"));
+  console.log("Lookup Unknown:", book.lookup("Unknown"));
+
+  try {
+    book.add("Alice", "GDIFFERENTAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF");
+  } catch (err) {
+    console.log(`Adding duplicate name rejected: ${err instanceof Error ? err.message : String(err)}`);
+  }
+
+  book.remove("Alice");
+  console.log("Lookup Alice after remove:", book.lookup("Alice"));
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main();
+}

--- a/contrib/examples/read-token-balance/README.md
+++ b/contrib/examples/read-token-balance/README.md
@@ -1,0 +1,30 @@
+# Read a SEP-41 token balance
+
+Reads a SEP-41 token balance for a given account and token contract id,
+using `vellar-sdk`'s RPC-backed balance reader (`createRpcBalanceReader`,
+`vellar-sdk/rpc`). Prints the balance in raw base units — this script
+doesn't assume any particular decimals, unlike `read-xlm-balance` which
+formats specifically for XLM's 7 decimals.
+
+## Finding a testnet token contract id
+
+Stellar Laboratory's testnet asset explorer, or the Stellar testnet Friendbot
+issuers used by common SDF sample tokens, are the usual sources for a
+testnet SAC (Stellar Asset Contract) id to test against. The SAC id is
+deterministic from the asset code + issuer + network passphrase — a wallet's
+own `nativeToken()` helper (`src/balances-rpc.ts`) shows the same derivation
+for the native asset.
+
+## Run it
+
+```sh
+npx tsx read-token-balance.ts <accountId> <tokenContractId>
+```
+
+## Tests
+
+Injects a mock `BalanceReader`, so the tests don't depend on a live RPC call:
+
+```sh
+npx vitest run contrib/examples/read-token-balance
+```

--- a/contrib/examples/read-token-balance/read-token-balance.test.ts
+++ b/contrib/examples/read-token-balance/read-token-balance.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it, vi } from "vitest";
+import type { BalanceReader } from "../../../src/balances";
+import { readTokenBalance } from "./read-token-balance";
+
+describe("readTokenBalance", () => {
+  it("returns the raw base-unit balance from the reader", async () => {
+    const reader: BalanceReader = { getTokenBalance: vi.fn().mockResolvedValue(42_500_000n) };
+    await expect(readTokenBalance(reader, "CTOKEN", "GHOLDER")).resolves.toBe(42_500_000n);
+    expect(reader.getTokenBalance).toHaveBeenCalledWith("CTOKEN", "GHOLDER");
+  });
+
+  it("propagates reader failures", async () => {
+    const reader: BalanceReader = { getTokenBalance: vi.fn().mockRejectedValue(new Error("rpc down")) };
+    await expect(readTokenBalance(reader, "CTOKEN", "GHOLDER")).rejects.toThrow("rpc down");
+  });
+});

--- a/contrib/examples/read-token-balance/read-token-balance.ts
+++ b/contrib/examples/read-token-balance/read-token-balance.ts
@@ -1,0 +1,48 @@
+// Example: read a SEP-41 token balance for a given account and token
+// contract id, using the SDK's RPC-backed balance reader. Prints the
+// balance in raw base units (unlike read-xlm-balance, this does not assume
+// 7 decimals — it just prints the raw bigint the contract returns).
+//
+// Run with: npx tsx read-token-balance.ts <accountId> <tokenContractId>
+
+import type { BalanceReader } from "../../../src/balances";
+import { createRpcBalanceReader } from "../../../src/rpc";
+import { TESTNET } from "../../../src/config";
+
+/** Reads one token balance. Reader is injected so this is directly
+ * unit-testable without a real RPC round trip. */
+export async function readTokenBalance(
+  reader: BalanceReader,
+  tokenContractId: string,
+  accountId: string,
+): Promise<bigint> {
+  return reader.getTokenBalance(tokenContractId, accountId);
+}
+
+async function main() {
+  const [accountId, tokenContractId] = process.argv.slice(2);
+  if (!accountId || !tokenContractId) {
+    console.error("Usage: npx tsx read-token-balance.ts <accountId> <tokenContractId>");
+    process.exitCode = 1;
+    return;
+  }
+
+  const reader = createRpcBalanceReader({
+    rpcUrl: TESTNET.rpcUrl,
+    networkPassphrase: TESTNET.networkPassphrase,
+  });
+
+  try {
+    const balance = await readTokenBalance(reader, tokenContractId, accountId);
+    console.log(`Account:  ${accountId}`);
+    console.log(`Token:    ${tokenContractId}`);
+    console.log(`Balance:  ${balance} (raw base units)`);
+  } catch (err) {
+    console.error(`Error reading balance: ${err instanceof Error ? err.message : String(err)}`);
+    process.exitCode = 1;
+  }
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main();
+}

--- a/contrib/examples/tx-history-table/README.md
+++ b/contrib/examples/tx-history-table/README.md
@@ -1,0 +1,32 @@
+# Transaction history table
+
+Formats an array of sample transaction records as an aligned text table for
+terminal output, with columns for hash, amount, and timestamp. An empty
+array prints a clear "No transactions." message instead of an
+empty/headerless table.
+
+## Run it
+
+```sh
+npx tsx tx-history-table.ts
+```
+
+Expected output:
+
+```
+With transactions:
+HASH                    AMOUNT  TIMESTAMP
+-----------------------------------------
+a1b2c3d4e5f6a7b8   100.5000000  2026-01-15T09:30:00Z
+f6e5d4c3b2a1f0e9     2.5000000  2026-01-15T10:12:45Z
+1234567890abcdef  1000.0000000  2026-01-16T08:00:00Z
+
+With an empty array:
+No transactions.
+```
+
+## Tests
+
+```sh
+npx vitest run contrib/examples/tx-history-table
+```

--- a/contrib/examples/tx-history-table/tx-history-table.test.ts
+++ b/contrib/examples/tx-history-table/tx-history-table.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+import { formatTxHistoryTable } from "./tx-history-table";
+
+describe("formatTxHistoryTable", () => {
+  it("prints a clear message for an empty array", () => {
+    expect(formatTxHistoryTable([])).toBe("No transactions.");
+  });
+
+  it("includes a header row with hash, amount, and timestamp columns", () => {
+    const table = formatTxHistoryTable([{ hash: "abc123", amount: "10.0000000", timestamp: "2026-01-01T00:00:00Z" }]);
+    expect(table).toContain("HASH");
+    expect(table).toContain("AMOUNT");
+    expect(table).toContain("TIMESTAMP");
+  });
+
+  it("includes a row for each transaction", () => {
+    const table = formatTxHistoryTable([
+      { hash: "hash1", amount: "1.0000000", timestamp: "2026-01-01T00:00:00Z" },
+      { hash: "hash2", amount: "2.0000000", timestamp: "2026-01-02T00:00:00Z" },
+    ]);
+    expect(table).toContain("hash1");
+    expect(table).toContain("hash2");
+  });
+
+  it("right-aligns the amount column for readability", () => {
+    const table = formatTxHistoryTable([
+      { hash: "h1", amount: "1", timestamp: "t1" },
+      { hash: "h2", amount: "1000000", timestamp: "t2" },
+    ]);
+    const lines = table.split("\n");
+    // Both amount values should end at the same column position.
+    const amountEnd1 = lines[2]!.indexOf("t1");
+    const amountEnd2 = lines[3]!.indexOf("t2");
+    expect(amountEnd1).toBe(amountEnd2);
+  });
+});

--- a/contrib/examples/tx-history-table/tx-history-table.ts
+++ b/contrib/examples/tx-history-table/tx-history-table.ts
@@ -1,0 +1,50 @@
+// Example: format an array of sample transaction records as an aligned
+// text table for terminal output.
+//
+// Run with: npx tsx tx-history-table.ts
+
+export interface TxRecord {
+  hash: string;
+  amount: string;
+  timestamp: string;
+}
+
+/** Formats transactions as an aligned text table (hash, amount, timestamp).
+ * An empty array prints a clear "no transactions" message instead of an
+ * empty/headerless table. */
+export function formatTxHistoryTable(transactions: TxRecord[]): string {
+  if (transactions.length === 0) {
+    return "No transactions.";
+  }
+
+  const headers = { hash: "HASH", amount: "AMOUNT", timestamp: "TIMESTAMP" };
+  const hashWidth = Math.max(headers.hash.length, ...transactions.map((t) => t.hash.length));
+  const amountWidth = Math.max(headers.amount.length, ...transactions.map((t) => t.amount.length));
+
+  const row = (t: { hash: string; amount: string; timestamp: string }) =>
+    `${t.hash.padEnd(hashWidth)}  ${t.amount.padStart(amountWidth)}  ${t.timestamp}`;
+
+  const lines = [row(headers), "-".repeat(row(headers).length)];
+  for (const tx of transactions) {
+    lines.push(row(tx));
+  }
+  return lines.join("\n");
+}
+
+function main() {
+  const sample: TxRecord[] = [
+    { hash: "a1b2c3d4e5f6a7b8", amount: "100.5000000", timestamp: "2026-01-15T09:30:00Z" },
+    { hash: "f6e5d4c3b2a1f0e9", amount: "2.5000000", timestamp: "2026-01-15T10:12:45Z" },
+    { hash: "1234567890abcdef", amount: "1000.0000000", timestamp: "2026-01-16T08:00:00Z" },
+  ];
+
+  console.log("With transactions:");
+  console.log(formatTxHistoryTable(sample));
+  console.log();
+  console.log("With an empty array:");
+  console.log(formatTxHistoryTable([]));
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main();
+}

--- a/contrib/examples/wallet-with-defaults/README.md
+++ b/contrib/examples/wallet-with-defaults/README.md
@@ -1,0 +1,30 @@
+# Wallet with sane defaults
+
+Wraps `createVellarWallet` with a helper, `createWalletWithDefaults()`, that
+fills in `network: "testnet"`, `appName: "vellar-example"`, and an
+`isValidAddress` accepting both classic (`G...`) and contract (`C...`)
+addresses — so a caller only needs to supply `kit`, `backend`, and `sac`.
+Any default can still be overridden by passing it explicitly.
+
+`sac` is **not** defaulted, on purpose: there's no safe stand-in for the
+real SAC client — a stub that throws breaks payments unexpectedly, and a
+stub that silently succeeds would fake a payment working. Both are worse
+than asking the caller for it explicitly.
+
+## Run it
+
+```sh
+npx tsx wallet-with-defaults.ts
+```
+
+Wires a mock kit/backend/sac into `createWalletWithDefaults()` and calls
+`create()`, printing the resulting session.
+
+## Tests
+
+Shows the helper producing a working wallet handle with a mock kit, and
+that both `network` and `isValidAddress` can be overridden:
+
+```sh
+npx vitest run contrib/examples/wallet-with-defaults
+```

--- a/contrib/examples/wallet-with-defaults/wallet-with-defaults.test.ts
+++ b/contrib/examples/wallet-with-defaults/wallet-with-defaults.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from "vitest";
+import { createWalletWithDefaults } from "./wallet-with-defaults";
+
+function mockKit() {
+  return {
+    async createWallet(_app: string, user: string) {
+      return { keyIdBase64: `keyid-${user}`, contractId: "CMOCK", signedTx: "mock-tx" };
+    },
+    async connectWallet() {
+      throw new Error("not used");
+    },
+    async sign(tx: unknown) {
+      return tx;
+    },
+  };
+}
+
+function mockBackend() {
+  return {
+    async submitWalletCreation() {
+      return { sessionId: "sess_1" };
+    },
+    async lookupContractId() {
+      return undefined;
+    },
+    async submitTransaction() {
+      return { hash: "tx_1" };
+    },
+  };
+}
+
+const mockSac = { getSACClient: () => ({ transfer: async () => "mock-tx" }) };
+
+describe("createWalletWithDefaults", () => {
+  it("produces a working wallet handle with just kit, backend, and sac", async () => {
+    const wallet = createWalletWithDefaults({ kit: mockKit(), backend: mockBackend(), sac: mockSac });
+    const session = await wallet.create({ username: "Test User" });
+    expect(session.network).toBe("testnet");
+    expect(session.accountId).toBe("CMOCK");
+  });
+
+  it("allows overriding a default (network)", async () => {
+    const wallet = createWalletWithDefaults({
+      kit: mockKit(),
+      backend: mockBackend(),
+      sac: mockSac,
+      network: "mainnet",
+    });
+    const session = await wallet.create({ username: "Test User" });
+    expect(session.network).toBe("mainnet");
+  });
+
+  it("allows overriding the default isValidAddress", async () => {
+    const wallet = createWalletWithDefaults({
+      kit: mockKit(),
+      backend: mockBackend(),
+      sac: mockSac,
+      isValidAddress: () => false, // reject every address, including well-formed ones
+    });
+    await wallet.create({ username: "Test User" });
+
+    // The default isValidAddress would accept a well-formed classic address;
+    // the override rejects everything, so preparePayment must fail here —
+    // proving the override, not the default, is what's actually wired in.
+    await expect(
+      wallet.pay({
+        to: "GBRPYHIL2CI3FNQ4BXLFMNDLFJUNPU2HY3ZMFSHONUCEOASW7QC7OX2H",
+        amount: 100n,
+        token: { symbol: "XLM", contractId: "CNATIVE", decimals: 7 },
+      }),
+    ).rejects.toThrow(/not a valid Stellar address/);
+  });
+});

--- a/contrib/examples/wallet-with-defaults/wallet-with-defaults.ts
+++ b/contrib/examples/wallet-with-defaults/wallet-with-defaults.ts
@@ -1,0 +1,78 @@
+// Example: wrap createVellarWallet with sane testnet defaults, so callers
+// only need to supply a kit and a backend. Any default may still be
+// overridden.
+//
+// Run with: npx tsx wallet-with-defaults.ts
+
+import { StrKey } from "@stellar/stellar-sdk";
+import { createVellarWallet, type VellarWallet, type VellarWalletConfig } from "../../../src/index";
+
+/**
+ * The subset of VellarWalletConfig a caller must always supply — the rest
+ * gets sane testnet defaults below.
+ *
+ * `sac` is required, not defaulted: there is no safe stand-in for the real
+ * SAC client — a stub that throws breaks payments unexpectedly, and a stub
+ * that succeeds silently would fake a payment working. Both are worse than
+ * asking the caller for it explicitly.
+ */
+export type MinimalWalletConfig = Pick<VellarWalletConfig, "kit" | "backend" | "sac"> &
+  Partial<Omit<VellarWalletConfig, "kit" | "backend" | "sac">>;
+
+function defaultIsValidAddress(address: string): boolean {
+  return StrKey.isValidEd25519PublicKey(address) || StrKey.isValidContract(address);
+}
+
+/**
+ * createVellarWallet with defaults filled in: network="testnet",
+ * appName="vellar-example", and an isValidAddress that accepts both
+ * classic (G...) and contract (C...) addresses. Every default can still be
+ * overridden by passing it explicitly.
+ */
+export function createWalletWithDefaults(config: MinimalWalletConfig): VellarWallet {
+  return createVellarWallet({
+    network: "testnet",
+    appName: "vellar-example",
+    isValidAddress: defaultIsValidAddress,
+    ...config,
+  });
+}
+
+async function main() {
+  const wallet = createWalletWithDefaults({
+    kit: {
+      async createWallet(_app, user) {
+        return {
+          keyIdBase64: `mock-keyid-${user.toLowerCase().replace(/\s+/g, "-")}`,
+          contractId: "CMOCKWALLETWITHDEFAULTSCONTRACTXXXXXXXXXXXXXXXXXXXXXXXXX",
+          signedTx: "mock-signed-deployment-tx",
+        };
+      },
+      async connectWallet() {
+        throw new Error("mock kit: connectWallet is not used by this example");
+      },
+      async sign(tx) {
+        return tx;
+      },
+    },
+    backend: {
+      async submitWalletCreation() {
+        return { sessionId: "mock-session-id" };
+      },
+      async lookupContractId() {
+        return undefined;
+      },
+      async submitTransaction() {
+        return { hash: "mock-tx-hash" };
+      },
+    },
+    sac: { getSACClient: () => ({ transfer: async () => "mock-tx" }) },
+  });
+
+  const session = await wallet.create({ username: "Defaults Example User" });
+  console.log("Created wallet with defaults; session:", session);
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main();
+}


### PR DESCRIPTION
## Summary
Four standalone examples under contrib/examples/, covering a SEP-41 token balance read, a createVellarWallet defaults wrapper, a transaction-history table formatter, and an in-memory address book.

closes #12
closes #41
closes #50
closes #70

## Changes
- **#12 — read-token-balance**: CLI script reading a SEP-41 token balance via the SDK's RPC-backed reader (`vellar-sdk/rpc`), printing the raw base-unit balance without assuming any particular decimals. Reader is injected so the logic is unit-testable without a live RPC call.
- **#41 — wallet-with-defaults**: `createWalletWithDefaults()` wraps `createVellarWallet` with sane testnet defaults (`network`, `appName`, `isValidAddress`), requiring only `kit`/`backend`/`sac`. `sac` is deliberately **not** defaulted — no safe stand-in exists (a throwing stub breaks payments unexpectedly, a silent one fakes them working). Every default remains overridable, proven in tests by overriding both `network` and `isValidAddress`.
- **#50 — tx-history-table**: `formatTxHistoryTable()` renders transactions as an aligned text table (hash/amount/timestamp), printing a clear `"No transactions."` message for an empty array instead of a headerless table.
- **#70 — address-book**: `AddressBook` maps friendly names to Stellar addresses with `add`/`lookup`/`remove`. A duplicate `add` throws `DuplicateNameError`; an unknown `lookup` returns `undefined` rather than throwing.

## Test plan
- Each example has a colocated `*.test.ts` (vitest) — 15 new tests, all passing.
- Ran every script directly (`npx tsx ...`) and confirmed output matches each README exactly.
- `npm run typecheck`, `npm test` (281/281 passing on top of `drips`), and `npm run build` all clean on top of this branch.
- All changes are confined to `contrib/examples/`; verified `git status` shows no files touched outside `contrib/`.