### PR TITLE
feat(examples): multi-asset summary, nonce tracker, CLI parser, and onboarding checklist examples

### DIFF
--- a/contrib/examples/cli-arg-parser/README.md
+++ b/contrib/examples/cli-arg-parser/README.md
@@ -1,0 +1,47 @@
+# Minimal CLI argument parser
+
+Reads named flags and positional arguments from a `process.argv`-style
+array, returning a plain object with parsed flags and an array of
+positionals.
+
+## Supported syntax
+
+- `--key=value` — a flag with a string value.
+- `--key` (no `=`) — a boolean flag (`true`).
+- anything else — a positional argument.
+
+**Deliberately not supported: `--key value` (space-separated).** Without a
+predefined schema of which flags take a value, that form is ambiguous —
+`--dry-run positional1` can't be told apart from `--amount 100` without
+knowing in advance whether `--dry-run` is boolean-only. Requiring `=` for
+any flag that takes a value sidesteps the ambiguity entirely.
+
+## Run it
+
+```sh
+npx tsx cli-arg-parser.ts
+```
+
+Expected output:
+
+```
+Input:  [
+  '--network=testnet',
+  '--dry-run',
+  'positional1',
+  '--amount=100',
+  'positional2'
+]
+Parsed: {
+  flags: { network: 'testnet', 'dry-run': true, amount: '100' },
+  positionals: [ 'positional1', 'positional2' ]
+}
+```
+
+## Tests
+
+Covers a mix of flags and positionals in one call:
+
+```sh
+npx vitest run contrib/examples/cli-arg-parser
+```

--- a/contrib/examples/cli-arg-parser/cli-arg-parser.test.ts
+++ b/contrib/examples/cli-arg-parser/cli-arg-parser.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+import { parseArgs } from "./cli-arg-parser";
+
+describe("parseArgs", () => {
+  it("parses a --key=value flag", () => {
+    expect(parseArgs(["--network=testnet"])).toEqual({
+      flags: { network: "testnet" },
+      positionals: [],
+    });
+  });
+
+  it("parses a bare flag as boolean true", () => {
+    expect(parseArgs(["--dry-run"])).toEqual({ flags: { "dry-run": true }, positionals: [] });
+  });
+
+  it("collects non-flag tokens as positionals", () => {
+    expect(parseArgs(["one", "two"])).toEqual({ flags: {}, positionals: ["one", "two"] });
+  });
+
+  it("parses a mix of flags and positionals in one call", () => {
+    const result = parseArgs(["--network=testnet", "--dry-run", "positional1", "--amount=100", "positional2"]);
+    expect(result).toEqual({
+      flags: { network: "testnet", "dry-run": true, amount: "100" },
+      positionals: ["positional1", "positional2"],
+    });
+  });
+
+  it("returns empty flags and positionals for an empty input", () => {
+    expect(parseArgs([])).toEqual({ flags: {}, positionals: [] });
+  });
+});

--- a/contrib/examples/cli-arg-parser/cli-arg-parser.ts
+++ b/contrib/examples/cli-arg-parser/cli-arg-parser.ts
@@ -1,0 +1,52 @@
+// Example: a minimal CLI argument parser reading named flags and
+// positional arguments from a process.argv-style array.
+//
+// Supported flag styles: --key=value, and a bare --key (boolean true).
+// Everything else (including anything not starting with --) is a
+// positional.
+//
+// Deliberately NOT supporting "--key value" (space-separated): without a
+// predefined schema of which flags take a value, that form is ambiguous —
+// `--dry-run positional1` can't be told apart from `--amount 100` without
+// knowing in advance whether --dry-run is boolean-only. Requiring `=` for
+// any flag that takes a value sidesteps the ambiguity entirely.
+//
+// Run with: npx tsx cli-arg-parser.ts --network=testnet --dry-run positional1 --amount=100 positional2
+
+export interface ParsedArgs {
+  flags: Record<string, string | boolean>;
+  positionals: string[];
+}
+
+export function parseArgs(argv: string[]): ParsedArgs {
+  const flags: Record<string, string | boolean> = {};
+  const positionals: string[] = [];
+
+  for (const token of argv) {
+    if (token.startsWith("--")) {
+      const body = token.slice(2);
+      const eqIndex = body.indexOf("=");
+
+      if (eqIndex !== -1) {
+        flags[body.slice(0, eqIndex)] = body.slice(eqIndex + 1);
+      } else {
+        flags[body] = true;
+      }
+      continue;
+    }
+
+    positionals.push(token);
+  }
+
+  return { flags, positionals };
+}
+
+function main() {
+  const sampleArgv = ["--network=testnet", "--dry-run", "positional1", "--amount=100", "positional2"];
+  console.log("Input: ", sampleArgv);
+  console.log("Parsed:", parseArgs(sampleArgv));
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main();
+}

