### PR TITLE
feat(examples): passphrase validation, policy migration, multi-signer, and session-key dashboard examples

### DIFF
--- a/contrib/examples/multi-signer-approval-demo/README.md
+++ b/contrib/examples/multi-signer-approval-demo/README.md
@@ -1,0 +1,39 @@
+# Multi-signer approval demo
+
+Several mock signers each approve a sample transaction until a configured
+threshold is met, at which point it's marked ready. Approvals are
+deduplicated by signer id — a signer approving twice only counts once
+toward the threshold.
+
+## The flow
+
+1. Construct `new MultiSignerApproval(threshold)`.
+2. Each signer calls `approve(signerId)` independently and in any order.
+3. `approvalCount` reports the number of **distinct** signers who've
+   approved; `isReady` becomes `true` once that count reaches the threshold.
+
+## Run it
+
+```sh
+npx tsx multi-signer-approval-demo.ts
+```
+
+Expected output (threshold 2, `signer-alice` approves twice, then
+`signer-bob` approves once — reaching threshold on the second *distinct*
+signer, not the third call):
+
+```
+Threshold: 2 of 3 signers
+signer-alice approves...
+  approvals: 1, ready: false
+signer-alice approves again (should not double-count)...
+  approvals: 1, ready: false
+signer-bob approves...
+  approvals: 2, ready: true
+```
+
+## Tests
+
+```sh
+npx vitest run contrib/examples/multi-signer-approval-demo
+```

--- a/contrib/examples/multi-signer-approval-demo/multi-signer-approval-demo.test.ts
+++ b/contrib/examples/multi-signer-approval-demo/multi-signer-approval-demo.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+import { MultiSignerApproval } from "./multi-signer-approval-demo";
+
+describe("MultiSignerApproval", () => {
+  it("is not ready before the threshold is reached", () => {
+    const approval = new MultiSignerApproval(3);
+    approval.approve("alice");
+    approval.approve("bob");
+    expect(approval.approvalCount).toBe(2);
+    expect(approval.isReady).toBe(false);
+  });
+
+  it("becomes ready once distinct approvals reach the threshold", () => {
+    const approval = new MultiSignerApproval(3);
+    approval.approve("alice");
+    approval.approve("bob");
+    approval.approve("carol");
+    expect(approval.approvalCount).toBe(3);
+    expect(approval.isReady).toBe(true);
+  });
+
+  it("a signer approving twice only counts once", () => {
+    const approval = new MultiSignerApproval(2);
+    approval.approve("alice");
+    approval.approve("alice");
+    approval.approve("alice");
+    expect(approval.approvalCount).toBe(1);
+    expect(approval.isReady).toBe(false);
+
+    approval.approve("bob");
+    expect(approval.approvalCount).toBe(2);
+    expect(approval.isReady).toBe(true);
+  });
+
+  it("rejects a non-positive threshold", () => {
+    expect(() => new MultiSignerApproval(0)).toThrow(RangeError);
+    expect(() => new MultiSignerApproval(-1)).toThrow(RangeError);
+  });
+});

--- a/contrib/examples/multi-signer-approval-demo/multi-signer-approval-demo.ts
+++ b/contrib/examples/multi-signer-approval-demo/multi-signer-approval-demo.ts
@@ -1,0 +1,56 @@
+// Example: several mock signers each approve a sample transaction until a
+// configured threshold is met, then it's marked ready. A signer approving
+// twice only counts once toward the threshold — approvals are deduplicated
+// by signer id.
+//
+// Run with: npx tsx multi-signer-approval-demo.ts
+
+export class MultiSignerApproval {
+  #threshold: number;
+  #approvals = new Set<string>();
+
+  constructor(threshold: number) {
+    if (threshold <= 0) {
+      throw new RangeError(`threshold must be a positive number, got ${threshold}`);
+    }
+    this.#threshold = threshold;
+  }
+
+  /** Records an approval from `signerId`. A repeat approval from the same
+   * signer is a no-op — it does not count twice toward the threshold. */
+  approve(signerId: string): void {
+    this.#approvals.add(signerId);
+  }
+
+  get approvalCount(): number {
+    return this.#approvals.size;
+  }
+
+  /** True once distinct approvals reach (or exceed) the threshold. */
+  get isReady(): boolean {
+    return this.#approvals.size >= this.#threshold;
+  }
+}
+
+function main() {
+  const approval = new MultiSignerApproval(2);
+  const signers = ["signer-alice", "signer-bob", "signer-carol"];
+
+  console.log(`Threshold: 2 of ${signers.length} signers`);
+
+  console.log(`${signers[0]} approves...`);
+  approval.approve(signers[0]!);
+  console.log(`  approvals: ${approval.approvalCount}, ready: ${approval.isReady}`);
+
+  console.log(`${signers[0]} approves again (should not double-count)...`);
+  approval.approve(signers[0]!);
+  console.log(`  approvals: ${approval.approvalCount}, ready: ${approval.isReady}`);
+
+  console.log(`${signers[1]} approves...`);
+  approval.approve(signers[1]!);
+  console.log(`  approvals: ${approval.approvalCount}, ready: ${approval.isReady}`);
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main();
+}

