### PR TITLE
feat(contrib): session scheduler, x402 fallback, headless signer, auto-refresh manager

### DIFF
--- a/contrib/examples/auto-refresh-manager/README.md
+++ b/contrib/examples/auto-refresh-manager/README.md
@@ -1,0 +1,69 @@
+# Auto-refresh session manager (capstone)
+
+A single exported `AutoRefreshManager` class that composes three concerns into
+one cohesive component so a long-running agent's session is transparently
+refreshed **before** it would ever expire:
+
+| concern       | responsibility                              | related example |
+| ------------- | ------------------------------------------- | --------------- |
+| **store**     | holds the current session                   | [`memory-session-store`](../memory-session-store/) |
+| **watcher**   | is it expired / how long left               | [`session-expiry-check`](../session-expiry-check/) |
+| **scheduler** | refresh just before expiry, then reschedule | [`session-refresh-scheduler`](../session-refresh-scheduler/) (issue #74) |
+
+It reuses vellar-sdk's real [`WalletSession`](../../../src/types.ts) and layers
+an `expiresAt` on top — the SDK's `WalletSession` tracks activity timestamps; an
+app that mints short-lived x402 session keys adds the expiry this manager
+schedules against.
+
+## API
+
+```ts
+const manager = new AutoRefreshManager({
+  leadTimeMs: 150,                 // refresh this long before expiry
+  refresh: async (previous) => mintNextSession(previous), // rotate the key
+});
+
+manager.start(initialSession);     // store + arm the scheduler
+manager.getSession();              // current session (store)
+manager.isExpired();               // has it lapsed? (watcher)
+manager.msUntilExpiry();           // time left in ms (watcher)
+manager.stop();                    // clear the pending timer (scheduler)
+```
+
+## Flow
+
+1. `start(session)` stores the session and arms a timer for `leadTimeMs` before
+   its `expiresAt`.
+2. When the timer fires, `refresh(previous)` mints the next session; the manager
+   updates the store and re-arms against the **new** expiry.
+3. Because each refresh precedes expiry, `isExpired()` stays `false` the whole
+   time the manager runs — even past the point where the original session would
+   have lapsed.
+4. `stop()` clears the pending timer.
+
+## Run it
+
+```sh
+npx tsx auto-refresh-manager.ts
+```
+
+```
+Starting manager (lifetime 400ms, refresh 150ms before expiry)
+[start]   session key-1, expires 2026-01-01T00:00:00.400Z
+[poll]    key=key-1 expired=false msLeft=150
+[refresh] rotating key-1 -> key-2 before expiry
+[poll]    key=key-2 expired=false msLeft=300
+[refresh] rotating key-2 -> key-3 before expiry
+[poll]    key=key-3 expired=false msLeft=150
+[poll]    key=key-3 expired=false msLeft=300
+[stop]    stopped after 3 generations; final key=key-3
+```
+
+## Tests
+
+Uses Vitest fake timers to prove the session stays live past the original
+expiry because it was refreshed in time:
+
+```sh
+npx vitest run contrib/examples/auto-refresh-manager
+```

--- a/contrib/examples/auto-refresh-manager/auto-refresh-manager.test.ts
+++ b/contrib/examples/auto-refresh-manager/auto-refresh-manager.test.ts
@@ -1,0 +1,103 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { AutoRefreshManager, type ManagedSession } from "./auto-refresh-manager";
+
+/** A managed session expiring `ms` from the (faked) current time. */
+function makeSession(expiresInMs: number, keyId: string): ManagedSession {
+  const nowIso = new Date().toISOString();
+  return {
+    accountId: "CTESTWALLET",
+    network: "testnet",
+    connected: true,
+    authMethod: "passkey",
+    createdAt: nowIso,
+    lastActiveAt: nowIso,
+    keyId,
+    expiresAt: new Date(Date.now() + expiresInMs).toISOString(),
+  };
+}
+
+describe("AutoRefreshManager", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("stores the initial session and reports it active", () => {
+    const refresh = vi.fn(async () => makeSession(1000, "key-2"));
+    const manager = new AutoRefreshManager({ leadTimeMs: 200, refresh });
+
+    manager.start(makeSession(1000, "key-1"));
+    expect(manager.getSession()?.keyId).toBe("key-1");
+    expect(manager.isExpired()).toBe(false);
+    manager.stop();
+  });
+
+  it("auto-refreshes before expiry and keeps the session live across time", async () => {
+    const lifetimeMs = 1000;
+    const leadTimeMs = 200;
+    let gen = 1;
+    const refresh = vi.fn(async (): Promise<ManagedSession> => {
+      gen += 1;
+      return makeSession(lifetimeMs, `key-${gen}`);
+    });
+
+    const manager = new AutoRefreshManager({ leadTimeMs, refresh });
+    manager.start(makeSession(lifetimeMs, "key-1"));
+
+    // Fire point is leadTimeMs before expiry, i.e. at 800ms.
+    await vi.advanceTimersByTimeAsync(801);
+    expect(refresh).toHaveBeenCalledTimes(1);
+    expect(manager.getSession()?.keyId).toBe("key-2");
+    expect(manager.isExpired()).toBe(false);
+
+    // Past the ORIGINAL session's 1000ms expiry — still live because refreshed.
+    await vi.advanceTimersByTimeAsync(400); // now at 1201ms
+    expect(manager.isExpired()).toBe(false);
+
+    // The refreshed session reschedules itself for a second refresh.
+    await vi.advanceTimersByTimeAsync(600); // now at ~1801ms (fire point of gen-2)
+    expect(refresh).toHaveBeenCalledTimes(2);
+    expect(manager.getSession()?.keyId).toBe("key-3");
+
+    manager.stop();
+  });
+
+  it("stop() halts further refreshes", async () => {
+    const refresh = vi.fn(async () => makeSession(1000, "later"));
+    const manager = new AutoRefreshManager({ leadTimeMs: 200, refresh });
+
+    manager.start(makeSession(1000, "key-1"));
+    manager.stop();
+
+    await vi.advanceTimersByTimeAsync(10_000);
+    expect(refresh).not.toHaveBeenCalled();
+  });
+
+  it("reports a lapsed session as expired when refresh is not armed", () => {
+    const refresh = vi.fn(async () => makeSession(1000, "x"));
+    const manager = new AutoRefreshManager({ leadTimeMs: 200, refresh });
+
+    // Never started: no stored session => treated as expired.
+    expect(manager.getSession()).toBeNull();
+    expect(manager.isExpired()).toBe(true);
+  });
+
+  it("routes a refresh error to onError without crashing", async () => {
+    const onError = vi.fn();
+    const refresh = vi.fn(async (): Promise<ManagedSession> => {
+      throw new Error("rotate failed");
+    });
+    const manager = new AutoRefreshManager({ leadTimeMs: 200, refresh, onError });
+
+    manager.start(makeSession(1000, "key-1"));
+    await vi.advanceTimersByTimeAsync(1000);
+
+    expect(refresh).toHaveBeenCalledTimes(1);
+    expect(onError).toHaveBeenCalledTimes(1);
+    expect(onError.mock.calls[0]?.[0]).toBeInstanceOf(Error);
+    manager.stop();
+  });
+});