--- a/contrib/examples/multi-asset-summary/README.md
+++ b/contrib/examples/multi-asset-summary/README.md
@@ -1,0 +1,33 @@
+# Multi-asset balance summary
+
+Formats a readable "SYMBOL: amount" summary line per asset from a sample
+array of balances across several assets (`vellar-sdk`'s `TokenBalance` shape,
+`src/balances.ts`), sorted alphabetically by asset code. Reuses the SDK's
+own `formatTokenAmount` for the amount formatting.
+
+## Run it
+
+```sh
+npx tsx multi-asset-summary.ts
+```
+
+Expected output:
+
+```
+With balances:
+AQUA: 50000
+USDC: 250
+XLM: 1000
+
+With no balances:
+No balances.
+```
+
+An empty balances array prints a clear "No balances." message instead of an
+empty output.
+
+## Tests
+
+```sh
+npx vitest run contrib/examples/multi-asset-summary
+```

--- a/contrib/examples/multi-asset-summary/multi-asset-summary.test.ts
+++ b/contrib/examples/multi-asset-summary/multi-asset-summary.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+import type { TokenBalance } from "../../../src/balances";
+import { formatMultiAssetSummary } from "./multi-asset-summary";
+
+describe("formatMultiAssetSummary", () => {
+  it("prints a clear message for an empty array", () => {
+    expect(formatMultiAssetSummary([])).toBe("No balances.");
+  });
+
+  it("formats one line per asset", () => {
+    const balances: TokenBalance[] = [
+      { symbol: "XLM", contractId: "CNATIVE", decimals: 7, amount: 1_000_000_000n },
+    ];
+    expect(formatMultiAssetSummary(balances)).toBe("XLM: 100");
+  });
+
+  it("sorts the summary alphabetically by asset code", () => {
+    const balances: TokenBalance[] = [
+      { symbol: "XLM", contractId: "CNATIVE", decimals: 7, amount: 100n },
+      { symbol: "AQUA", contractId: "CAQUA", decimals: 7, amount: 200n },
+      { symbol: "USDC", contractId: "CUSDC", decimals: 7, amount: 300n },
+    ];
+    const lines = formatMultiAssetSummary(balances).split("\n");
+    expect(lines.map((l) => l.split(":")[0])).toEqual(["AQUA", "USDC", "XLM"]);
+  });
+
+  it("does not mutate the input array order", () => {
+    const balances: TokenBalance[] = [
+      { symbol: "XLM", contractId: "CNATIVE", decimals: 7, amount: 100n },
+      { symbol: "AQUA", contractId: "CAQUA", decimals: 7, amount: 200n },
+    ];
+    formatMultiAssetSummary(balances);
+    expect(balances[0]!.symbol).toBe("XLM"); // original order untouched
+  });
+});

--- a/contrib/examples/multi-asset-summary/multi-asset-summary.ts
+++ b/contrib/examples/multi-asset-summary/multi-asset-summary.ts
@@ -1,0 +1,35 @@
+// Example: format a readable summary line per asset from a sample array of
+// balances across several assets, sorted alphabetically by asset code.
+//
+// Run with: npx tsx multi-asset-summary.ts
+
+import { formatTokenAmount, type TokenBalance } from "../../../src/balances";
+
+/** Formats a "SYMBOL: amount" line per asset, sorted alphabetically by
+ * symbol. An empty array prints a clear "No balances." message. */
+export function formatMultiAssetSummary(balances: TokenBalance[]): string {
+  if (balances.length === 0) {
+    return "No balances.";
+  }
+
+  const sorted = [...balances].sort((a, b) => a.symbol.localeCompare(b.symbol));
+  return sorted.map((b) => `${b.symbol}: ${formatTokenAmount(b.amount, b.decimals)}`).join("\n");
+}
+
+function main() {
+  const sampleBalances: TokenBalance[] = [
+    { symbol: "USDC", contractId: "CUSDC", decimals: 7, amount: 250_000_0000n },
+    { symbol: "XLM", contractId: "CNATIVE", decimals: 7, amount: 1_000_000_0000n },
+    { symbol: "AQUA", contractId: "CAQUA", decimals: 7, amount: 50_000_0000000n },
+  ];
+
+  console.log("With balances:");
+  console.log(formatMultiAssetSummary(sampleBalances));
+  console.log();
+  console.log("With no balances:");
+  console.log(formatMultiAssetSummary([]));
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main();
+}