--- a/contrib/examples/policy-migration-dry-run/README.md
+++ b/contrib/examples/policy-migration-dry-run/README.md
@@ -1,0 +1,47 @@
+# Policy migration dry run
+
+Previews what an old-style (pre-v1) policy configuration would look like
+migrated to the current `PolicyDefinition` shape (`src/types.ts`), **without
+applying anything**. Reports any old fields that have no equivalent in the
+new shape, so a caller can decide what to do with them before migrating for
+real.
+
+## Field mapping
+
+| Old field | New field | Notes |
+| --- | --- | --- |
+| `policyOwner` (single string) | `owners` (`string[]`) | Wrapped in a single-element array — the new shape supports multiple owners, the old one didn't. |
+| `dailyLimit` | `spendingLimits.dailyXlm` | |
+| `perTxLimit` | `spendingLimits.perTxXlm` | |
+| `allowedContracts` | `allowlistedContracts` | |
+| `adminDelaySeconds` | `timelocks.adminActionDelaySeconds` | |
+| `legacyFlag` | *(none)* | Every policy is now versioned by its deployed contract wasm hash instead. Dropped. |
+| `notes` | *(none)* | Free-text notes had no structured home in the old shape either. Dropped. |
+
+## Run it
+
+```sh
+npx tsx policy-migration-dry-run.ts
+```
+
+Expected output (against the sample old config with all fields, including
+the two unmapped ones):
+
+```
+Migration preview: {
+  version: '1',
+  type: 'spending-limit',
+  owners: [ 'GOWNERAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF' ],
+  spendingLimits: { dailyXlm: '100', perTxXlm: '20' },
+  allowlistedContracts: [ 'CUSDCAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA' ],
+  timelocks: { adminActionDelaySeconds: 3600 }
+}
+
+Unmapped fields (dropped, no equivalent in the new shape): [ 'legacyFlag', 'notes' ]
+```
+
+## Tests
+
+```sh
+npx vitest run contrib/examples/policy-migration-dry-run
+```

--- a/contrib/examples/policy-migration-dry-run/policy-migration-dry-run.test.ts
+++ b/contrib/examples/policy-migration-dry-run/policy-migration-dry-run.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+import { previewMigration } from "./policy-migration-dry-run";
+
+describe("previewMigration", () => {
+  it("wraps policyOwner in the owners array", () => {
+    const { preview } = previewMigration({ policyOwner: "GOWNER" });
+    expect(preview.owners).toEqual(["GOWNER"]);
+    expect(preview.version).toBe("1");
+    expect(preview.type).toBe("spending-limit");
+  });
+
+  it("maps dailyLimit/perTxLimit into spendingLimits", () => {
+    const { preview } = previewMigration({ policyOwner: "GOWNER", dailyLimit: "100", perTxLimit: "20" });
+    expect(preview.spendingLimits).toEqual({ dailyXlm: "100", perTxXlm: "20" });
+  });
+
+  it("maps allowedContracts into allowlistedContracts", () => {
+    const { preview } = previewMigration({ policyOwner: "GOWNER", allowedContracts: ["CUSDC"] });
+    expect(preview.allowlistedContracts).toEqual(["CUSDC"]);
+  });
+
+  it("maps adminDelaySeconds into timelocks", () => {
+    const { preview } = previewMigration({ policyOwner: "GOWNER", adminDelaySeconds: 3600 });
+    expect(preview.timelocks).toEqual({ adminActionDelaySeconds: 3600 });
+  });
+
+  it("reports fields with no equivalent in the new shape", () => {
+    const { unmappedFields } = previewMigration({
+      policyOwner: "GOWNER",
+      legacyFlag: true,
+      notes: "some notes",
+    });
+    expect(unmappedFields).toEqual(["legacyFlag", "notes"]);
+  });
+
+  it("reports no unmapped fields when only mapped fields are present", () => {
+    const { unmappedFields } = previewMigration({ policyOwner: "GOWNER", dailyLimit: "100" });
+    expect(unmappedFields).toEqual([]);
+  });
+
+  it("omits spendingLimits/allowlistedContracts/timelocks entirely when the old config lacks them", () => {
+    const { preview } = previewMigration({ policyOwner: "GOWNER" });
+    expect(preview.spendingLimits).toBeUndefined();
+    expect(preview.allowlistedContracts).toBeUndefined();
+    expect(preview.timelocks).toBeUndefined();
+  });
+});