--- a/contrib/examples/auto-refresh-manager/auto-refresh-manager.ts
+++ b/contrib/examples/auto-refresh-manager/auto-refresh-manager.ts
@@ -1,0 +1,178 @@
+// Example (capstone): a single exported AutoRefreshManager class that composes
+// three concerns into one cohesive component:
+//
+//   - a session STORE      (holds the current session; cf. memory-session-store)
+//   - an expiry WATCHER    (is it expired / how long left; cf. session-expiry-check)
+//   - a refresh SCHEDULER  (refresh just before expiry; cf. session-refresh-scheduler, #74)
+//
+// The result is a session that is transparently refreshed BEFORE it would ever
+// expire, so a long-running agent always holds a live key. Mock-driven, no
+// network. It reuses vellar-sdk's real `WalletSession` (src/types.ts) and layers
+// an `expiresAt` on top (the SDK's WalletSession tracks activity timestamps; an
+// app that mints short-lived x402 session keys adds the expiry).
+//
+// Run with: npx tsx auto-refresh-manager.ts
+
+import type { WalletSession } from "../../../src/types";
+
+/** A WalletSession plus the expiry this manager schedules against. */
+export interface ManagedSession extends WalletSession {
+  /** ISO 8601 timestamp at which the session (key) must be rotated. */
+  expiresAt: string;
+}
+
+export interface AutoRefreshOptions {
+  /** Fire the refresh this many milliseconds before expiry. */
+  leadTimeMs: number;
+  /** Mint the next session (rotate the key, extend expiry). */
+  refresh: (previous: ManagedSession) => Promise<ManagedSession>;
+  /** Clock source, injectable for tests. Defaults to Date.now. */
+  now?: () => number;
+  /** Called when a refresh throws. Defaults to console.error. */
+  onError?: (err: unknown) => void;
+}
+
+/**
+ * Combines a session store, an expiry watcher, and a refresh scheduler behind
+ * one class. Call `start(session)` to begin; the manager keeps the stored
+ * session refreshed until you `stop()`.
+ */
+export class AutoRefreshManager {
+  // --- store (cf. memory-session-store) ---
+  private session: ManagedSession | null = null;
+
+  // --- scheduler (cf. session-refresh-scheduler / issue #74) ---
+  private timer: ReturnType<typeof setTimeout> | undefined;
+  private stopped = false;
+
+  private readonly leadTimeMs: number;
+  private readonly refresh: (previous: ManagedSession) => Promise<ManagedSession>;
+  private readonly now: () => number;
+  private readonly onError: (err: unknown) => void;
+
+  constructor(options: AutoRefreshOptions) {
+    this.leadTimeMs = options.leadTimeMs;
+    this.refresh = options.refresh;
+    this.now = options.now ?? (() => Date.now());
+    this.onError = options.onError ?? ((err) => console.error("auto-refresh failed:", err));
+  }
+
+  /** Begin managing `session`: store it and arm the refresh timer. */
+  start(session: ManagedSession): void {
+    this.stopped = false;
+    this.setSession(session);
+    this.arm();
+  }
+
+  /** The current session, or null before start() / after stop(). (store) */
+  getSession(): ManagedSession | null {
+    return this.session;
+  }
+
+  /** Whether the stored session has passed its expiry. (watcher) */
+  isExpired(): boolean {
+    if (!this.session) return true;
+    return this.expiryOf(this.session) <= this.now();
+  }
+
+  /** Milliseconds until the stored session expires (negative if past). (watcher) */
+  msUntilExpiry(): number {
+    if (!this.session) return 0;
+    return this.expiryOf(this.session) - this.now();
+  }
+
+  /** Stop the manager and clear any pending refresh timer. (scheduler) */
+  stop(): void {
+    this.stopped = true;
+    if (this.timer !== undefined) {
+      clearTimeout(this.timer);
+      this.timer = undefined;
+    }
+  }
+
+  // --- internals ---
+
+  private setSession(session: ManagedSession): void {
+    this.session = session;
+  }
+
+  private expiryOf(session: ManagedSession): number {
+    const t = new Date(session.expiresAt).getTime();
+    if (Number.isNaN(t)) {
+      throw new RangeError(`"${session.expiresAt}" is not a valid ISO timestamp`);
+    }
+    return t;
+  }
+
+  private arm(): void {
+    if (this.stopped || !this.session) return;
+    const delay = Math.max(0, this.expiryOf(this.session) - this.leadTimeMs - this.now());
+    this.timer = setTimeout(() => {
+      void this.runRefresh();
+    }, delay);
+  }
+
+  private async runRefresh(): Promise<void> {
+    const current = this.session;
+    if (this.stopped || !current) return;
+    try {
+      const next = await this.refresh(current);
+      if (this.stopped) return;
+      this.setSession(next); // store update
+      this.arm(); // reschedule against the new expiry
+    } catch (err) {
+      this.onError(err);
+    }
+  }
+}
+
+// --- runnable demo -----------------------------------------------------------
+
+function makeSession(expiresInMs: number, keyId: string): ManagedSession {
+  const nowIso = new Date().toISOString();
+  return {
+    accountId: "CABC123SAMPLEWALLETCONTRACTADDRESSXXXXXXXXXXXXXXXXXXXXXX",
+    network: "testnet",
+    connected: true,
+    authMethod: "passkey",
+    createdAt: nowIso,
+    lastActiveAt: nowIso,
+    keyId,
+    expiresAt: new Date(Date.now() + expiresInMs).toISOString(),
+  };
+}
+
+async function main(): Promise<void> {
+  const lifetimeMs = 400;
+  const leadTimeMs = 150;
+  let generation = 1;
+
+  const manager = new AutoRefreshManager({
+    leadTimeMs,
+    refresh: async (previous) => {
+      generation += 1;
+      console.log(`[refresh] rotating ${previous.keyId} -> key-${generation} before expiry`);
+      return makeSession(lifetimeMs, `key-${generation}`);
+    },
+  });
+
+  console.log(`Starting manager (lifetime ${lifetimeMs}ms, refresh ${leadTimeMs}ms before expiry)`);
+  manager.start(makeSession(lifetimeMs, "key-1"));
+  console.log(`[start]   session ${manager.getSession()?.keyId}, expires ${manager.getSession()?.expiresAt}`);
+
+  // Sample the manager a few times across a window longer than one lifetime.
+  for (let i = 0; i < 4; i += 1) {
+    await new Promise((resolve) => setTimeout(resolve, 250));
+    const s = manager.getSession();
+    console.log(
+      `[poll]    key=${s?.keyId} expired=${manager.isExpired()} msLeft=${Math.round(manager.msUntilExpiry())}`,
+    );
+  }
+
+  manager.stop();
+  console.log(`[stop]    stopped after ${generation} generations; final key=${manager.getSession()?.keyId}`);
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main();
+}

