### PR TITLE
feat(contrib): mock full backend, passkey ceremony, x402 budget tracker, tx history sync worker

### DIFF
--- a/contrib/examples/mock-full-backend/README.md
+++ b/contrib/examples/mock-full-backend/README.md
@@ -1,0 +1,51 @@
+# Mock end-to-end wallet backend
+
+A fully in-memory `WalletBackend` — `submitWalletCreation`, `lookupContractId`,
+and `submitTransaction` — backed by an append-only ledger of submitted
+transactions queryable by hash. Wired into a real `createVellarWallet` handle
+(with equally minimal mock `kit`/`sac`) to demonstrate a complete
+create-then-pay sequence with no WebAuthn prompt, RPC call, or relayer.
+
+## Usage
+
+```ts
+import { createMockVellarWallet } from "./mock-full-backend";
+
+const { wallet, backend } = createMockVellarWallet("testnet");
+const session = await wallet.create();
+const { hash } = await wallet.pay({ to: "G...", amount: 100_0000000n, token });
+
+backend.getTransaction(hash); // { hash, signedXdr, network, submittedAt }
+backend.listTransactions();   // every submission so far, oldest first
+```
+
+`createMockWalletBackend()` on its own gives you just the backend, if you
+want to wire it into your own kit/sac instead of the ones this example
+provides.
+
+## Run it
+
+```sh
+npx tsx mock-full-backend.ts
+```
+
+Expected output (hashes vary only in their counter suffix):
+
+```
+Step 1: create the wallet
+  session.accountId = CMOCKSMARTACCOUNTXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+Step 2: send a payment
+  submitted, hash = mocktxhash100000
+Step 3: send a second payment
+  submitted, hash = mocktxhash200000
+Step 4: query the ledger by hash
+  getTransaction(first.hash) -> {"hash":"mocktxhash100000","signedXdr":"signed:unsigned-transfer-tx:CUSDCMOCK","network":"testnet","submittedAt":"..."}
+Step 5: list every submitted transaction
+  listTransactions() has 2 entries
+```
+
+## Tests
+
+```sh
+npx vitest run contrib/examples/mock-full-backend
+```

--- a/contrib/examples/mock-full-backend/mock-full-backend.test.ts
+++ b/contrib/examples/mock-full-backend/mock-full-backend.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "vitest";
+import { createMockVellarWallet, createMockWalletBackend } from "./mock-full-backend";
+
+const token = { symbol: "USDC", contractId: "CUSDCMOCK", decimals: 7 };
+
+describe("createMockWalletBackend", () => {
+  it("returns undefined for a hash that was never submitted", () => {
+    const backend = createMockWalletBackend();
+    expect(backend.getTransaction("nope")).toBeUndefined();
+  });
+
+  it("records a submitted transaction, queryable by its returned hash", async () => {
+    const backend = createMockWalletBackend();
+    const { hash } = await backend.submitTransaction({ signedXdr: "xdr-1", network: "testnet" });
+
+    const entry = backend.getTransaction(hash);
+    expect(entry).toBeDefined();
+    expect(entry?.signedXdr).toBe("xdr-1");
+    expect(entry?.network).toBe("testnet");
+  });
+
+  it("gives every submission a distinct hash", async () => {
+    const backend = createMockWalletBackend();
+    const a = await backend.submitTransaction({ signedXdr: "xdr-a", network: "testnet" });
+    const b = await backend.submitTransaction({ signedXdr: "xdr-b", network: "testnet" });
+    expect(a.hash).not.toBe(b.hash);
+  });
+
+  it("lists transactions oldest first", async () => {
+    const backend = createMockWalletBackend();
+    await backend.submitTransaction({ signedXdr: "xdr-1", network: "testnet" });
+    await backend.submitTransaction({ signedXdr: "xdr-2", network: "testnet" });
+
+    const list = backend.listTransactions();
+    expect(list).toHaveLength(2);
+    expect(list[0]?.signedXdr).toBe("xdr-1");
+    expect(list[1]?.signedXdr).toBe("xdr-2");
+  });
+});
+
+describe("createMockVellarWallet — full create then pay sequence", () => {
+  it("creates a wallet and completes a payment, recorded in the backend's ledger", async () => {
+    const { wallet, backend } = createMockVellarWallet("testnet");
+
+    const session = await wallet.create({ username: "demo-user" });
+    expect(session.accountId).toBeTruthy();
+    expect(session.connected).toBe(true);
+
+    const result = await wallet.pay({ to: "GRECIPIENTXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX", amount: 1_0000000n, token });
+
+    expect(backend.getTransaction(result.hash)).toBeDefined();
+    expect(backend.listTransactions()).toHaveLength(1);
+  });
+
+  it("accumulates multiple payments in the ledger across the same session", async () => {
+    const { wallet, backend } = createMockVellarWallet("testnet");
+    await wallet.create();
+
+    await wallet.pay({ to: "GRECIPIENT1XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX", amount: 1_0000000n, token });
+    await wallet.pay({ to: "GRECIPIENT2XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX", amount: 2_0000000n, token });
+
+    expect(backend.listTransactions()).toHaveLength(2);
+  });
+});