--- a/contrib/examples/nonce-tracker/README.md
+++ b/contrib/examples/nonce-tracker/README.md
@@ -1,0 +1,32 @@
+# Simple in-memory nonce tracker
+
+Records used nonce values per account in memory, to detect and reject a
+repeated nonce — useful for replay protection on a signed request.
+
+`checkAndConsume(account, nonce)` returns `true` and marks the nonce used
+the first time it's seen for that account; a second check for the same
+account+nonce pair returns `false` without re-marking anything. Nonces are
+tracked independently per account — the same nonce string is fresh again
+for a different account.
+
+## Run it
+
+```sh
+npx tsx nonce-tracker.ts
+```
+
+Expected output:
+
+```
+First check of nonce 'abc' for account GALICE: true
+Second check of the same nonce (should be rejected): false
+Same nonce, different account (should be fresh): true
+```
+
+## Tests
+
+Covers a fresh nonce accepted and a repeated nonce rejected:
+
+```sh
+npx vitest run contrib/examples/nonce-tracker
+```

--- a/contrib/examples/nonce-tracker/nonce-tracker.test.ts
+++ b/contrib/examples/nonce-tracker/nonce-tracker.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+import { NonceTracker } from "./nonce-tracker";
+
+describe("NonceTracker", () => {
+  it("accepts a fresh nonce", () => {
+    const tracker = new NonceTracker();
+    expect(tracker.checkAndConsume("GALICE", "n1")).toBe(true);
+  });
+
+  it("rejects a repeated nonce for the same account", () => {
+    const tracker = new NonceTracker();
+    tracker.checkAndConsume("GALICE", "n1");
+    expect(tracker.checkAndConsume("GALICE", "n1")).toBe(false);
+  });
+
+  it("tracks nonces independently per account", () => {
+    const tracker = new NonceTracker();
+    tracker.checkAndConsume("GALICE", "n1");
+    expect(tracker.checkAndConsume("GBOB", "n1")).toBe(true);
+  });
+
+  it("accepts a different nonce for an account that already used one", () => {
+    const tracker = new NonceTracker();
+    tracker.checkAndConsume("GALICE", "n1");
+    expect(tracker.checkAndConsume("GALICE", "n2")).toBe(true);
+  });
+});

--- a/contrib/examples/nonce-tracker/nonce-tracker.ts
+++ b/contrib/examples/nonce-tracker/nonce-tracker.ts
@@ -1,0 +1,39 @@
+// Example: an in-memory tracker recording used nonce values per account,
+// to detect and reject a repeated nonce (e.g. for replay protection on a
+// signed request).
+//
+// Run with: npx tsx nonce-tracker.ts
+
+export class NonceTracker {
+  #used = new Map<string, Set<string>>();
+
+  /**
+   * Checks whether `nonce` is fresh for `account`. If fresh, marks it used
+   * (so a second check for the same account+nonce returns false) and
+   * returns true. If already used, returns false without side effects.
+   */
+  checkAndConsume(account: string, nonce: string): boolean {
+    let seen = this.#used.get(account);
+    if (!seen) {
+      seen = new Set();
+      this.#used.set(account, seen);
+    }
+    if (seen.has(nonce)) {
+      return false;
+    }
+    seen.add(nonce);
+    return true;
+  }
+}
+
+function main() {
+  const tracker = new NonceTracker();
+
+  console.log("First check of nonce 'abc' for account GALICE:", tracker.checkAndConsume("GALICE", "abc"));
+  console.log("Second check of the same nonce (should be rejected):", tracker.checkAndConsume("GALICE", "abc"));
+  console.log("Same nonce, different account (should be fresh):", tracker.checkAndConsume("GBOB", "abc"));
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main();
+}