--- a/contrib/examples/headless-agent-signer/README.md
+++ b/contrib/examples/headless-agent-signer/README.md
@@ -1,0 +1,63 @@
+# Headless agent signer
+
+Constructs a `createSessionKeySigner` from a **freshly generated** ed25519
+keypair and uses it to sign a hand-built sample x402 auth entry — entirely
+headless: no browser, no passkey, no external input.
+
+This is the **agent** x402 signing path (as opposed to the human passkey path).
+An ed25519 session key the agent holds signs each V1
+(`sorobanCredentialsAddress`) auth entry directly, producing the smart-wallet
+signature map a Vellar wallet's `__check_auth` accepts. The key's spending
+authority would be bounded on-chain by the spending-limit policy attached to it.
+
+It uses the SDK's real exports:
+[`createSessionKeySigner`](../../../src/x402-signer.ts),
+[`SmartAccountX402Signer`](../../../src/x402-types.ts), and `TESTNET` (for the
+network passphrase).
+
+> **Testnet only.** The keypair is generated fresh on every run and holds no
+> funds. Never fund it or reuse the secret for anything real.
+
+## Flow
+
+1. Generate a fresh ed25519 session keypair (`Keypair.random()`).
+2. Pick the smart-account wallet C-address the key signs for.
+3. Build the headless signer around the raw secret via `createSessionKeySigner`.
+4. Hand-build a minimal V1 auth entry (a dummy SEP-41 `transfer`) and sign it
+   with `signer.signAuthEntry(...)`, passing the testnet passphrase and an
+   expiration ledger.
+
+The result is inspected to confirm the credentials stayed **V1** (hosted x402
+facilitators reject V2), that the embedded signer key matches the generated
+public key, and that the signature is 64 bytes.
+
+## Run it
+
+```sh
+npx tsx headless-agent-signer.ts
+```
+
+```
+Headless agent signer (TESTNET ONLY — disposable key)
+
+1. Generated session key : GB...
+2. Smart-account wallet   : CA...
+3. Built + signed a sample V1 auth entry (expiration ledger 1000)
+4. Credentials kept V1    : true
+   Signature expiration   : 1000
+   Signer key matches      : true
+   Signature length (bytes): 64
+5. Signed entry XDR length: 288 chars
+
+WARNING: the session key above is disposable — do not fund or reuse it.
+```
+
+## Tests
+
+The test decodes the signed entry and additionally **cryptographically
+verifies** the ed25519 signature against the recomputed auth payload, proving
+the headless signer produced a valid signature:
+
+```sh
+npx vitest run contrib/examples/headless-agent-signer
+```

--- a/contrib/examples/headless-agent-signer/headless-agent-signer.test.ts
+++ b/contrib/examples/headless-agent-signer/headless-agent-signer.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "vitest";
+import { buildAuthorizationEntryPreimage, hash, xdr } from "@stellar/stellar-sdk";
+import { TESTNET } from "../../../src/config";
+import { runHeadlessSigning } from "./headless-agent-signer";
+
+describe("runHeadlessSigning", () => {
+  it("signs a sample auth entry with a freshly generated session key", async () => {
+    const { sessionKeypair, walletAddress, signer, signedEntryXdr } = await runHeadlessSigning();
+
+    // The signer is wired to the generated wallet address.
+    expect(signer.address).toBe(walletAddress);
+    expect(walletAddress.startsWith("C")).toBe(true);
+    expect(walletAddress).toHaveLength(56);
+
+    const signed = xdr.SorobanAuthorizationEntry.fromXDR(signedEntryXdr, "base64");
+
+    // Credentials stay V1 (NOT upgraded to V2 — hosted facilitators require V1).
+    expect(signed.credentials().switch().name).toBe("sorobanCredentialsAddress");
+    const creds = signed.credentials().address();
+    expect(creds.signatureExpirationLedger()).toBe(1000);
+
+    // Signature is the smart-wallet map: Vec[ Map[ SignerKey -> Signature ] ].
+    const map = creds.signature().vec()?.[0]?.map();
+    expect(map).toHaveLength(1);
+    const key = map?.[0]?.key();
+    const val = map?.[0]?.val();
+
+    // SignerKey.Ed25519(pubkey) == the generated session key's raw public key.
+    expect(key?.vec()?.[0]?.sym().toString()).toBe("Ed25519");
+    expect(new Uint8Array(key?.vec()?.[1]?.bytes() ?? new Uint8Array())).toEqual(
+      new Uint8Array(sessionKeypair.rawPublicKey()),
+    );
+
+    // Signature.Ed25519(sig) — 64 bytes.
+    expect(val?.vec()?.[0]?.sym().toString()).toBe("Ed25519");
+    const sig = val?.vec()?.[1]?.bytes();
+    expect(sig).toHaveLength(64);
+  });
+
+  it("produces a signature that cryptographically verifies against the auth payload", async () => {
+    const { sessionKeypair, signedEntryXdr } = await runHeadlessSigning();
+
+    const signed = xdr.SorobanAuthorizationEntry.fromXDR(signedEntryXdr, "base64");
+    const creds = signed.credentials().address();
+
+    // Recompute the payload the signer hashed and signed: the preimage does not
+    // include the signature itself, so the signed entry reproduces it exactly.
+    const preimage = buildAuthorizationEntryPreimage(
+      signed,
+      creds.signatureExpirationLedger(),
+      TESTNET.networkPassphrase,
+    );
+    const payload = hash(preimage.toXDR());
+
+    const sig = creds.signature().vec()?.[0]?.map()?.[0]?.val().vec()?.[1]?.bytes();
+    expect(sig).toBeDefined();
+    expect(sessionKeypair.verify(payload, sig as Buffer)).toBe(true);
+  });
+
+  it("generates a different key on every run", async () => {
+    const a = await runHeadlessSigning();
+    const b = await runHeadlessSigning();
+    expect(a.sessionKeypair.publicKey()).not.toBe(b.sessionKeypair.publicKey());
+    expect(a.walletAddress).not.toBe(b.walletAddress);
+  });
+});