--- a/contrib/examples/mock-full-backend/mock-full-backend.ts
+++ b/contrib/examples/mock-full-backend/mock-full-backend.ts
@@ -1,0 +1,137 @@
+// Example: a mock end-to-end WalletBackend — create, connect, and
+// submitTransaction — backed by an in-memory ledger of submitted
+// transactions queryable by hash, wired into a real createVellarWallet for
+// a full create-then-pay sequence with no live network call.
+//
+// Run with: npx tsx mock-full-backend.ts
+
+import { createVellarWallet, type VellarWallet } from "../../../src/client";
+import type { PasskeyKitLike, WalletBackend } from "../../../src/passkeykit-connector";
+import type { SacClientLike, TokenContractClientLike } from "../../../src/payments-client";
+import type { Network } from "../../../src/types";
+import type { TokenInfo } from "../../../src/balances";
+
+export interface LedgerEntry {
+  hash: string;
+  signedXdr: string;
+  network: Network;
+  submittedAt: string;
+}
+
+export interface MockWalletBackend extends WalletBackend {
+  submitTransaction(input: { signedXdr: string; network: Network }): Promise<{ hash: string }>;
+  /** Looks up a previously submitted transaction by the hash returned from
+   * submitTransaction. Undefined if no such hash was ever submitted. */
+  getTransaction(hash: string): LedgerEntry | undefined;
+  /** Every transaction submitted so far, oldest first. */
+  listTransactions(): LedgerEntry[];
+}
+
+/**
+ * Builds a fully in-memory WalletBackend: wallet creation always succeeds
+ * with a fresh session id, and every submitted transaction is recorded in
+ * an append-only ledger, queryable by its hash. No network I/O.
+ */
+export function createMockWalletBackend(): MockWalletBackend {
+  const ledger: LedgerEntry[] = [];
+  let nextHash = 1;
+
+  return {
+    async submitWalletCreation(input) {
+      return { sessionId: `session-${input.keyId}` };
+    },
+    async lookupContractId() {
+      // This example only exercises the create flow, not reconnect; a
+      // reconnect-focused example would populate a keyId->contractId map here.
+      return undefined;
+    },
+    async submitTransaction(input) {
+      const hash = `mocktxhash${nextHash++}`.padEnd(16, "0");
+      ledger.push({ hash, signedXdr: input.signedXdr, network: input.network, submittedAt: new Date().toISOString() });
+      return { hash };
+    },
+    getTransaction(hash) {
+      return ledger.find((entry) => entry.hash === hash);
+    },
+    listTransactions() {
+      return [...ledger];
+    },
+  };
+}
+
+/** A minimal mock PasskeyKitLike + SacClientLike, just enough to complete a
+ * create-then-pay sequence against the mock backend above. */
+function createMockKitAndSac(): { kit: PasskeyKitLike; sac: SacClientLike } {
+  const kit: PasskeyKitLike = {
+    async createWallet(_app, _user) {
+      return {
+        keyIdBase64: "mock-key-id",
+        contractId: "CMOCKSMARTACCOUNTXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+        signedTx: "mock-create-tx",
+      };
+    },
+    async connectWallet() {
+      return { keyIdBase64: "mock-key-id", contractId: "CMOCKSMARTACCOUNTXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX" };
+    },
+    async sign(tx: unknown) {
+      return typeof tx === "string" ? `signed:${tx}` : "signed:mock-payment-tx";
+    },
+  };
+
+  const sac: SacClientLike = {
+    getSACClient(tokenContractId: string): TokenContractClientLike {
+      return {
+        async transfer() {
+          return `unsigned-transfer-tx:${tokenContractId}`;
+        },
+      };
+    },
+  };
+
+  return { kit, sac };
+}
+
+export function createMockVellarWallet(network: Network): { wallet: VellarWallet; backend: MockWalletBackend } {
+  const backend = createMockWalletBackend();
+  const { kit, sac } = createMockKitAndSac();
+
+  const wallet = createVellarWallet({
+    network,
+    appName: "mock-full-backend example",
+    kit,
+    backend,
+    sac,
+    isValidAddress: (address: string) => address.length > 0,
+  });
+
+  return { wallet, backend };
+}
+
+async function main() {
+  const log = (line: string) => console.log(line);
+  const { wallet, backend } = createMockVellarWallet("testnet");
+
+  log("Step 1: create the wallet");
+  const session = await wallet.create({ username: "demo-user" });
+  log(`  session.accountId = ${session.accountId}`);
+
+  const token: TokenInfo = { symbol: "USDC", contractId: "CUSDCMOCK", decimals: 7 };
+
+  log("Step 2: send a payment");
+  const first = await wallet.pay({ to: "GRECIPIENT1XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX", amount: 10_0000000n, token });
+  log(`  submitted, hash = ${first.hash}`);
+
+  log("Step 3: send a second payment");
+  const second = await wallet.pay({ to: "GRECIPIENT2XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX", amount: 5_0000000n, token });
+  log(`  submitted, hash = ${second.hash}`);
+
+  log("Step 4: query the ledger by hash");
+  log(`  getTransaction(first.hash) -> ${JSON.stringify(backend.getTransaction(first.hash))}`);
+
+  log("Step 5: list every submitted transaction");
+  log(`  listTransactions() has ${backend.listTransactions().length} entries`);
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main();
+}