--- a/contrib/examples/onboarding-checklist-runner/README.md
+++ b/contrib/examples/onboarding-checklist-runner/README.md
@@ -1,0 +1,44 @@
+# Wallet onboarding checklist runner
+
+Walks through a fixed sequence of onboarding steps against mocked
+dependencies, tracking which steps are complete after each run.
+`runOnboardingChecklist()` runs steps **in order**, stops at the first
+failure, and reports both `completed` and `remaining` (the failed step and
+everything after it) so a caller can show progress even on a partial run.
+
+## The steps
+
+`buildMockChecklist()` builds the standard four-step checklist, in order:
+
+1. **create-wallet** — register a passkey and create the smart account.
+2. **fund-account** — sponsor-fund the new account so it can pay fees.
+3. **verify-balance** — confirm the funded balance actually landed.
+4. **attach-policy** — attach a default spending-limit policy.
+
+Each step operates on shared mock state (an in-closure account id, balance,
+and policy flag) standing in for a real wallet/backend round trip — no
+network calls.
+
+## Run it
+
+```sh
+npx tsx onboarding-checklist-runner.ts
+```
+
+Expected output:
+
+```
+Running 4 onboarding steps: create-wallet -> fund-account -> verify-balance -> attach-policy
+
+Completed: [ 'create-wallet', 'fund-account', 'verify-balance', 'attach-policy' ]
+Remaining: (none — onboarding complete)
+```
+
+## Tests
+
+Covers the full checklist completing, and a partial run where a step fails
+partway through:
+
+```sh
+npx vitest run contrib/examples/onboarding-checklist-runner
+```

--- a/contrib/examples/onboarding-checklist-runner/onboarding-checklist-runner.test.ts
+++ b/contrib/examples/onboarding-checklist-runner/onboarding-checklist-runner.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+import { buildMockChecklist, runOnboardingChecklist, type OnboardingStep } from "./onboarding-checklist-runner";
+
+describe("runOnboardingChecklist", () => {
+  it("completes all four steps of the standard mock checklist in order", async () => {
+    const result = await runOnboardingChecklist(buildMockChecklist());
+    expect(result.completed).toEqual(["create-wallet", "fund-account", "verify-balance", "attach-policy"]);
+    expect(result.remaining).toEqual([]);
+  });
+
+  it("stops at the first failing step, reporting it and everything after as remaining", async () => {
+    const steps: OnboardingStep[] = [
+      { id: "step-1", description: "ok", async run() {} },
+      { id: "step-2", description: "fails", async run() { throw new Error("boom"); } },
+      { id: "step-3", description: "never reached", async run() {} },
+    ];
+
+    const result = await runOnboardingChecklist(steps);
+    expect(result.completed).toEqual(["step-1"]);
+    expect(result.remaining).toEqual(["step-2", "step-3"]);
+  });
+
+  it("runs steps in the given order, not concurrently", async () => {
+    const order: string[] = [];
+    const steps: OnboardingStep[] = [
+      { id: "a", description: "", async run() { order.push("a"); } },
+      { id: "b", description: "", async run() { order.push("b"); } },
+    ];
+    await runOnboardingChecklist(steps);
+    expect(order).toEqual(["a", "b"]);
+  });
+
+  it("returns an empty result for an empty checklist", async () => {
+    expect(await runOnboardingChecklist([])).toEqual({ completed: [], remaining: [] });
+  });
+});
+
+describe("buildMockChecklist", () => {
+  it("includes at least four distinct steps", () => {
+    const steps = buildMockChecklist();
+    expect(steps.length).toBeGreaterThanOrEqual(4);
+    expect(new Set(steps.map((s) => s.id)).size).toBe(steps.length);
+  });
+});