--- a/contrib/examples/headless-agent-signer/headless-agent-signer.ts
+++ b/contrib/examples/headless-agent-signer/headless-agent-signer.ts
@@ -1,0 +1,128 @@
+// Example: a fully HEADLESS agent signer. It generates a fresh ed25519 session
+// keypair, wraps it in vellar-sdk's real `createSessionKeySigner`
+// (src/x402-signer.ts), and signs a hand-built sample x402 auth entry — no
+// browser, no passkey, no external input.
+//
+// This is the "agent" x402 path: an ed25519 session key the agent holds signs
+// each V1 (`sorobanCredentialsAddress`) auth entry directly. The produced
+// signature is a smart-wallet signature map `Vec[Map[SignerKey -> Signature]]`
+// that a Vellar wallet's `__check_auth` accepts. Its spending authority would
+// be bounded on-chain by the spending-limit policy attached to the key.
+//
+// WARNING: TESTNET ONLY. The keypair is generated fresh on every run and holds
+// no funds. Never fund it or reuse it for anything real.
+//
+// Run with: npx tsx headless-agent-signer.ts
+
+import { Address, Keypair, StrKey, nativeToScVal, xdr } from "@stellar/stellar-sdk";
+import { createSessionKeySigner } from "../../../src/x402-signer";
+import type { SmartAccountX402Signer } from "../../../src/x402-types";
+import { TESTNET } from "../../../src/config";
+
+const EXPIRATION_LEDGER = 1_000;
+
+/**
+ * Build a minimal V1 (`sorobanCredentialsAddress`) auth entry for `payer`,
+ * authorizing a dummy SEP-41 `transfer` — just enough structure for the signer
+ * to set the expiration, hash the preimage, and sign. Mirrors the fixture used
+ * in `src/x402-signer.test.ts`.
+ */
+export function makeSampleAuthEntry(
+  payer: string,
+  tokenContract: string,
+  payTo: string,
+): xdr.SorobanAuthorizationEntry {
+  const credentials = xdr.SorobanCredentials.sorobanCredentialsAddress(
+    new xdr.SorobanAddressCredentials({
+      address: new Address(payer).toScAddress(),
+      nonce: xdr.Int64.fromString("42"),
+      signatureExpirationLedger: 0,
+      signature: xdr.ScVal.scvVoid(),
+    }),
+  );
+  const rootInvocation = new xdr.SorobanAuthorizedInvocation({
+    function: xdr.SorobanAuthorizedFunction.sorobanAuthorizedFunctionTypeContractFn(
+      new xdr.InvokeContractArgs({
+        contractAddress: new Address(tokenContract).toScAddress(),
+        functionName: "transfer",
+        args: [
+          nativeToScVal(payer, { type: "address" }),
+          nativeToScVal(payTo, { type: "address" }),
+          nativeToScVal(1n, { type: "i128" }),
+        ],
+      }),
+    ),
+    subInvocations: [],
+  });
+  return new xdr.SorobanAuthorizationEntry({ credentials, rootInvocation });
+}
+
+/** A fresh, disposable contract (C…) address — StrKey-encoded random bytes. */
+function randomContractAddress(): string {
+  return StrKey.encodeContract(Keypair.random().rawPublicKey());
+}
+
+export interface HeadlessSigningResult {
+  /** The freshly generated session key (TESTNET ONLY, disposable). */
+  sessionKeypair: Keypair;
+  /** The smart-account C-address the key signs for. */
+  walletAddress: string;
+  /** The signer built from the session key. */
+  signer: SmartAccountX402Signer;
+  /** The signed auth entry, base64 XDR. */
+  signedEntryXdr: string;
+}
+
+/**
+ * Generate a fresh session key, build the signer, and sign a sample auth entry
+ * end-to-end. Returns everything needed to inspect (or verify) the result.
+ */
+export async function runHeadlessSigning(): Promise<HeadlessSigningResult> {
+  // 1. Generate a fresh ed25519 session keypair (no external input).
+  const sessionKeypair = Keypair.random();
+
+  // 2. Pick the smart-account wallet the key is authorized to sign for.
+  const walletAddress = randomContractAddress();
+
+  // 3. Build the headless signer around the raw secret.
+  const signer = createSessionKeySigner({
+    address: walletAddress,
+    secretKey: sessionKeypair.secret(),
+  });
+
+  // 4. Hand-build a sample auth entry for that wallet and sign it.
+  const entry = makeSampleAuthEntry(walletAddress, randomContractAddress(), randomContractAddress());
+  const signedEntryXdr = await signer.signAuthEntry(entry.toXDR("base64"), {
+    networkPassphrase: TESTNET.networkPassphrase,
+    expirationLedger: EXPIRATION_LEDGER,
+  });
+
+  return { sessionKeypair, walletAddress, signer, signedEntryXdr };
+}
+
+async function main(): Promise<void> {
+  console.log("Headless agent signer (TESTNET ONLY — disposable key)\n");
+
+  const { sessionKeypair, walletAddress, signedEntryXdr } = await runHeadlessSigning();
+
+  console.log(`1. Generated session key : ${sessionKeypair.publicKey()}`);
+  console.log(`2. Smart-account wallet   : ${walletAddress}`);
+  console.log(`3. Built + signed a sample V1 auth entry (expiration ledger ${EXPIRATION_LEDGER})`);
+
+  const signed = xdr.SorobanAuthorizationEntry.fromXDR(signedEntryXdr, "base64");
+  const creds = signed.credentials().address();
+  const sigMap = creds.signature().vec()?.[0]?.map();
+  const signerKeyBytes = sigMap?.[0]?.key().vec()?.[1]?.bytes();
+  const sigBytes = sigMap?.[0]?.val().vec()?.[1]?.bytes();
+
+  console.log(`4. Credentials kept V1    : ${signed.credentials().switch().name === "sorobanCredentialsAddress"}`);
+  console.log(`   Signature expiration   : ${creds.signatureExpirationLedger()}`);
+  console.log(`   Signer key matches      : ${Buffer.compare(signerKeyBytes ?? Buffer.alloc(0), sessionKeypair.rawPublicKey()) === 0}`);
+  console.log(`   Signature length (bytes): ${sigBytes?.length}`);
+  console.log(`5. Signed entry XDR length: ${signedEntryXdr.length} chars`);
+  console.log("\nWARNING: the session key above is disposable — do not fund or reuse it.");
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main();
+}