--- a/contrib/examples/mock-passkey-ceremony/README.md
+++ b/contrib/examples/mock-passkey-ceremony/README.md
@@ -1,0 +1,56 @@
+# Mock passkey ceremony for CI
+
+A deterministic mock passkey registration + authentication ceremony —
+useful for wiring into a CI test suite that needs a stable "user has a
+passkey" scenario without a real browser or WebAuthn/authenticator support.
+
+## Flow
+
+1. `generateMockCredential(seed)` derives a `{ credentialId, publicKey }`
+   pair from `seed` using a small seeded PRNG (mulberry32). **The same seed
+   always produces the same credential** — no hidden randomness, no global
+   state, reproducible across processes and CI runs.
+2. `createMockAuthenticator()` wraps that generator with an in-memory
+   "authenticator": `register(seed)` derives and remembers a credential;
+   `authenticate(credentialId)` looks it up, throwing for an id that was
+   never registered — the same refusal a real authenticator gives for an
+   unknown credential.
+
+## Usage
+
+```ts
+import { createMockAuthenticator } from "./mock-passkey-ceremony";
+
+const authenticator = createMockAuthenticator();
+const { credential } = authenticator.register("alice-device");
+const { credential: authed } = authenticator.authenticate(credential.credentialId);
+// authed.credentialId === credential.credentialId
+```
+
+## Run it
+
+```sh
+npx tsx mock-passkey-ceremony.ts
+```
+
+Expected output (the two determinism-check lines are always identical to
+each other, though the exact hex values are fixed by the PRNG):
+
+```
+Determinism check: generateMockCredential('alice-device') called twice...
+  call 1: a638baa8f7332b207ac6e86a8bcb454c
+  call 2: a638baa8f7332b207ac6e86a8bcb454c
+  same credentialId both times: true
+
+Full register-then-authenticate sequence:
+  Step 1: register with seed 'alice-device'
+    registered credentialId = a638baa8f7332b207ac6e86a8bcb454c
+  Step 2: authenticate with that credentialId
+    authenticated at 2026-...-...T...Z, publicKey = ...
+```
+
+## Tests
+
+```sh
+npx vitest run contrib/examples/mock-passkey-ceremony
+```

--- a/contrib/examples/mock-passkey-ceremony/mock-passkey-ceremony.test.ts
+++ b/contrib/examples/mock-passkey-ceremony/mock-passkey-ceremony.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+import { createMockAuthenticator, generateMockCredential } from "./mock-passkey-ceremony";
+
+describe("generateMockCredential", () => {
+  it("produces the same credential for the same seed across two calls", () => {
+    const first = generateMockCredential("alice-device");
+    const second = generateMockCredential("alice-device");
+    expect(first).toEqual(second);
+  });
+
+  it("produces different credentials for different seeds", () => {
+    const alice = generateMockCredential("alice-device");
+    const bob = generateMockCredential("bob-device");
+    expect(alice.credentialId).not.toBe(bob.credentialId);
+  });
+
+  it("returns hex strings of the expected length", () => {
+    const credential = generateMockCredential("seed");
+    expect(credential.credentialId).toMatch(/^[0-9a-f]{32}$/); // 16 bytes
+    expect(credential.publicKey).toMatch(/^[0-9a-f]{64}$/); // 32 bytes
+  });
+});
+
+describe("createMockAuthenticator", () => {
+  it("authenticates a credential it registered", () => {
+    const authenticator = createMockAuthenticator();
+    const { credential } = authenticator.register("alice-device");
+
+    const result = authenticator.authenticate(credential.credentialId);
+    expect(result.credential).toEqual(credential);
+  });
+
+  it("throws for a credential id it never registered", () => {
+    const authenticator = createMockAuthenticator();
+    expect(() => authenticator.authenticate("unknown-id")).toThrow(/No credential registered/);
+  });
+
+  it("keeps registrations independent across separate authenticator instances", () => {
+    const a = createMockAuthenticator();
+    const b = createMockAuthenticator();
+    const { credential } = a.register("alice-device");
+
+    expect(() => b.authenticate(credential.credentialId)).toThrow(/No credential registered/);
+  });
+
+  it("supports registering and authenticating multiple credentials", () => {
+    const authenticator = createMockAuthenticator();
+    const alice = authenticator.register("alice-device").credential;
+    const bob = authenticator.register("bob-device").credential;
+
+    expect(authenticator.authenticate(alice.credentialId).credential).toEqual(alice);
+    expect(authenticator.authenticate(bob.credentialId).credential).toEqual(bob);
+  });
+});