--- a/contrib/examples/policy-migration-dry-run/policy-migration-dry-run.ts
+++ b/contrib/examples/policy-migration-dry-run/policy-migration-dry-run.ts
@@ -1,0 +1,93 @@
+// Example: preview what an old-style (pre-v1) policy configuration would
+// look like migrated to the current PolicyDefinition shape (src/types.ts),
+// without applying anything. Reports any old fields that have no
+// equivalent in the new shape, so a caller can decide what to do with them
+// before actually migrating.
+//
+// Field mapping (documented — see the README for the full table):
+//   policyOwner (string)     -> owners (string[], wrapped in an array)
+//   dailyLimit                -> spendingLimits.dailyXlm
+//   perTxLimit                -> spendingLimits.perTxXlm
+//   allowedContracts           -> allowlistedContracts
+//   adminDelaySeconds          -> timelocks.adminActionDelaySeconds
+//   legacyFlag, notes          -> no equivalent (reported as unmapped)
+//
+// Run with: npx tsx policy-migration-dry-run.ts
+
+import type { PolicyDefinition } from "../../../src/types";
+
+export interface OldPolicyConfig {
+  policyOwner: string;
+  dailyLimit?: string;
+  perTxLimit?: string;
+  allowedContracts?: string[];
+  adminDelaySeconds?: number;
+  /** No longer meaningful — every policy is versioned by contract wasm now. */
+  legacyFlag?: boolean;
+  /** Free-text notes had no structured home in the old shape either; still none in the new one. */
+  notes?: string;
+}
+
+export interface MigrationPreview {
+  preview: PolicyDefinition;
+  unmappedFields: string[];
+}
+
+const MAPPED_OLD_FIELDS = new Set([
+  "policyOwner",
+  "dailyLimit",
+  "perTxLimit",
+  "allowedContracts",
+  "adminDelaySeconds",
+]);
+
+/** Builds a preview of the migrated PolicyDefinition, plus a list of old
+ * fields that had no equivalent and were dropped. Does not mutate or
+ * persist anything — purely a dry-run preview. */
+export function previewMigration(old: OldPolicyConfig): MigrationPreview {
+  const preview: PolicyDefinition = {
+    version: "1",
+    type: "spending-limit",
+    owners: [old.policyOwner],
+  };
+
+  if (old.dailyLimit !== undefined || old.perTxLimit !== undefined) {
+    preview.spendingLimits = {
+      ...(old.dailyLimit !== undefined && { dailyXlm: old.dailyLimit }),
+      ...(old.perTxLimit !== undefined && { perTxXlm: old.perTxLimit }),
+    };
+  }
+  if (old.allowedContracts !== undefined) {
+    preview.allowlistedContracts = old.allowedContracts;
+  }
+  if (old.adminDelaySeconds !== undefined) {
+    preview.timelocks = { adminActionDelaySeconds: old.adminDelaySeconds };
+  }
+
+  const unmappedFields = Object.entries(old)
+    .filter(([key, value]) => !MAPPED_OLD_FIELDS.has(key) && value !== undefined)
+    .map(([key]) => key);
+
+  return { preview, unmappedFields };
+}
+
+function main() {
+  const sampleOldConfig: OldPolicyConfig = {
+    policyOwner: "GOWNERAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF",
+    dailyLimit: "100",
+    perTxLimit: "20",
+    allowedContracts: ["CUSDCAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"],
+    adminDelaySeconds: 3600,
+    legacyFlag: true,
+    notes: "Migrated from the v0 policy service",
+  };
+
+  const { preview, unmappedFields } = previewMigration(sampleOldConfig);
+  console.log("Migration preview:", preview);
+  console.log();
+  console.log("Unmapped fields (dropped, no equivalent in the new shape):", unmappedFields);
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main();
+}