--- a/contrib/examples/session-refresh-scheduler/README.md
+++ b/contrib/examples/session-refresh-scheduler/README.md
@@ -1,0 +1,56 @@
+# Session refresh scheduler
+
+A self-rescheduling timer that refreshes a wallet session shortly **before** it
+is due to expire, then re-arms itself against the expiry of the session the
+refresh returns. Mock-driven and timer-based — no network.
+
+A real Vellar session (`WalletSession` in `vellar-sdk`'s `src/types.ts`) tracks
+`createdAt` / `lastActiveAt`; an app that mints short-lived x402 session keys
+layers an expiry on top. This example models that expiry with an `expiresAt` ISO
+timestamp so a long-running agent never presents an expired key.
+
+## Flow
+
+1. `startRefreshScheduler(session, refresh, { leadTimeMs })` computes when the
+   session expires and arms a timer for `leadTimeMs` **before** that moment.
+2. When the timer fires it calls your `refresh()` function, which returns the
+   next session (a freshly minted key with a later `expiresAt`).
+3. The scheduler re-arms itself against the **new** expiry — repeating for as
+   long as the process runs.
+4. `stop()` clears any pending timer so nothing fires after you tear down.
+
+Edge cases handled:
+
+- If the session already expires within the lead time, the refresh fires
+  immediately (the delay is clamped to `0`).
+- A `refresh()` that throws is reported via `onError` and ends the loop rather
+  than crashing the timer.
+- An invalid `expiresAt` on the initial session throws synchronously.
+
+## Run it
+
+```sh
+npx tsx session-refresh-scheduler.ts
+```
+
+Uses a mock that mints 400ms sessions and refreshes 150ms before each expiry,
+so you can watch it reschedule a couple of times before it stops:
+
+```
+Starting scheduler (lifetime 400ms, refresh 150ms before expiry)
+[mint]    session #1 expires at 2026-01-01T00:00:00.400Z
+[refresh] refreshing session #1 before it expires
+[mint]    session #2 expires at 2026-01-01T00:00:00.650Z
+[refresh] refreshing session #2 before it expires
+[mint]    session #3 expires at 2026-01-01T00:00:00.900Z
+[stop]    scheduler stopped after 3 generations
+```
+
+## Tests
+
+Uses Vitest fake timers (`vi.advanceTimersByTimeAsync`) so the reschedule is
+observed deterministically with no real delays:
+
+```sh
+npx vitest run contrib/examples/session-refresh-scheduler
+```

--- a/contrib/examples/session-refresh-scheduler/session-refresh-scheduler.test.ts
+++ b/contrib/examples/session-refresh-scheduler/session-refresh-scheduler.test.ts
@@ -1,0 +1,95 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  startRefreshScheduler,
+  type ExpiringSession,
+  type RefreshFn,
+} from "./session-refresh-scheduler";
+
+/** A session expiring `ms` from the (faked) current time. */
+function sessionExpiringInMs(ms: number): ExpiringSession {
+  return { expiresAt: new Date(Date.now() + ms).toISOString() };
+}
+
+describe("startRefreshScheduler", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("fires the refresh leadTimeMs before expiry and reschedules on the new expiry", async () => {
+    const lifetimeMs = 1000;
+    const leadTimeMs = 200;
+    // Each refresh returns a fresh session with the same lifetime.
+    const refresh: RefreshFn = vi.fn(async () => sessionExpiringInMs(lifetimeMs));
+
+    const scheduler = startRefreshScheduler(sessionExpiringInMs(lifetimeMs), refresh, {
+      leadTimeMs,
+    });
+
+    // Nothing fires before the lead-time window (fire point is at 800ms).
+    await vi.advanceTimersByTimeAsync(lifetimeMs - leadTimeMs - 1);
+    expect(refresh).not.toHaveBeenCalled();
+
+    // Crossing the lead point triggers the first refresh...
+    await vi.advanceTimersByTimeAsync(2);
+    expect(refresh).toHaveBeenCalledTimes(1);
+
+    // ...and it reschedules itself: another full cycle triggers a second refresh.
+    await vi.advanceTimersByTimeAsync(lifetimeMs - leadTimeMs);
+    expect(refresh).toHaveBeenCalledTimes(2);
+
+    scheduler.stop();
+  });
+
+  it("stop() clears the pending timer so no further refresh runs", async () => {
+    const refresh: RefreshFn = vi.fn(async () => sessionExpiringInMs(1000));
+    const scheduler = startRefreshScheduler(sessionExpiringInMs(1000), refresh, {
+      leadTimeMs: 200,
+    });
+
+    scheduler.stop();
+    await vi.advanceTimersByTimeAsync(5000);
+    expect(refresh).not.toHaveBeenCalled();
+  });
+
+  it("fires immediately (delay clamped to 0) when expiry is already within the lead time", async () => {
+    const refresh: RefreshFn = vi.fn(async () => sessionExpiringInMs(1000));
+    // Expiry 50ms out but lead time is 200ms => fire point already passed.
+    const scheduler = startRefreshScheduler(sessionExpiringInMs(50), refresh, {
+      leadTimeMs: 200,
+    });
+
+    await vi.advanceTimersByTimeAsync(1);
+    expect(refresh).toHaveBeenCalledTimes(1);
+
+    scheduler.stop();
+  });
+
+  it("routes a refresh error to onError and stops rescheduling", async () => {
+    const onError = vi.fn();
+    const refresh: RefreshFn = vi.fn(async () => {
+      throw new Error("mint failed");
+    });
+    const scheduler = startRefreshScheduler(sessionExpiringInMs(1000), refresh, {
+      leadTimeMs: 200,
+      onError,
+    });
+
+    await vi.advanceTimersByTimeAsync(2000);
+    expect(refresh).toHaveBeenCalledTimes(1);
+    expect(onError).toHaveBeenCalledTimes(1);
+    expect(onError.mock.calls[0]?.[0]).toBeInstanceOf(Error);
+
+    scheduler.stop();
+  });
+
+  it("throws synchronously if the initial session has an invalid expiresAt", () => {
+    const refresh: RefreshFn = vi.fn(async () => sessionExpiringInMs(1000));
+    expect(() =>
+      startRefreshScheduler({ expiresAt: "not-a-date" }, refresh, { leadTimeMs: 100 }),
+    ).toThrow(RangeError);
+  });
+});

--- a/contrib/examples/session-refresh-scheduler/session-refresh-scheduler.ts
+++ b/contrib/examples/session-refresh-scheduler/session-refresh-scheduler.ts
@@ -1,0 +1,121 @@
+// Example: a self-rescheduling timer that refreshes a wallet session shortly
+// BEFORE it is due to expire, then re-arms itself against the expiry of the
+// session the refresh returns. Timer-based, mock-driven, no network.
+//
+// A real Vellar session (vellar-sdk's WalletSession, src/types.ts) tracks
+// createdAt / lastActiveAt; an app that mints short-lived x402 session keys
+// layers an expiry on top of that. This example models the expiry with an
+// `expiresAt` ISO timestamp and keeps the session alive by refreshing just
+// before it lapses — so a long-running agent never presents an expired key.
+//
+// Run with: npx tsx session-refresh-scheduler.ts
+
+/** The only slice of session state this scheduler needs: when it expires. */
+export interface ExpiringSession {
+  /** ISO 8601 timestamp at which the session expires. */
+  expiresAt: string;
+}
+
+/** Produces the next session (e.g. by minting a fresh session key). */
+export type RefreshFn = () => Promise<ExpiringSession>;
+
+export interface SchedulerOptions {
+  /** How long before expiry to fire the refresh, in milliseconds. */
+  leadTimeMs: number;
+  /** Clock source, injectable for tests. Defaults to Date.now. */
+  now?: () => number;
+  /** Called when a scheduled refresh throws. Defaults to console.error. */
+  onError?: (err: unknown) => void;
+}
+
+export interface RefreshScheduler {
+  /** Stop the scheduler and clear any pending refresh timer. */
+  stop(): void;
+}
+
+/**
+ * Starts a self-rescheduling refresh loop. It arms a timer to fire
+ * `leadTimeMs` before `session.expiresAt`; when the timer fires it calls
+ * `refresh()`, then re-arms against the expiry of the session that returns.
+ *
+ * If the session already expires within the lead time, the refresh fires
+ * immediately (the delay is clamped to 0). A refresh that throws is reported
+ * via `onError` and ends the loop (no further reschedule) — the caller can
+ * restart with a fresh session.
+ */
+export function startRefreshScheduler(
+  session: ExpiringSession,
+  refresh: RefreshFn,
+  options: SchedulerOptions,
+): RefreshScheduler {
+  const now = options.now ?? (() => Date.now());
+  const reportError =
+    options.onError ?? ((err: unknown) => console.error("scheduled refresh failed:", err));
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  let stopped = false;
+
+  function delayUntilRefresh(current: ExpiringSession): number {
+    const expiry = new Date(current.expiresAt).getTime();
+    if (Number.isNaN(expiry)) {
+      throw new RangeError(`"${current.expiresAt}" is not a valid ISO timestamp`);
+    }
+    return Math.max(0, expiry - options.leadTimeMs - now());
+  }
+
+  function arm(current: ExpiringSession): void {
+    if (stopped) return;
+    const delay = delayUntilRefresh(current);
+    timer = setTimeout(() => {
+      void (async () => {
+        try {
+          const next = await refresh();
+          arm(next); // reschedule against the new expiry
+        } catch (err) {
+          reportError(err);
+        }
+      })();
+    }, delay);
+  }
+
+  arm(session);
+
+  return {
+    stop() {
+      stopped = true;
+      if (timer !== undefined) {
+        clearTimeout(timer);
+        timer = undefined;
+      }
+    },
+  };
+}
+
+async function main(): Promise<void> {
+  const lifetimeMs = 400;
+  const leadTimeMs = 150;
+  let generation = 0;
+
+  const mint = (): ExpiringSession => {
+    generation += 1;
+    const expiresAt = new Date(Date.now() + lifetimeMs).toISOString();
+    console.log(`[mint]    session #${generation} expires at ${expiresAt}`);
+    return { expiresAt };
+  };
+
+  const refresh: RefreshFn = async () => {
+    console.log(`[refresh] refreshing session #${generation} before it expires`);
+    return mint();
+  };
+
+  console.log(`Starting scheduler (lifetime ${lifetimeMs}ms, refresh ${leadTimeMs}ms before expiry)`);
+  const scheduler = startRefreshScheduler(mint(), refresh, { leadTimeMs });
+
+  // Run long enough to observe at least two reschedules, then stop.
+  await new Promise((resolve) => setTimeout(resolve, 1000));
+  scheduler.stop();
+  console.log(`[stop]    scheduler stopped after ${generation} generations`);
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main();
+}