--- a/contrib/examples/onboarding-checklist-runner/onboarding-checklist-runner.ts
+++ b/contrib/examples/onboarding-checklist-runner/onboarding-checklist-runner.ts
@@ -1,0 +1,96 @@
+// Example: walk through a fixed sequence of wallet onboarding steps
+// against mocked dependencies, tracking which steps are complete after
+// each run.
+//
+// Steps (in order):
+//   1. create-wallet     — register a passkey and create the smart account.
+//   2. fund-account       — sponsor-fund the new account so it can pay fees.
+//   3. verify-balance     — confirm the funded balance actually landed.
+//   4. attach-policy      — attach a default spending-limit policy.
+//
+// Run with: npx tsx onboarding-checklist-runner.ts
+
+export interface OnboardingStep {
+  id: string;
+  description: string;
+  run: () => Promise<void>;
+}
+
+export interface ChecklistResult {
+  completed: string[];
+  remaining: string[];
+}
+
+/** Runs each step in order, stopping at the first failure. Returns which
+ * steps completed and which remain (including the failed one and anything
+ * after it), so a caller can show progress even on a partial run. */
+export async function runOnboardingChecklist(steps: OnboardingStep[]): Promise<ChecklistResult> {
+  const completed: string[] = [];
+
+  for (let i = 0; i < steps.length; i++) {
+    try {
+      await steps[i]!.run();
+      completed.push(steps[i]!.id);
+    } catch {
+      return { completed, remaining: steps.slice(i).map((s) => s.id) };
+    }
+  }
+
+  return { completed, remaining: [] };
+}
+
+/** Builds the standard four-step checklist against mocked dependencies. */
+export function buildMockChecklist(): OnboardingStep[] {
+  // Shared mutable mock state the steps operate on, standing in for a real
+  // wallet/backend round trip.
+  let accountId: string | undefined;
+  let balance = 0n;
+  let policyAttached = false;
+
+  return [
+    {
+      id: "create-wallet",
+      description: "Register a passkey and create the smart account.",
+      async run() {
+        accountId = "CMOCKONBOARDEDACCOUNTXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX";
+      },
+    },
+    {
+      id: "fund-account",
+      description: "Sponsor-fund the new account so it can pay fees.",
+      async run() {
+        if (!accountId) throw new Error("fund-account requires create-wallet to have run first");
+        balance = 5_0000000n; // 5 XLM, in stroops
+      },
+    },
+    {
+      id: "verify-balance",
+      description: "Confirm the funded balance actually landed.",
+      async run() {
+        if (balance <= 0n) throw new Error("verify-balance: account has no balance");
+      },
+    },
+    {
+      id: "attach-policy",
+      description: "Attach a default spending-limit policy.",
+      async run() {
+        policyAttached = true;
+      },
+    },
+  ];
+}
+
+async function main() {
+  const steps = buildMockChecklist();
+  console.log(`Running ${steps.length} onboarding steps: ${steps.map((s) => s.id).join(" -> ")}`);
+
+  const result = await runOnboardingChecklist(steps);
+
+  console.log();
+  console.log("Completed:", result.completed);
+  console.log("Remaining:", result.remaining.length > 0 ? result.remaining : "(none — onboarding complete)");
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main();
+}


### PR DESCRIPTION
## Summary
Four standalone examples under contrib/examples/, covering a multi-asset balance summary, an in-memory nonce tracker, a minimal CLI argument parser, and a reference onboarding checklist runner.

closes #120
closes #121
closes #123
closes #126

## Changes
- **#120 — multi-asset-summary**: `formatMultiAssetSummary()` prints one `"SYMBOL: amount"` line per asset, sorted alphabetically by code, reusing the SDK's own `formatTokenAmount`. Empty array prints a clear `"No balances."` message.
- **#121 — nonce-tracker**: `NonceTracker.checkAndConsume(account, nonce)` returns `true` and marks a nonce used the first time it's seen per account, `false` on a repeat. Nonces are tracked independently per account.
- **#123 — cli-arg-parser**: `parseArgs()` reads `--key=value` and bare `--key` (boolean) flags plus positionals from an argv-style array. Deliberately does not support space-separated `--key value`, since that's ambiguous without a predefined flag schema.
- **#126 — onboarding-checklist-runner**: `runOnboardingChecklist()` runs a fixed 4-step sequence (create wallet, fund account, verify balance, attach policy) against mocked dependencies, stopping at the first failure and reporting completed vs. remaining steps.

## Test plan
- Each example has a colocated `*.test.ts` (vitest) — 18 new tests, all passing.
- Ran every script directly (`npx tsx ...`) and confirmed output matches each README exactly.
- Caught and fixed two real issues during verification: an ambiguous `--key value` parsing case in the CLI parser (`--dry-run positional1` would have swallowed the positional as the flag's value) redesigned to require `=`, and a wrong expected value in my own `multi-asset-summary` test.
- `npm run typecheck`, `npm test` (284/284 passing on top of `drips`), and `npm run build` all clean on top of this branch.
- All changes are confined to `contrib/examples/`; verified `git status` shows no files touched outside `contrib/`.