--- a/contrib/examples/session-key-dashboard-source/README.md
+++ b/contrib/examples/session-key-dashboard-source/README.md
@@ -1,0 +1,35 @@
+# Session key expiry dashboard source
+
+A data source function, `buildSessionKeyDashboard()`, that lists several
+mock session keys with a computed expiry status — `active`,
+`expiring_soon`, or `expired` — suitable for feeding a dashboard UI.
+
+## Status shape
+
+Given a simulated "now" (defaults to the real current time, but the demo
+and tests pass a fixed one for reproducibility):
+
+- **`expired`** — expiry is at or before now.
+- **`expiring_soon`** — expiry is within the next 24 hours.
+- **`active`** — expiry is more than 24 hours out.
+
+## Run it
+
+```sh
+npx tsx session-key-dashboard-source.ts
+```
+
+Expected output (three sample keys, one in each state, against a fixed
+`now` of `2026-06-15T12:00:00.000Z`):
+
+```
+sk_active (CACTIVE): active — expires 2026-07-01T00:00:00.000Z
+sk_expiring_soon (CEXPIRINGSOON): expiring_soon — expires 2026-06-15T20:00:00.000Z
+sk_expired (CEXPIRED): expired — expires 2026-06-01T00:00:00.000Z
+```
+
+## Tests
+
+```sh
+npx vitest run contrib/examples/session-key-dashboard-source
+```

--- a/contrib/examples/session-key-dashboard-source/session-key-dashboard-source.test.ts
+++ b/contrib/examples/session-key-dashboard-source/session-key-dashboard-source.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+import { buildSessionKeyDashboard, type SessionKeyRecord } from "./session-key-dashboard-source";
+
+describe("buildSessionKeyDashboard", () => {
+  const now = new Date("2026-06-15T12:00:00.000Z");
+
+  it("marks a key expiring more than 24h out as active", () => {
+    const keys: SessionKeyRecord[] = [{ keyId: "k1", address: "C1", expiresAt: "2026-07-01T00:00:00.000Z" }];
+    expect(buildSessionKeyDashboard(keys, now)[0]!.status).toBe("active");
+  });
+
+  it("marks a key expiring within 24h as expiring_soon", () => {
+    const keys: SessionKeyRecord[] = [{ keyId: "k2", address: "C2", expiresAt: "2026-06-15T20:00:00.000Z" }];
+    expect(buildSessionKeyDashboard(keys, now)[0]!.status).toBe("expiring_soon");
+  });
+
+  it("marks a key already past its expiry as expired", () => {
+    const keys: SessionKeyRecord[] = [{ keyId: "k3", address: "C3", expiresAt: "2026-06-01T00:00:00.000Z" }];
+    expect(buildSessionKeyDashboard(keys, now)[0]!.status).toBe("expired");
+  });
+
+  it("treats an expiry exactly at now as expired (inclusive boundary)", () => {
+    const keys: SessionKeyRecord[] = [{ keyId: "k4", address: "C4", expiresAt: now.toISOString() }];
+    expect(buildSessionKeyDashboard(keys, now)[0]!.status).toBe("expired");
+  });
+
+  it("preserves keyId and address alongside the computed status", () => {
+    const keys: SessionKeyRecord[] = [{ keyId: "k5", address: "C5", expiresAt: "2026-07-01T00:00:00.000Z" }];
+    expect(buildSessionKeyDashboard(keys, now)[0]).toEqual({
+      keyId: "k5",
+      address: "C5",
+      expiresAt: "2026-07-01T00:00:00.000Z",
+      status: "active",
+    });
+  });
+
+  it("processes multiple keys independently", () => {
+    const keys: SessionKeyRecord[] = [
+      { keyId: "active", address: "C1", expiresAt: "2026-07-01T00:00:00.000Z" },
+      { keyId: "expired", address: "C2", expiresAt: "2026-06-01T00:00:00.000Z" },
+    ];
+    const dashboard = buildSessionKeyDashboard(keys, now);
+    expect(dashboard.map((e) => e.status)).toEqual(["active", "expired"]);
+  });
+});