--- a/contrib/examples/x402-fetch-fallback/README.md
+++ b/contrib/examples/x402-fetch-fallback/README.md
@@ -1,0 +1,53 @@
+# x402 fetch with a lower-cost fallback
+
+Demonstrates an x402 (HTTP 402 "pay to unlock") request that handles a
+`PaymentRejectedError` by falling back **once** to a lower `maxAmount`, which
+selects a cheaper payment tier that settles within the wallet's budget.
+
+Everything runs against a **mock x402 client** and a **mock resource server**
+defined in this example — no network. The mock client implements the SDK's real
+[`X402Client`](../../../src/x402-types.ts) interface and throws the SDK's real
+`PaymentRejectedError`, so the control flow mirrors production.
+
+## Flow
+
+1. The resource server answers an unpaid request with a 402 challenge listing
+   two accepted tiers — **premium** (`800`) and **basic** (`400`) base units.
+2. The client pays the most premium tier it can afford under `maxAmount`. With
+   `maxAmount = 1000` it picks the premium `800`.
+3. The facilitator verifies the payment against the wallet's remaining on-chain
+   spending-limit budget (`500`). `800 > 500`, so it throws
+   `PaymentRejectedError` (`reason: "over_budget"`) — exactly what happens when
+   the on-chain policy blocks an over-budget transfer.
+4. `fetchWithPaymentFallback` catches that error and retries **exactly once**
+   with `fallbackMaxAmount = 450`. Now only the basic `400` tier is affordable;
+   it is chosen, `400 <= 500`, and the facilitator settles it.
+5. The unlocked resource (HTTP 200) and its settlement are returned.
+
+A second rejection, or any non-`PaymentRejectedError`, propagates without a
+further retry — the fallback happens at most once.
+
+## Run it
+
+```sh
+npx tsx x402-fetch-fallback.ts
+```
+
+```
+Remaining on-chain budget: 500 base units
+Premium tier: 800, basic tier: 400
+
+1. GET /reports/quarterly with maxAmount=1000 (fallback=450)...
+  ! payment rejected (over_budget): facilitator rejected payment of 800: exceeds remaining budget 500
+  > retrying once at lower maxAmount 450
+2. Unlocked (paid=true, status=200): {"url":"/reports/quarterly","report":"Q3 revenue up 12% YoY","unlocked":true}
+3. Settled 400 of CDLZFC3SYJYDZT7K67VZ75HPJVIEUVNIXF47ZG2FB2RMQQVU2HHGCYSC on testnet — tx mocktx-0001
+4. Server quoted 2x; facilitator settle attempts: 2
+   Remaining budget now: 100
+```
+
+## Tests
+
+```sh
+npx vitest run contrib/examples/x402-fetch-fallback
+```

--- a/contrib/examples/x402-fetch-fallback/x402-fetch-fallback.test.ts
+++ b/contrib/examples/x402-fetch-fallback/x402-fetch-fallback.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it } from "vitest";
+import { MaxAmountExceededError, PaymentRejectedError } from "../../../src/x402-types";
+import {
+  createMockFacilitator,
+  createMockResourceServer,
+  createMockX402Client,
+  fetchWithPaymentFallback,
+} from "./x402-fetch-fallback";
+
+const silent = { log: () => {} };
+
+function wire(remainingBudget: bigint) {
+  const server = createMockResourceServer();
+  const facilitator = createMockFacilitator({ remainingBudget });
+  const client = createMockX402Client({ server, facilitator, payer: "CPAYER" });
+  return { server, facilitator, client };
+}
+
+describe("mock x402 client", () => {
+  it("pays the most premium affordable tier and settles within budget", async () => {
+    const { client, facilitator } = wire(1000n);
+    const res = await client.fetch("/reports/quarterly", { maxAmount: 1000n });
+
+    expect(res.paid).toBe(true);
+    expect(res.response.status).toBe(200);
+    expect(res.settlement?.amount).toBe(800n); // premium tier
+    expect(facilitator.remaining()).toBe(200n);
+  });
+
+  it("throws PaymentRejectedError when the chosen tier exceeds the on-chain budget", async () => {
+    const { client } = wire(500n); // premium 800 > budget 500
+    await expect(client.fetch("/reports/quarterly", { maxAmount: 1000n })).rejects.toBeInstanceOf(
+      PaymentRejectedError,
+    );
+  });
+
+  it("refuses to sign when nothing fits maxAmount (MaxAmountExceededError, no settle)", async () => {
+    const { client, facilitator } = wire(1000n);
+    await expect(client.fetch("/reports/quarterly", { maxAmount: 100n })).rejects.toBeInstanceOf(
+      MaxAmountExceededError,
+    );
+    expect(facilitator.attempts()).toBe(0);
+  });
+});
+
+describe("fetchWithPaymentFallback", () => {
+  it("catches PaymentRejectedError and retries once at the lower maxAmount, then succeeds", async () => {
+    const { client, server, facilitator } = wire(500n);
+
+    const res = await fetchWithPaymentFallback(
+      client,
+      "/reports/quarterly",
+      { maxAmount: 1000n, fallbackMaxAmount: 450n },
+      silent,
+    );
+
+    expect(res.paid).toBe(true);
+    expect(res.settlement?.amount).toBe(400n); // basic tier, within budget
+    expect(server.quotes()).toBe(2); // one initial attempt + one fallback
+    expect(facilitator.attempts()).toBe(2); // rejected once, settled once
+    expect(facilitator.remaining()).toBe(100n); // 500 - 400
+  });
+
+  it("retries at most ONCE — a second rejection propagates", async () => {
+    const { client, server, facilitator } = wire(300n); // even basic 400 > budget
+
+    await expect(
+      fetchWithPaymentFallback(
+        client,
+        "/reports/quarterly",
+        { maxAmount: 1000n, fallbackMaxAmount: 450n },
+        silent,
+      ),
+    ).rejects.toBeInstanceOf(PaymentRejectedError);
+
+    expect(server.quotes()).toBe(2); // not more than two attempts
+    expect(facilitator.attempts()).toBe(2);
+  });
+
+  it("does not retry when the first attempt succeeds", async () => {
+    const { client, server } = wire(1000n);
+    const res = await fetchWithPaymentFallback(
+      client,
+      "/reports/quarterly",
+      { maxAmount: 1000n, fallbackMaxAmount: 450n },
+      silent,
+    );
+
+    expect(res.settlement?.amount).toBe(800n); // premium, no fallback needed
+    expect(server.quotes()).toBe(1);
+  });
+
+  it("does not retry on a non-PaymentRejectedError (e.g. MaxAmountExceededError)", async () => {
+    const { client, server } = wire(1000n);
+    await expect(
+      fetchWithPaymentFallback(
+        client,
+        "/reports/quarterly",
+        { maxAmount: 100n, fallbackMaxAmount: 50n },
+        silent,
+      ),
+    ).rejects.toBeInstanceOf(MaxAmountExceededError);
+    expect(server.quotes()).toBe(1); // failed before any retry
+  });
+});