--- a/contrib/examples/mock-passkey-ceremony/mock-passkey-ceremony.ts
+++ b/contrib/examples/mock-passkey-ceremony/mock-passkey-ceremony.ts
@@ -1,0 +1,114 @@
+// Example: a deterministic mock passkey registration + authentication
+// ceremony, for wiring into a CI test suite with no real browser or
+// WebAuthn support. The same seed always produces the same mock
+// credential, so tests stay reproducible.
+//
+// Run with: npx tsx mock-passkey-ceremony.ts
+
+export interface MockCredential {
+  credentialId: string;
+  publicKey: string;
+}
+
+// A small seeded PRNG (mulberry32) so credential generation is
+// deterministic from a string seed without pulling in a crypto dependency
+// — this is a test double, not a real key generator.
+function hashSeed(seed: string): number {
+  let h = 0;
+  for (let i = 0; i < seed.length; i++) {
+    h = (Math.imul(31, h) + seed.charCodeAt(i)) | 0;
+  }
+  return h >>> 0;
+}
+
+function mulberry32(seed: number): () => number {
+  let state = seed;
+  return () => {
+    state = (state + 0x6d2b79f5) | 0;
+    let t = Math.imul(state ^ (state >>> 15), 1 | state);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+function randomHex(rand: () => number, byteLength: number): string {
+  let out = "";
+  for (let i = 0; i < byteLength; i++) {
+    out += Math.floor(rand() * 256).toString(16).padStart(2, "0");
+  }
+  return out;
+}
+
+/**
+ * Deterministically derives a mock WebAuthn-shaped credential from `seed`:
+ * the same seed always produces the same credentialId and publicKey across
+ * calls (and across process restarts — there's no hidden global state).
+ */
+export function generateMockCredential(seed: string): MockCredential {
+  const rand = mulberry32(hashSeed(seed));
+  return {
+    credentialId: randomHex(rand, 16),
+    publicKey: randomHex(rand, 32),
+  };
+}
+
+export interface RegisterResult {
+  credential: MockCredential;
+  registeredAt: string;
+}
+
+export interface AuthenticateResult {
+  credential: MockCredential;
+  authenticatedAt: string;
+}
+
+/** In-memory "authenticator": remembers registered credentials by id, the
+ * same way a real platform authenticator would, so authenticate() can only
+ * succeed for a credential this instance actually registered. */
+export function createMockAuthenticator() {
+  const registered = new Map<string, MockCredential>();
+
+  return {
+    /** Registration ceremony: derives a credential from `seed` and stores it. */
+    register(seed: string): RegisterResult {
+      const credential = generateMockCredential(seed);
+      registered.set(credential.credentialId, credential);
+      return { credential, registeredAt: new Date().toISOString() };
+    },
+
+    /** Authentication ceremony: looks up a previously registered credential
+     * by id. Throws for an id this authenticator never registered — a real
+     * authenticator refuses an unknown credential too. */
+    authenticate(credentialId: string): AuthenticateResult {
+      const credential = registered.get(credentialId);
+      if (!credential) {
+        throw new Error(`No credential registered with id "${credentialId}"`);
+      }
+      return { credential, authenticatedAt: new Date().toISOString() };
+    },
+  };
+}
+
+function main() {
+  console.log("Determinism check: generateMockCredential('alice-device') called twice...");
+  const first = generateMockCredential("alice-device");
+  const second = generateMockCredential("alice-device");
+  console.log(`  call 1: ${first.credentialId}`);
+  console.log(`  call 2: ${second.credentialId}`);
+  console.log(`  same credentialId both times: ${first.credentialId === second.credentialId}`);
+
+  console.log("\nFull register-then-authenticate sequence:");
+  const authenticator = createMockAuthenticator();
+
+  console.log("  Step 1: register with seed 'alice-device'");
+  const { credential } = authenticator.register("alice-device");
+  console.log(`    registered credentialId = ${credential.credentialId}`);
+
+  console.log("  Step 2: authenticate with that credentialId");
+  const authResult = authenticator.authenticate(credential.credentialId);
+  console.log(`    authenticated at ${authResult.authenticatedAt}, publicKey = ${authResult.credential.publicKey}`);
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main();
+}

--- a/contrib/examples/tx-history-sync-worker/README.md
+++ b/contrib/examples/tx-history-sync-worker/README.md
@@ -1,0 +1,62 @@
+# Transaction history sync worker
+
+A worker that periodically polls a transaction source and appends only
+newly-seen transactions to a local in-memory history — safe against a
+source whose results **overlap between polls** (e.g. "the last N
+transactions" rather than strictly incremental results).
+
+## How dedup works
+
+`mergeBatch` tracks every id it has ever accepted in a `Set`, so a
+transaction that reappears in a later poll (because the source's window
+overlapped with the previous one) is silently skipped rather than
+re-appended. The worker also exposes `lastSeenId()` — the id of the most
+recently *accepted* transaction — for observability, derived from the same
+dedup state rather than being a second, separately-tracked cursor that could
+drift out of sync with it.
+
+## Usage
+
+```ts
+import { createSyncWorker } from "./tx-history-sync-worker";
+
+const worker = createSyncWorker(fetchLatestTransactions, 5000);
+worker.start(); // polls immediately, then every 5s
+
+// later
+worker.history();   // every transaction seen so far, oldest first, deduplicated
+worker.lastSeenId(); // the most recently accepted transaction's id
+worker.stop();       // stop polling; history is preserved
+```
+
+## Run it
+
+```sh
+npx tsx tx-history-sync-worker.ts
+```
+
+Expected output (three polls, each overlapping the previous one by one
+transaction):
+
+```
+Poll 1: saw 2, 2 new
+Poll 2: saw 2, 1 new
+Poll 3: saw 3, 2 new
+Deduplicated history: [
+  { id: 'tx-1', amount: '10' },
+  { id: 'tx-2', amount: '20' },
+  { id: 'tx-3', amount: '30' },
+  { id: 'tx-4', amount: '40' },
+  { id: 'tx-5', amount: '50' }
+]
+```
+
+## Tests
+
+```sh
+npx vitest run contrib/examples/tx-history-sync-worker
+```
+
+`mergeBatch` (the dedup core) is tested directly with plain arrays; the
+`createSyncWorker` interval/start/stop behavior is tested with vitest's fake
+timers.

--- a/contrib/examples/tx-history-sync-worker/tx-history-sync-worker.test.ts
+++ b/contrib/examples/tx-history-sync-worker/tx-history-sync-worker.test.ts
@@ -1,0 +1,103 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createEmptyState, createSyncWorker, mergeBatch, type SyncedTransaction } from "./tx-history-sync-worker";
+
+describe("mergeBatch", () => {
+  it("appends every transaction from an all-new batch", () => {
+    const state = createEmptyState();
+    const newCount = mergeBatch(state, [{ id: "tx-1", amount: "10" }, { id: "tx-2", amount: "20" }]);
+
+    expect(newCount).toBe(2);
+    expect(state.history).toEqual([{ id: "tx-1", amount: "10" }, { id: "tx-2", amount: "20" }]);
+  });
+
+  it("skips ids already seen in a previous merge, keeping only the new ones", () => {
+    const state = createEmptyState();
+    mergeBatch(state, [{ id: "tx-1", amount: "10" }, { id: "tx-2", amount: "20" }]);
+    const newCount = mergeBatch(state, [{ id: "tx-2", amount: "20" }, { id: "tx-3", amount: "30" }]);
+
+    expect(newCount).toBe(1);
+    expect(state.history.map((tx) => tx.id)).toEqual(["tx-1", "tx-2", "tx-3"]);
+  });
+
+  it("handles a fully overlapping batch as zero new", () => {
+    const state = createEmptyState();
+    mergeBatch(state, [{ id: "tx-1", amount: "10" }]);
+    const newCount = mergeBatch(state, [{ id: "tx-1", amount: "10" }]);
+
+    expect(newCount).toBe(0);
+    expect(state.history).toHaveLength(1);
+  });
+
+  it("processes three overlapping polls into a fully deduplicated history", () => {
+    const state = createEmptyState();
+    mergeBatch(state, [{ id: "tx-1", amount: "10" }, { id: "tx-2", amount: "20" }]);
+    mergeBatch(state, [{ id: "tx-2", amount: "20" }, { id: "tx-3", amount: "30" }]);
+    mergeBatch(state, [{ id: "tx-3", amount: "30" }, { id: "tx-4", amount: "40" }, { id: "tx-5", amount: "50" }]);
+
+    expect(state.history.map((tx) => tx.id)).toEqual(["tx-1", "tx-2", "tx-3", "tx-4", "tx-5"]);
+  });
+});
+
+describe("createSyncWorker", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("polls immediately on start and reports history/lastSeenId", async () => {
+    const source = vi.fn<() => SyncedTransaction[]>().mockReturnValue([{ id: "tx-1", amount: "10" }]);
+    const worker = createSyncWorker(source, 1000);
+
+    worker.start();
+    await vi.waitFor(() => expect(source).toHaveBeenCalledTimes(1));
+
+    expect(worker.history()).toEqual([{ id: "tx-1", amount: "10" }]);
+    expect(worker.lastSeenId()).toBe("tx-1");
+    worker.stop();
+  });
+
+  it("polls again after the interval elapses", async () => {
+    const source = vi
+      .fn<() => SyncedTransaction[]>()
+      .mockReturnValueOnce([{ id: "tx-1", amount: "10" }])
+      .mockReturnValueOnce([{ id: "tx-1", amount: "10" }, { id: "tx-2", amount: "20" }]);
+    const worker = createSyncWorker(source, 1000);
+
+    worker.start();
+    await vi.waitFor(() => expect(source).toHaveBeenCalledTimes(1));
+
+    await vi.advanceTimersByTimeAsync(1000);
+    await vi.waitFor(() => expect(source).toHaveBeenCalledTimes(2));
+
+    expect(worker.history().map((tx) => tx.id)).toEqual(["tx-1", "tx-2"]);
+    worker.stop();
+  });
+
+  it("stops polling after stop() is called", async () => {
+    const source = vi.fn<() => SyncedTransaction[]>().mockReturnValue([{ id: "tx-1", amount: "10" }]);
+    const worker = createSyncWorker(source, 1000);
+
+    worker.start();
+    await vi.waitFor(() => expect(source).toHaveBeenCalledTimes(1));
+    worker.stop();
+
+    await vi.advanceTimersByTimeAsync(5000);
+    expect(source).toHaveBeenCalledTimes(1);
+  });
+
+  it("calling start() twice does not double the polling interval", async () => {
+    const source = vi.fn<() => SyncedTransaction[]>().mockReturnValue([]);
+    const worker = createSyncWorker(source, 1000);
+
+    worker.start();
+    await vi.waitFor(() => expect(source).toHaveBeenCalledTimes(1));
+    worker.start(); // no-op, already running
+
+    await vi.advanceTimersByTimeAsync(1000);
+    await vi.waitFor(() => expect(source).toHaveBeenCalledTimes(2));
+    worker.stop();
+  });
+});

--- a/contrib/examples/tx-history-sync-worker/tx-history-sync-worker.ts
+++ b/contrib/examples/tx-history-sync-worker/tx-history-sync-worker.ts
@@ -1,0 +1,119 @@
+// Example: a worker that periodically polls a transaction source and
+// appends only newly-seen transactions to a local in-memory history,
+// deduplicating across polls whose results overlap — e.g. a source that
+// always returns "the last N transactions" rather than only new ones since
+// last poll.
+//
+// Run with: npx tsx tx-history-sync-worker.ts
+
+export interface SyncedTransaction {
+  id: string;
+  amount: string;
+}
+
+export type TransactionSource = () => Promise<SyncedTransaction[]> | SyncedTransaction[];
+
+export interface SyncState {
+  history: SyncedTransaction[];
+  seenIds: Set<string>;
+}
+
+export function createEmptyState(): SyncState {
+  return { history: [], seenIds: new Set() };
+}
+
+/**
+ * Merges one poll's `batch` into `state`, mutating it in place: any
+ * transaction whose id has already been seen is skipped, everything else is
+ * appended to history in the order it appears in the batch. Returns how
+ * many were newly added.
+ *
+ * A plain seen-id set (rather than only comparing against a single "last
+ * seen" cursor) is used so this stays correct even if the mock/real source
+ * doesn't guarantee strict ordering across polls — the tracked "last seen
+ * identifier" the worker reports (see `lastSeenId` below) is simply the id
+ * of the most recently accepted transaction, derived from this set.
+ */
+export function mergeBatch(state: SyncState, batch: SyncedTransaction[]): number {
+  let newCount = 0;
+  for (const tx of batch) {
+    if (state.seenIds.has(tx.id)) continue;
+    state.seenIds.add(tx.id);
+    state.history.push(tx);
+    newCount++;
+  }
+  return newCount;
+}
+
+export interface SyncWorker {
+  /** Runs one poll immediately, then again every `intervalMs`. Calling
+   * start() while already running is a no-op. */
+  start(): void;
+  /** Stops future polling. The accumulated history is left intact. */
+  stop(): void;
+  /** A copy of every transaction seen so far, oldest first. */
+  history(): SyncedTransaction[];
+  /** The id of the most recently accepted transaction, or undefined before
+   * the first successful poll. */
+  lastSeenId(): string | undefined;
+}
+
+export function createSyncWorker(
+  source: TransactionSource,
+  intervalMs: number,
+  log: (line: string) => void = () => {},
+): SyncWorker {
+  const state = createEmptyState();
+  let timer: ReturnType<typeof setInterval> | undefined;
+  let lastId: string | undefined;
+
+  async function pollOnce(): Promise<void> {
+    const batch = await source();
+    const newCount = mergeBatch(state, batch);
+    if (newCount > 0) {
+      lastId = state.history[state.history.length - 1]?.id;
+    }
+    log(`Poll: saw ${batch.length}, ${newCount} new (history size: ${state.history.length}, last seen id: ${lastId ?? "none"})`);
+  }
+
+  return {
+    start() {
+      if (timer) return;
+      void pollOnce();
+      timer = setInterval(() => void pollOnce(), intervalMs);
+    },
+    stop() {
+      if (timer) {
+        clearInterval(timer);
+        timer = undefined;
+      }
+    },
+    history: () => [...state.history],
+    lastSeenId: () => lastId,
+  };
+}
+
+async function main() {
+  // A mock source whose results overlap between polls, like a "last N
+  // transactions" feed rather than a strictly incremental one.
+  const pages: SyncedTransaction[][] = [
+    [{ id: "tx-1", amount: "10" }, { id: "tx-2", amount: "20" }],
+    [{ id: "tx-2", amount: "20" }, { id: "tx-3", amount: "30" }], // tx-2 repeats
+    [{ id: "tx-3", amount: "30" }, { id: "tx-4", amount: "40" }, { id: "tx-5", amount: "50" }], // tx-3 repeats
+  ];
+  let pageIndex = 0;
+  const source: TransactionSource = () => pages[Math.min(pageIndex++, pages.length - 1)] ?? [];
+
+  const state = createEmptyState();
+  for (let i = 0; i < pages.length; i++) {
+    const batch = await source();
+    const newCount = mergeBatch(state, batch);
+    console.log(`Poll ${i + 1}: saw ${batch.length}, ${newCount} new`);
+  }
+
+  console.log("Deduplicated history:", state.history);
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main();
+}

--- a/contrib/examples/x402-budget-tracker/README.md
+++ b/contrib/examples/x402-budget-tracker/README.md
@@ -1,0 +1,45 @@
+# x402 budget tracker for an agent
+
+`X402BudgetTracker` records an agent's successful x402 payments against a
+fixed total budget and reports the remaining allowance. A proposed payment
+that would exceed what's left is rejected with a clear reason and is never
+partially recorded — the tracked spend only changes on approval.
+
+This is a **client-side** guard, the same kind `X402PayOptions.maxAmount`
+already is in `src/x402-types.ts` — the durable budget enforcement is the
+on-chain spending-limit policy attached to the signing key. This tracker is
+useful for an agent that wants to stop making requests *before* hitting that
+on-chain wall, e.g. to fail fast with a clear reason instead of discovering
+the rejection only after a signed payment bounces off the facilitator.
+
+## Usage
+
+```ts
+import { X402BudgetTracker } from "./x402-budget-tracker";
+
+const tracker = new X402BudgetTracker(1_000_000n);
+
+tracker.tryRecordPayment(300_000n); // { approved: true, remainingBudget: 700000n }
+tracker.tryRecordPayment(800_000n); // { approved: false, reason: "...", remainingBudget: 700000n }
+```
+
+## Run it
+
+```sh
+npx tsx x402-budget-tracker.ts
+```
+
+Expected output:
+
+```
+Payment of 300000: APPROVED (remaining: 700000)
+Payment of 400000: APPROVED (remaining: 300000)
+Payment of 500000: REJECTED — Payment of 500000 would exceed remaining budget of 300000 (total 1000000, already spent 700000)
+Payment of 200000: APPROVED (remaining: 100000)
+```
+
+## Tests
+
+```sh
+npx vitest run contrib/examples/x402-budget-tracker
+```

--- a/contrib/examples/x402-budget-tracker/x402-budget-tracker.test.ts
+++ b/contrib/examples/x402-budget-tracker/x402-budget-tracker.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "vitest";
+import { X402BudgetTracker } from "./x402-budget-tracker";
+
+describe("X402BudgetTracker", () => {
+  it("approves a payment within the budget and reduces the remaining allowance", () => {
+    const tracker = new X402BudgetTracker(1000n);
+    const decision = tracker.tryRecordPayment(300n);
+
+    expect(decision).toEqual({ approved: true, remainingBudget: 700n });
+    expect(tracker.remainingBudget).toBe(700n);
+    expect(tracker.totalSpent).toBe(300n);
+  });
+
+  it("rejects a payment that would exceed the remaining budget, with a reason", () => {
+    const tracker = new X402BudgetTracker(1000n);
+    tracker.tryRecordPayment(700n);
+
+    const decision = tracker.tryRecordPayment(400n);
+
+    expect(decision.approved).toBe(false);
+    expect(decision.reason).toMatch(/exceed remaining budget/);
+    expect(decision.remainingBudget).toBe(300n);
+  });
+
+  it("does not record a rejected payment against spend", () => {
+    const tracker = new X402BudgetTracker(1000n);
+    tracker.tryRecordPayment(700n);
+    tracker.tryRecordPayment(400n); // rejected
+
+    expect(tracker.totalSpent).toBe(700n);
+    expect(tracker.remainingBudget).toBe(300n);
+  });
+
+  it("approves a payment that exactly exhausts the remaining budget", () => {
+    const tracker = new X402BudgetTracker(1000n);
+    const decision = tracker.tryRecordPayment(1000n);
+    expect(decision.approved).toBe(true);
+    expect(tracker.remainingBudget).toBe(0n);
+  });
+
+  it("rejects any further payment once the budget is exhausted", () => {
+    const tracker = new X402BudgetTracker(1000n);
+    tracker.tryRecordPayment(1000n);
+    const decision = tracker.tryRecordPayment(1n);
+    expect(decision.approved).toBe(false);
+  });
+
+  it("throws for a negative total budget", () => {
+    expect(() => new X402BudgetTracker(-1n)).toThrow(RangeError);
+  });
+
+  it("throws for a negative payment amount", () => {
+    const tracker = new X402BudgetTracker(1000n);
+    expect(() => tracker.tryRecordPayment(-1n)).toThrow(RangeError);
+  });
+
+  it("processes a mixed sequence, approving and rejecting as budget allows", () => {
+    const tracker = new X402BudgetTracker(1_000_000n);
+    const results = [300_000n, 400_000n, 500_000n, 200_000n].map((amount) =>
+      tracker.tryRecordPayment(amount).approved,
+    );
+    expect(results).toEqual([true, true, false, true]);
+    expect(tracker.totalSpent).toBe(900_000n);
+  });
+});

--- a/contrib/examples/x402-budget-tracker/x402-budget-tracker.ts
+++ b/contrib/examples/x402-budget-tracker/x402-budget-tracker.ts
@@ -1,0 +1,75 @@
+// Example: track an agent's x402 spend over time against a configured
+// budget, reporting a clear rejection reason when a proposed payment would
+// exceed the remaining allowance. A client-side companion to the on-chain
+// spending-limit policy — see src/x402-types.ts's X402PayOptions.maxAmount
+// doc comment, which makes the same "client-side guard, not the durable
+// budget" distinction.
+//
+// Run with: npx tsx x402-budget-tracker.ts
+
+export interface BudgetDecision {
+  approved: boolean;
+  /** Present only when approved is false. */
+  reason?: string;
+  /** Remaining allowance after this decision (unchanged if rejected). */
+  remainingBudget: bigint;
+}
+
+/**
+ * Tracks spend against a fixed total budget (in the asset's base units).
+ * Each call to `tryRecordPayment` either records the amount (if it fits in
+ * the remaining allowance) or rejects it with a reason, leaving the
+ * tracked spend unchanged — a rejected payment is never partially recorded.
+ */
+export class X402BudgetTracker {
+  private spent = 0n;
+
+  constructor(private readonly totalBudget: bigint) {
+    if (totalBudget < 0n) {
+      throw new RangeError("totalBudget must not be negative");
+    }
+  }
+
+  /** Remaining allowance: totalBudget - spent so far. */
+  get remainingBudget(): bigint {
+    return this.totalBudget - this.spent;
+  }
+
+  /** Total spent so far (only successfully recorded payments count). */
+  get totalSpent(): bigint {
+    return this.spent;
+  }
+
+  tryRecordPayment(amount: bigint): BudgetDecision {
+    if (amount < 0n) {
+      throw new RangeError("amount must not be negative");
+    }
+    if (amount > this.remainingBudget) {
+      return {
+        approved: false,
+        reason: `Payment of ${amount} would exceed remaining budget of ${this.remainingBudget} (total ${this.totalBudget}, already spent ${this.spent})`,
+        remainingBudget: this.remainingBudget,
+      };
+    }
+    this.spent += amount;
+    return { approved: true, remainingBudget: this.remainingBudget };
+  }
+}
+
+function main() {
+  const tracker = new X402BudgetTracker(1_000_000n); // 1,000,000 base units
+  const plannedPayments = [300_000n, 400_000n, 500_000n, 200_000n];
+
+  for (const amount of plannedPayments) {
+    const decision = tracker.tryRecordPayment(amount);
+    if (decision.approved) {
+      console.log(`Payment of ${amount}: APPROVED (remaining: ${decision.remainingBudget})`);
+    } else {
+      console.log(`Payment of ${amount}: REJECTED — ${decision.reason}`);
+    }
+  }
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main();
+}


### PR DESCRIPTION
## Summary

Four self-contained reference examples under contrib/examples/, each with its own README and vitest suite.

closes #81
closes #84
closes #85
closes #86

## Changes

- **#81 — Mock end-to-end wallet backend** (`contrib/examples/mock-full-backend/`): a fully in-memory `WalletBackend` (create, connect, `submitTransaction`) backed by an append-only ledger of submitted transactions queryable by hash, wired into a real `createVellarWallet` handle for a complete create-then-pay sequence with no network I/O.

- **#84 — Mock passkey ceremony for CI** (`contrib/examples/mock-passkey-ceremony/`): `generateMockCredential(seed)` deterministically derives a `{credentialId, publicKey}` pair via a seeded PRNG (mulberry32) — the same seed always produces the same credential. `createMockAuthenticator()` wraps it with an in-memory register/authenticate ceremony that refuses an unregistered credential id.

- **#85 — x402 budget tracker** (`contrib/examples/x402-budget-tracker/`): `X402BudgetTracker` records successful payments against a fixed total budget, rejecting (with a clear reason) any proposed payment that would exceed the remaining allowance. A rejected payment is never partially recorded — same "client-side guard, not the durable budget" spirit as `X402PayOptions.maxAmount`.

- **#86 — Transaction history sync worker** (`contrib/examples/tx-history-sync-worker/`): a worker that periodically polls a transaction source and appends only newly-seen transactions to a local history, deduplicating via a seen-id set so it stays correct even when the source's polls overlap. `lastSeenId()` reports the most recently accepted id, derived from the same dedup state.

## Test plan

- `npm run typecheck`, `npm test`, and `npm run build` all pass clean at the repo root (56 test files / 295 tests, including these 15 new ones and every pre-existing example).
- Each example's script was run directly (`npx tsx <file>`) and its output verified against the README's documented sample output.

All work is inside `contrib/`; no files outside it were touched.