--- a/contrib/examples/session-key-dashboard-source/session-key-dashboard-source.ts
+++ b/contrib/examples/session-key-dashboard-source/session-key-dashboard-source.ts
@@ -1,0 +1,56 @@
+// Example: a data source function listing several mock session keys with
+// their expiry status, suitable for feeding a dashboard UI.
+//
+// Run with: npx tsx session-key-dashboard-source.ts
+
+export type ExpiryStatus = "active" | "expiring_soon" | "expired";
+
+export interface SessionKeyRecord {
+  keyId: string;
+  address: string;
+  expiresAt: string;
+}
+
+export interface SessionKeyDashboardEntry extends SessionKeyRecord {
+  status: ExpiryStatus;
+}
+
+// A key within this window of expiry (but not yet expired) is "expiring
+// soon" — enough lead time for a dashboard to flag it before it lapses.
+const EXPIRING_SOON_WINDOW_MS = 24 * 60 * 60 * 1000; // 24h
+
+function statusFor(expiresAt: string, now: Date): ExpiryStatus {
+  const msUntilExpiry = new Date(expiresAt).getTime() - now.getTime();
+  if (msUntilExpiry <= 0) return "expired";
+  if (msUntilExpiry <= EXPIRING_SOON_WINDOW_MS) return "expiring_soon";
+  return "active";
+}
+
+/** Builds dashboard-ready entries from raw session key records, given a
+ * simulated "now" (defaults to the real current time). */
+export function buildSessionKeyDashboard(
+  keys: SessionKeyRecord[],
+  now: Date = new Date(),
+): SessionKeyDashboardEntry[] {
+  return keys.map((key) => ({ ...key, status: statusFor(key.expiresAt, now) }));
+}
+
+function main() {
+  // A fixed "now" so the example's output is reproducible.
+  const now = new Date("2026-06-15T12:00:00.000Z");
+
+  const sampleKeys: SessionKeyRecord[] = [
+    { keyId: "sk_active", address: "CACTIVE", expiresAt: "2026-07-01T00:00:00.000Z" }, // ~16 days out
+    { keyId: "sk_expiring_soon", address: "CEXPIRINGSOON", expiresAt: "2026-06-15T20:00:00.000Z" }, // 8h out
+    { keyId: "sk_expired", address: "CEXPIRED", expiresAt: "2026-06-01T00:00:00.000Z" }, // in the past
+  ];
+
+  const dashboard = buildSessionKeyDashboard(sampleKeys, now);
+  for (const entry of dashboard) {
+    console.log(`${entry.keyId} (${entry.address}): ${entry.status} — expires ${entry.expiresAt}`);
+  }
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main();
+}

--- a/contrib/examples/validate-passphrase/README.md
+++ b/contrib/examples/validate-passphrase/README.md
@@ -1,0 +1,36 @@
+# Validate a network passphrase
+
+Checks a given network passphrase string against `vellar-sdk`'s known
+`TESTNET`/`MAINNET` passphrases (`src/config.ts`), returning which network
+it matches, or `null` if unknown.
+
+**The comparison is exact and case-sensitive** — a passphrase that differs
+only by casing, or has extra surrounding whitespace, does **not** match and
+returns `null`. This is deliberate: a network passphrase feeds directly into
+transaction signing, so a "close enough" match would be a correctness bug
+(e.g. Stellar's SDK computes different signatures for a passphrase that
+differs even by a single character), not a convenience worth adding.
+
+## Run it
+
+```sh
+npx tsx validate-passphrase.ts
+```
+
+Expected output:
+
+```
+"Test SDF Network ; September 2015" -> testnet
+"Public Global Stellar Network ; September 2015" -> mainnet
+"Not a real passphrase" -> unknown
+"test sdf network ; september 2015" -> unknown
+```
+
+## Tests
+
+Covers the testnet passphrase, the mainnet passphrase, and an unknown
+string:
+
+```sh
+npx vitest run contrib/examples/validate-passphrase
+```