--- a/contrib/examples/x402-fetch-fallback/x402-fetch-fallback.ts
+++ b/contrib/examples/x402-fetch-fallback/x402-fetch-fallback.ts
@@ -1,0 +1,259 @@
+// Example: an x402 (HTTP 402) "pay to unlock" flow with a lower-cost fallback.
+//
+// It wires up a MOCK x402 client and a MOCK resource server (both defined in
+// this file, no network) that mirror vellar-sdk's real surface:
+//   - the client implements the SDK's `X402Client` interface (src/x402-types.ts)
+//   - it throws the SDK's real `PaymentRejectedError` when the facilitator
+//     rejects a payment for exceeding the wallet's on-chain spending budget.
+//
+// The resource server offers two accepted tiers (a premium and a basic price).
+// The client pays the most premium tier it can afford under `maxAmount`. When
+// the facilitator rejects that payment as over-budget, `fetchWithPaymentFallback`
+// catches `PaymentRejectedError` and retries ONCE at a lower `maxAmount`, which
+// selects the cheaper tier and settles within budget.
+//
+// Run with: npx tsx x402-fetch-fallback.ts
+
+import {
+  DisallowedAssetError,
+  MaxAmountExceededError,
+  PaymentRejectedError,
+  type PaymentRequired,
+  type PaymentRequirements,
+  type SignedPayment,
+  type X402Client,
+  type X402FetchInit,
+  type X402Response,
+  type X402Settlement,
+} from "../../../src/x402-types";
+import type { Network } from "../../../src/types";
+
+// ── sample identifiers (mock; not validated on-chain) ───────────────────────
+const NETWORK_CAIP2 = "stellar:testnet";
+const USDC_SAC = "CDLZFC3SYJYDZT7K67VZ75HPJVIEUVNIXF47ZG2FB2RMQQVU2HHGCYSC"; // SEP-41 token (SAC)
+const PAY_TO = "CBIN4HTPJM2QLJ32DTRO6OCLIMM7TR7D74JDIPVQYLNYGL7SBWOXH5ND"; // resource server payee
+const PAYER = "CC5ZSTLTYKPNIFDSJ4233RVZPALGHHDBRTXGIN6Z3AJCWU57VR5ITXXR"; // our smart-account wallet
+
+const PREMIUM_AMOUNT = "800"; // base units
+const BASIC_AMOUNT = "400";
+
+// ── mock resource server ────────────────────────────────────────────────────
+
+export interface MockResourceServer {
+  /** Answer an unpaid request with a 402 challenge (two accepted tiers). */
+  quote(url: string): PaymentRequired;
+  /** Serve the unlocked content once a payment has been settled. */
+  deliver(url: string): Response;
+  /** How many times `quote()` was called — proves the retry count in tests. */
+  quotes(): number;
+}
+
+function requirement(amount: string, description: string): PaymentRequirements {
+  return {
+    scheme: "exact",
+    network: NETWORK_CAIP2,
+    asset: USDC_SAC,
+    amount,
+    payTo: PAY_TO,
+    maxTimeoutSeconds: 60,
+    extra: { description },
+  };
+}
+
+/** A mock x402 resource server offering a premium and a basic tier. */
+export function createMockResourceServer(): MockResourceServer {
+  let quoteCount = 0;
+  return {
+    quote(url) {
+      quoteCount += 1;
+      return {
+        x402Version: 2,
+        error: "payment required",
+        accepts: [
+          requirement(PREMIUM_AMOUNT, "premium quarterly report"),
+          requirement(BASIC_AMOUNT, "basic quarterly summary"),
+        ],
+        resource: { url, description: "Quarterly report", mimeType: "application/json" },
+      };
+    },
+    deliver(url) {
+      return new Response(
+        JSON.stringify({ url, report: "Q3 revenue up 12% YoY", unlocked: true }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      );
+    },
+    quotes: () => quoteCount,
+  };
+}
+
+// ── mock facilitator (enforces the wallet's remaining on-chain budget) ───────
+
+export interface MockFacilitator {
+  /** Verify + settle a payment. Throws PaymentRejectedError when over budget. */
+  settle(payment: SignedPayment): X402Settlement;
+  /** How many settle attempts were made — proves "retry at most once". */
+  attempts(): number;
+  /** Remaining spending-limit budget, in base units. */
+  remaining(): bigint;
+}
+
+export function createMockFacilitator(config: {
+  remainingBudget: bigint;
+  network?: Network;
+}): MockFacilitator {
+  let remaining = config.remainingBudget;
+  let attempts = 0;
+  let txSeq = 0;
+  const network = config.network ?? "testnet";
+
+  return {
+    settle(payment) {
+      attempts += 1;
+      if (payment.amount > remaining) {
+        // Mirrors the real flow: the on-chain spending-limit policy blocks the
+        // over-budget transfer, so the facilitator reports a rejection.
+        throw new PaymentRejectedError(
+          `facilitator rejected payment of ${payment.amount}: exceeds remaining budget ${remaining}`,
+          "over_budget",
+        );
+      }
+      remaining -= payment.amount;
+      txSeq += 1;
+      // The facilitator reads the payer out of the (mock) payment header.
+      const payer = payment.header.split(":")[3] ?? PAYER;
+      return {
+        transaction: `mocktx-${String(txSeq).padStart(4, "0")}`,
+        payer,
+        asset: payment.requirements.asset,
+        amount: payment.amount,
+        network,
+      };
+    },
+    attempts: () => attempts,
+    remaining: () => remaining,
+  };
+}
+
+// ── mock x402 client (implements the SDK's X402Client) ──────────────────────
+
+/** Pick the most premium tier the caller can afford under `maxAmount`
+ * (respecting `allowedAssets`), mirroring how a client maximizes service
+ * quality within budget. Throws the SDK's real errors when nothing fits. */
+function chooseRequirements(
+  accepts: PaymentRequirements[],
+  init: Pick<X402FetchInit, "maxAmount" | "allowedAssets">,
+): PaymentRequirements {
+  const byAsset = init.allowedAssets
+    ? accepts.filter((a) => init.allowedAssets!.includes(a.asset))
+    : accepts;
+  if (byAsset.length === 0) {
+    throw new DisallowedAssetError(accepts[0]?.asset ?? "?", init.allowedAssets ?? []);
+  }
+  const affordable = byAsset.filter((a) => BigInt(a.amount) <= init.maxAmount);
+  if (affordable.length === 0) {
+    const cheapest = byAsset.reduce((m, a) => (BigInt(a.amount) < BigInt(m.amount) ? a : m));
+    throw new MaxAmountExceededError(BigInt(cheapest.amount), init.maxAmount, cheapest.asset);
+  }
+  return affordable.reduce((m, a) => (BigInt(a.amount) > BigInt(m.amount) ? a : m));
+}
+
+export function createMockX402Client(config: {
+  server: MockResourceServer;
+  facilitator: MockFacilitator;
+  payer: string;
+}): X402Client {
+  async function createPayment(
+    requirements: PaymentRequirements,
+    opts: { maxAmount: bigint; allowedAssets?: string[] },
+  ): Promise<SignedPayment> {
+    if (opts.allowedAssets && !opts.allowedAssets.includes(requirements.asset)) {
+      throw new DisallowedAssetError(requirements.asset, opts.allowedAssets);
+    }
+    const amount = BigInt(requirements.amount);
+    if (amount > opts.maxAmount) {
+      throw new MaxAmountExceededError(amount, opts.maxAmount, requirements.asset);
+    }
+    return {
+      header: `mockpay:${requirements.asset}:${amount}:${config.payer}`,
+      requirements,
+      amount,
+    };
+  }
+
+  async function fetch(url: string, init: X402FetchInit): Promise<X402Response> {
+    const challenge = config.server.quote(url); // 402 + accepted tiers
+    const chosen = chooseRequirements(challenge.accepts, init); // most premium affordable
+    const payment = await createPayment(chosen, init); // "sign" the payment
+    const settlement = config.facilitator.settle(payment); // may throw PaymentRejectedError
+    return { response: config.server.deliver(url), paid: true, settlement };
+  }
+
+  return { fetch, createPayment };
+}
+
+// ── the fallback wrapper ────────────────────────────────────────────────────
+
+export interface FallbackFetchInit extends X402FetchInit {
+  /** `maxAmount` to retry with — once — if the first attempt is rejected. */
+  fallbackMaxAmount: bigint;
+}
+
+export interface FallbackOptions {
+  /** Injectable logger (tests pass a no-op). Defaults to console.log. */
+  log?: (message: string) => void;
+}
+
+/**
+ * Call `client.fetch(url, init)`. If it fails with `PaymentRejectedError`
+ * (the facilitator rejected the payment as over-budget), retry EXACTLY ONCE
+ * with `fallbackMaxAmount` — a lower ceiling that selects the cheaper tier.
+ * Any other error, and a second rejection, propagate to the caller.
+ */
+export async function fetchWithPaymentFallback(
+  client: X402Client,
+  url: string,
+  init: FallbackFetchInit,
+  options: FallbackOptions = {},
+): Promise<X402Response> {
+  const log = options.log ?? ((m: string) => console.log(m));
+  const { fallbackMaxAmount, ...first } = init;
+  try {
+    return await client.fetch(url, first);
+  } catch (err) {
+    if (!(err instanceof PaymentRejectedError)) throw err;
+    log(`  ! payment rejected (${err.reason ?? "unknown"}): ${err.message}`);
+    log(`  > retrying once at lower maxAmount ${fallbackMaxAmount}`);
+    return client.fetch(url, { ...first, maxAmount: fallbackMaxAmount });
+  }
+}
+
+async function main(): Promise<void> {
+  const server = createMockResourceServer();
+  const facilitator = createMockFacilitator({ remainingBudget: 500n });
+  const client = createMockX402Client({ server, facilitator, payer: PAYER });
+
+  console.log(`Remaining on-chain budget: ${facilitator.remaining()} base units`);
+  console.log(`Premium tier: ${PREMIUM_AMOUNT}, basic tier: ${BASIC_AMOUNT}`);
+  console.log("");
+  console.log("1. GET /reports/quarterly with maxAmount=1000 (fallback=450)...");
+
+  const res = await fetchWithPaymentFallback(client, "/reports/quarterly", {
+    maxAmount: 1000n,
+    fallbackMaxAmount: 450n,
+  });
+
+  const body = (await res.response.json()) as Record<string, unknown>;
+  console.log(`2. Unlocked (paid=${res.paid}, status=${res.response.status}): ${JSON.stringify(body)}`);
+  if (res.settlement) {
+    console.log(
+      `3. Settled ${res.settlement.amount} of ${res.settlement.asset} on ${res.settlement.network}` +
+        ` — tx ${res.settlement.transaction}`,
+    );
+  }
+  console.log(`4. Server quoted ${server.quotes()}x; facilitator settle attempts: ${facilitator.attempts()}`);
+  console.log(`   Remaining budget now: ${facilitator.remaining()}`);
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main();
+}


### PR DESCRIPTION
Adds four self-contained reference example modules under `contrib/examples/`, following the existing example conventions (self-contained `.ts` module + `.test.ts` + `README.md`, mock-based, no network). All work is confined to `contrib/` and the PR targets `drips`.

## Examples

- **`session-refresh-scheduler/`** (#74) — `startRefreshScheduler(session, refresh, { leadTimeMs })`: a self-rescheduling timer that fires `refresh()` `leadTimeMs` before `expiresAt`, then re-arms against the new expiry. `stop()` clears the pending timer. Handles clamp-to-zero, refresh errors (`onError`), and invalid timestamps.
- **`x402-fetch-fallback/`** (#78) — a mock resource server (two priced tiers) + mock facilitator (enforces an on-chain budget) + mock `X402Client`. Demonstrates catching the real `PaymentRejectedError` and retrying **once** at a lower `maxAmount`, selecting the cheaper tier that settles within budget. Script logs each step end to end.
- **`headless-agent-signer/`** (#79) — `runHeadlessSigning()` generates a fresh ed25519 keypair, builds a real `createSessionKeySigner`, hand-builds a V1 auth entry, and signs it entirely headless. The test cryptographically verifies the signature against the recomputed auth payload.
- **`auto-refresh-manager/`** (#80) — capstone `AutoRefreshManager` class composing an internal session store, expiry watcher, and refresh scheduler so a session stays live past its original expiry via pre-emptive refresh. Exposes `getSession` / `isExpired` / `msUntilExpiry` / `start` / `stop`.

## Test plan

- [x] Confined entirely to `contrib/` — no files touched outside it
- [x] PR base branch is `drips`
- [x] `npx vitest run contrib/examples/{session-refresh-scheduler,x402-fetch-fallback,headless-agent-signer,auto-refresh-manager}` → **4 files, 20 tests passing**
- [x] New example files typecheck clean under `tsc --noEmit`

Closes #74
Closes #78
Closes #79
Closes #80