--- a/contrib/examples/validate-passphrase/validate-passphrase.test.ts
+++ b/contrib/examples/validate-passphrase/validate-passphrase.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+import { MAINNET, TESTNET } from "../../../src/config";
+import { matchNetworkPassphrase } from "./validate-passphrase";
+
+describe("matchNetworkPassphrase", () => {
+  it("matches the testnet passphrase", () => {
+    expect(matchNetworkPassphrase(TESTNET.networkPassphrase)).toBe("testnet");
+  });
+
+  it("matches the mainnet passphrase", () => {
+    expect(matchNetworkPassphrase(MAINNET.networkPassphrase)).toBe("mainnet");
+  });
+
+  it("returns null for an unknown string", () => {
+    expect(matchNetworkPassphrase("Not a real passphrase")).toBeNull();
+  });
+
+  it("is case-sensitive — a different-case match returns null", () => {
+    expect(matchNetworkPassphrase(TESTNET.networkPassphrase.toLowerCase())).toBeNull();
+  });
+
+  it("does not trim — surrounding whitespace returns null", () => {
+    expect(matchNetworkPassphrase(` ${TESTNET.networkPassphrase} `)).toBeNull();
+  });
+});

--- a/contrib/examples/validate-passphrase/validate-passphrase.ts
+++ b/contrib/examples/validate-passphrase/validate-passphrase.ts
@@ -1,0 +1,36 @@
+// Example: check a given network passphrase string against the known
+// testnet/mainnet passphrases, returning which network it matches (or null
+// if unknown). Comparison is case-sensitive and exact — a passphrase with
+// different casing or extra whitespace does NOT match.
+//
+// Run with: npx tsx validate-passphrase.ts
+
+import { MAINNET, TESTNET } from "../../../src/config";
+
+export type NetworkMatch = "testnet" | "mainnet" | null;
+
+/** Exact, case-sensitive match against TESTNET/MAINNET.networkPassphrase.
+ * Returns null for anything else, including a passphrase that only differs
+ * by case or surrounding whitespace. */
+export function matchNetworkPassphrase(passphrase: string): NetworkMatch {
+  if (passphrase === TESTNET.networkPassphrase) return "testnet";
+  if (passphrase === MAINNET.networkPassphrase) return "mainnet";
+  return null;
+}
+
+function main() {
+  const examples = [
+    TESTNET.networkPassphrase,
+    MAINNET.networkPassphrase,
+    "Not a real passphrase",
+    TESTNET.networkPassphrase.toLowerCase(), // wrong case — does not match
+  ];
+
+  for (const passphrase of examples) {
+    console.log(`"${passphrase}" -> ${matchNetworkPassphrase(passphrase) ?? "unknown"}`);
+  }
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main();
+}


### PR DESCRIPTION
## Summary
Four standalone examples under contrib/examples/, covering network-passphrase validation and three reference examples: a policy migration dry run, a multi-signer approval demo, and a session-key expiry dashboard source.

closes #124
closes #127
closes #128
closes #129

## Changes
- **#124 — validate-passphrase**: `matchNetworkPassphrase()` checks a passphrase against `TESTNET`/`MAINNET` exactly and case-sensitively, returning which network it matches or `null`. A near-miss (wrong case, extra whitespace) deliberately does not match — a passphrase feeds directly into signing.
- **#127 — policy-migration-dry-run**: `previewMigration()` maps an old-style policy config to the current `PolicyDefinition` shape without applying anything, and reports old fields with no new-shape equivalent. Full field mapping documented in the README.
- **#128 — multi-signer-approval-demo**: `MultiSignerApproval` tracks distinct signer approvals in a `Set`, becoming ready once the count reaches the configured threshold. A signer approving twice is deduplicated and does not double-count.
- **#129 — session-key-dashboard-source**: `buildSessionKeyDashboard()` computes `active`/`expiring_soon`/`expired` status for a list of session keys against a simulated "now", with a 24h expiring-soon window. Inclusive expiry boundary (exactly-now counts as expired).

## Test plan
- Each example has a colocated `*.test.ts` (vitest) — 22 new tests, all passing.
- Ran every script directly (`npx tsx ...`) and confirmed output matches each README exactly.
- Caught and fixed one real type error during verification (an unsound `as Record<string, unknown>` cast in `policy-migration-dry-run.ts`) before it ever got committed.
- `npm run typecheck`, `npm test` (288/288 passing on top of `drips`), and `npm run build` all clean on top of this branch.
- All changes are confined to `contrib/examples/`; verified `git status` shows no files touched outside `contrib/`.