### PR TITLE
Implemented and pushed four more contrib example modules entirely under contrib/examples/:

### DIFF
--- a/contrib/examples/format-settlement-receipt/README.md
+++ b/contrib/examples/format-settlement-receipt/README.md
@@ -1,0 +1,21 @@
+# format-settlement-receipt
+
+Formats an x402 settlement object into a readable receipt.
+
+## Usage
+
+```ts
+import { formatSettlementReceipt } from "./index";
+
+const receipt = formatSettlementReceipt({
+  transaction: "aaa111...",
+  payer: "CAAAA...",
+  asset: "CAAAA...",
+  amount: 1000000n,
+  network: "testnet",
+});
+
+console.log(receipt.lines.join("\n"));
+```
+
+Output includes Transaction, Payer, Asset, Amount (human-readable plus base), and Network. Missing optional fields are omitted cleanly.

--- a/contrib/examples/format-settlement-receipt/index.ts
+++ b/contrib/examples/format-settlement-receipt/index.ts
@@ -1,0 +1,42 @@
+/**
+ * Format an x402 settlement receipt for display.
+ */
+
+export interface FormattedReceipt {
+  lines: string[];
+}
+
+export interface FormatSettlementOptions {
+  /** Decimals used to convert base units to a human-readable amount. Default: 7. */
+  assetDecimals?: number;
+}
+
+const REQUIRED_FIELDS: { key: keyof import("../../../src/x402-types").X402Settlement; label: string }[] = [
+  { key: "transaction", label: "Transaction" },
+  { key: "payer", label: "Payer" },
+  { key: "asset", label: "Asset" },
+  { key: "amount", label: "Amount" },
+  { key: "network", label: "Network" },
+];
+
+export function formatSettlementReceipt(
+  settlement: import("../../../src/x402-types").X402Settlement,
+  opts?: FormatSettlementOptions,
+): FormattedReceipt {
+  const decimals = opts?.assetDecimals ?? 7;
+  const lines: string[] = [];
+
+  for (const field of REQUIRED_FIELDS) {
+    let value = settlement[field.key];
+    if (value === undefined || value === null) continue;
+
+    if (field.key === "amount") {
+      const num = Number(value) / Math.pow(10, decimals);
+      value = `${num} (base ${value.toString()})`;
+    }
+
+    lines.push(`${field.label}: ${value}`);
+  }
+
+  return { lines };
+}

--- a/contrib/examples/format-settlement-receipt/test.ts
+++ b/contrib/examples/format-settlement-receipt/test.ts
@@ -1,0 +1,35 @@
+import { formatSettlementReceipt } from "./index";
+import type { X402Settlement } from "../../../src/x402-types";
+
+console.log("format-settlement-receipt tests:");
+
+{
+  const settlement: X402Settlement = {
+    transaction: "aaa111bbb222ccc333ddd444eee555fff666777888",
+    payer: "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHHHHH",
+    asset: "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHHHHH",
+    amount: 1000000n,
+    network: "testnet",
+  };
+
+  const receipt = formatSettlementReceipt(settlement);
+  console.log(receipt.lines.join("\n"));
+  console.assert(receipt.lines.length >= 4, "expected at least 4 lines");
+}
+
+{
+  // Optional fields present/absent are handled cleanly.
+  const settlement: X402Settlement = {
+    transaction: "aaa111bbb222ccc333ddd444eee555fff666777888",
+    payer: "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHHHHH",
+    asset: "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHHHHH",
+    amount: 2500000n,
+    network: "testnet",
+  };
+
+  const receipt = formatSettlementReceipt(settlement, { assetDecimals: 7 });
+  console.log(receipt.lines.join("\n"));
+  console.assert(receipt.lines.some((l) => l.startsWith("Network:")), "network rendered when present");
+}
+
+console.log("format-settlement-receipt tests passed");

--- a/contrib/examples/full-create-connect/README.md
+++ b/contrib/examples/full-create-connect/README.md
@@ -1,0 +1,29 @@
+# full-create-connect
+
+Reference example demonstrating a full create and connect wallet flow using mocked passkey kit and backend dependencies.
+
+## Flow
+
+1. Create a new wallet (passkey registration + backend submission).
+2. Build a session from the result.
+3. Simulate a page reload.
+4. Reconnect using the resulting keyId.
+5. Backend lookup confirms the mapping.
+
+All dependencies are mocked within the example.
+
+## Usage
+
+```ts
+import { createMockPasskeyKit, createMockBackend, createWalletSession } from "./index";
+
+const kit = createMockPasskeyKit();
+const backend = createMockBackend();
+
+const { keyIdBase64, contractId, signedTx } = await kit.createWallet("App", "user");
+const { sessionId } = await backend.submitWalletCreation({ keyId: keyIdBase64, contractId, network: "testnet", signedTx });
+const session = createWalletSession(contractId, keyIdBase64, sessionId);
+
+// After reload:
+const reconnected = await kit.connectWallet({ keyId: keyIdBase64 });
+const lookup = await backend.lookupContractId({ keyId: keyIdBase64, network: "testnet" });

--- a/contrib/examples/full-create-connect/index.ts
+++ b/contrib/examples/full-create-connect/index.ts
@@ -1,0 +1,65 @@
+/**
+ * Reference example: full create and connect wallet flow with mocked passkey kit
+ * and backend dependencies.
+ *
+ * Demonstrates:
+ * - Creating a new wallet (passkey registration + backend submission)
+ * - Simulating a page reload
+ * - Reconnecting using the resulting keyId
+ */
+
+import type { WalletSession } from "../../../src/types";
+
+export interface MockPasskeyKitLike {
+  createWallet(app: string, user: string): Promise<{ keyIdBase64: string; contractId: string; signedTx: unknown }>;
+  connectWallet(opts?: { keyId?: string }): Promise<{ keyIdBase64: string; contractId: string }>;
+  wallet?: unknown;
+}
+
+export interface MockBackend {
+  submitWalletCreation(input: { keyId: string; contractId: string; network: string; signedTx: unknown }): Promise<{ sessionId: string }>;
+  lookupContractId(input: { keyId: string; network: string }): Promise<{ contractId: string; sessionId: string } | undefined>;
+}
+
+export function createMockPasskeyKit(): MockPasskeyKitLike {
+  return {
+    wallet: undefined,
+    async createWallet() {
+      return {
+        keyIdBase64: "key-" + Math.random().toString(36).slice(2, 10),
+        contractId: "C" + "A".repeat(55),
+        signedTx: "AAAA...",
+      };
+    },
+    async connectWallet(opts) {
+      return {
+        keyIdBase64: opts?.keyId ?? "key-reconnected",
+        contractId: "C" + "B".repeat(55),
+      };
+    },
+  };
+}
+
+export function createMockBackend(): MockBackend {
+  return {
+    async submitWalletCreation() {
+      return { sessionId: "sess-" + Math.random().toString(36).slice(2, 10) };
+    },
+    async lookupContractId(input) {
+      return { contractId: "C" + "B".repeat(55), sessionId: "sess-restored" };
+    },
+  };
+}
+
+export function createWalletSession(contractId: string, keyId: string | undefined, sessionId: string | undefined): WalletSession {
+  return {
+    accountId: contractId,
+    network: "testnet",
+    connected: true,
+    authMethod: "passkey",
+    createdAt: new Date().toISOString(),
+    lastActiveAt: new Date().toISOString(),
+    ...(keyId !== undefined && { keyId }),
+    ...(sessionId !== undefined && { serverSessionId: sessionId }),
+  };
+}

--- a/contrib/examples/full-create-connect/test.ts
+++ b/contrib/examples/full-create-connect/test.ts
@@ -1,0 +1,38 @@
+import { createMockPasskeyKit, createMockBackend, createWalletSession } from "./index";
+
+console.log("full-create-connect tests:");
+
+{
+  const kit = createMockPasskeyKit();
+  const backend = createMockBackend();
+
+  // 1) Create wallet
+  const { keyIdBase64, contractId, signedTx } = await kit.createWallet("TestApp", "test-user");
+  console.assert(keyIdBase64.length > 0, "expected keyId");
+  console.assert(contractId.length > 0, "expected contractId");
+  console.log("ok: createWallet → keyId:", keyIdBase64, "contractId:", contractId);
+
+  // 2) Backend submission
+  const { sessionId } = await backend.submitWalletCreation({ keyId: keyIdBase64, contractId, network: "testnet", signedTx });
+  console.assert(sessionId.length > 0, "expected sessionId");
+  console.log("ok: submitWalletCreation → sessionId:", sessionId);
+
+  // 3) Build session
+  const session = createWalletSession(contractId, keyIdBase64, sessionId);
+  console.assert(session.connected === true, "expected connected");
+  console.assert(session.keyId === keyIdBase64, "expected keyId in session");
+  console.log("ok: session created with keyId");
+
+  // 4) Simulate reload: reconnect using keyId
+  const reconnected = await kit.connectWallet({ keyId: keyIdBase64 });
+  console.assert(reconnected.keyIdBase64 === keyIdBase64, "expected same keyId on reconnect");
+  console.log("ok: reconnect with keyId → same keyId");
+
+  // 5) Backend lookup
+  const lookup = await backend.lookupContractId({ keyId: keyIdBase64, network: "testnet" });
+  console.assert(lookup !== undefined, "expected lookup result");
+  console.assert(lookup!.contractId.length > 0, "expected contractId from lookup");
+  console.log("ok: backend lookup → contractId:", lookup!.contractId);
+}
+
+console.log("full-create-connect tests passed");

--- a/contrib/examples/full-payment-flow/README.md
+++ b/contrib/examples/full-payment-flow/README.md
@@ -1,0 +1,28 @@
+# full-payment-flow
+
+Reference example demonstrating a full payment build, review, and submit flow using mocked SAC and backend clients.
+
+## Flow
+
+1. Build + simulate the SAC transfer.
+2. Review the payment details.
+3. Submit (with a simulated first-attempt failure and retry).
+
+All API calls are mocked within the example.
+
+## Usage
+
+```ts
+import { createMockSacClient, createMockBackend, runPaymentFlow } from "./index";
+
+const result = await runPaymentFlow({
+  from: "G...",
+  to: "G...",
+  token: { contractId: "C...", symbol: "USDC", decimals: 7 },
+  amount: 1000000n,
+  network: "testnet",
+  sac: createMockSacClient(),
+  backend: createMockBackend(true), // first submit fails
+});
+
+console.log(result.attempts, result.hash);

--- a/contrib/examples/full-payment-flow/index.ts
+++ b/contrib/examples/full-payment-flow/index.ts
@@ -1,0 +1,92 @@
+/**
+ * Reference example: full payment build, review, submit flow with mocked SAC and backend clients.
+ *
+ * Demonstrates:
+ * - Building a payment (SAC transfer simulation)
+ * - Reviewing the payment details
+ * - First submit attempt failing
+ * - Successful retry
+ */
+
+import type { TokenInfo } from "../../../src/balances";
+import type { PaymentReview } from "../../../src/payments";
+
+export interface MockSacClient {
+  transfer(
+    args: { from: string; to: string; amount: bigint },
+    options?: { timeoutInSeconds?: number },
+  ): Promise<unknown>;
+}
+
+export interface MockBackend {
+  submitTransaction(input: { signedXdr: string; network: "testnet" | "mainnet" }): Promise<{ hash: string }>;
+}
+
+export interface PaymentFlowResult {
+  review: PaymentReview;
+  hash: string;
+  attempts: number;
+}
+
+export function createMockSacClient(failFirst: boolean = false): MockSacClient {
+  let callCount = 0;
+  return {
+    async transfer() {
+      callCount++;
+      // Simulate a successful build/simulation.
+      return { toXDR: () => "AAAAAgAAAABk..." };
+    },
+  };
+}
+
+export function createMockBackend(failFirst: boolean = false): MockBackend {
+  let callCount = 0;
+  return {
+    async submitTransaction() {
+      callCount++;
+      if (failFirst && callCount === 1) {
+        throw new Error("simulated_submit_failure");
+      }
+      return { hash: `tx-hash-${callCount}-${Date.now()}` };
+    },
+  };
+}
+
+export async function runPaymentFlow(options: {
+  from: string;
+  to: string;
+  token: TokenInfo;
+  amount: bigint;
+  network: string;
+  sac: MockSacClient;
+  backend: MockBackend;
+}): Promise<PaymentFlowResult> {
+  const { from, to, token, amount, network, sac, backend } = options;
+
+  // 1. Build + simulate the transfer
+  const tx = await sac.transfer({ from, to, amount }, { timeoutInSeconds: 30 });
+
+  // 2. Review
+  const review: PaymentReview = { from, to, token, amount, network: network as "testnet" | "mainnet" };
+
+  // 3. Submit (with retry on failure)
+  let attempts = 0;
+  let lastError: Error | undefined;
+
+  for (let i = 0; i < 2; i++) {
+    attempts++;
+    try {
+      const result = await backend.submitTransaction({
+        signedXdr: typeof tx === "object" && tx !== null && "toXDR" in tx
+          ? (tx as { toXDR: () => string }).toXDR()
+          : String(tx),
+        network: network as "testnet" | "mainnet",
+      });
+      return { review, hash: result.hash, attempts };
+    } catch (err) {
+      lastError = err instanceof Error ? err : new Error(String(err));
+    }
+  }
+
+  throw lastError ?? new Error("submit failed after retries");
+}

--- a/contrib/examples/full-payment-flow/test.ts
+++ b/contrib/examples/full-payment-flow/test.ts
@@ -1,0 +1,44 @@
+import { createMockSacClient, createMockBackend, runPaymentFlow } from "./index";
+
+console.log("full-payment-flow tests:");
+
+// 1) Successful submit on first attempt
+{
+  const sac = createMockSacClient();
+  const backend = createMockBackend(false);
+
+  const result = await runPaymentFlow({
+    from: "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+    to: "GBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB",
+    token: { contractId: "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHHHHH", symbol: "USDC", decimals: 7 },
+    amount: 1000000n,
+    network: "testnet",
+    sac,
+    backend,
+  });
+
+  console.assert(result.attempts === 1, "expected 1 attempt on success");
+  console.assert(result.hash.length > 0, "expected hash");
+  console.log("ok: successful submit → 1 attempt, hash:", result.hash);
+}
+
+// 2) First attempt fails, retry succeeds
+{
+  const sac = createMockSacClient();
+  const backend = createMockBackend(true);
+
+  const result = await runPaymentFlow({
+    from: "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+    to: "GBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB",
+    token: { contractId: "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHHHHH", symbol: "USDC", decimals: 7 },
+    amount: 1000000n,
+    network: "testnet",
+    sac,
+    backend,
+  });
+
+  console.assert(result.attempts === 2, "expected 2 attempts on retry");
+  console.log("ok: first attempt failed, retry succeeded → 2 attempts, hash:", result.hash);
+}
+
+console.log("full-payment-flow tests passed");

--- a/contrib/examples/full-policy-flow/README.md
+++ b/contrib/examples/full-policy-flow/README.md
@@ -1,0 +1,29 @@
+# full-policy-flow
+
+Reference example demonstrating a full policy generate and simulate flow using a mocked policy API.
+
+## Flow
+
+1. List available templates.
+2. Generate a policy from a definition.
+3. Simulate the policy for a wallet (both accepted and rejected outcomes).
+4. Deploy an instance and record the deployment.
+
+All API calls are mocked within the example.
+
+## Usage
+
+```ts
+import { createMockPolicyApi } from "./index";
+
+const api = createMockPolicyApi();
+
+const templates = await api.listTemplates();
+const generated = await api.generate({ version: "1", type: "spending-limit", owners: ["G..."] });
+const simulate = await api.simulate(generated.id, "G...");
+
+if (simulate.ok) {
+  const { contractId } = await api.deployInstance(generated.id, "G...");
+  const recorded = await api.recordDeployment(generated.id, "tx-hash", contractId);
+  console.log(recorded.status);
+}

--- a/contrib/examples/full-policy-flow/index.ts
+++ b/contrib/examples/full-policy-flow/index.ts
@@ -1,0 +1,93 @@
+/**
+ * Reference example: full policy generate and simulate flow with a mocked policy API.
+ */
+
+import type {
+  PolicyDefinition,
+  PolicyTemplateInfo,
+  GeneratedPolicy,
+  SimulateResult,
+} from "../../../src/policy-types";
+
+export interface MockPolicyApi {
+  listTemplates(): Promise<PolicyTemplateInfo[]>;
+  generate(definition: PolicyDefinition): Promise<GeneratedPolicy>;
+  simulate(policyId: string, wallet: string): Promise<SimulateResult>;
+  deployInstance(policyId: string, wallet: string): Promise<{ contractId: string }>;
+  recordDeployment(policyId: string, txHash: string, contractId?: string): Promise<GeneratedPolicy>;
+}
+
+const TEMPLATES: PolicyTemplateInfo[] = [
+  {
+    type: "spending-limit",
+    title: "Daily spending limit",
+    description: "Limits total outbound spend per rolling day.",
+    enforcement: {
+      kind: "policy-contract",
+      wasmHash: "a".repeat(64),
+      constructorArgs: { dailyLimitStroops: "1000000000", windowSeconds: 86400 },
+    },
+  },
+  {
+    type: "signer-limits",
+    title: "Signer limits",
+    description: "Enforces on-chain signer thresholds.",
+    enforcement: { kind: "signer-limits" },
+  },
+];
+
+const POLICIES = new Map<string, GeneratedPolicy>();
+
+export function createMockPolicyApi(): MockPolicyApi {
+  return {
+    async listTemplates() {
+      return TEMPLATES;
+    },
+
+    async generate(definition) {
+      const policyId = `policy-${definition.type || "custom"}-${Date.now()}`;
+      const policy: GeneratedPolicy = {
+        id: policyId,
+        createdAt: new Date().toISOString(),
+        status: "generated",
+        definition,
+        policyHash: "b".repeat(64),
+        manifest: {
+          template: definition.type || "custom",
+          enforcement: { kind: "policy-contract", wasmHash: "a".repeat(64) },
+          network: "testnet",
+        },
+      };
+      POLICIES.set(policyId, policy);
+      return policy;
+    },
+
+    async simulate(policyId, wallet) {
+      // Example: reject when wallet starts with "GZZZ", accept otherwise.
+      if (wallet.startsWith("GZZZ")) {
+        return { ok: false, error: "simulated_failure" };
+      }
+      return { ok: true, minResourceFee: "100000" };
+    },
+
+    async deployInstance(policyId, wallet) {
+      if (!POLICIES.has(policyId)) {
+        throw new Error(`policy ${policyId} not generated`);
+      }
+      return { contractId: `C${policyId}`.slice(0, 56) };
+    },
+
+    async recordDeployment(policyId, txHash, contractId) {
+      const existing = POLICIES.get(policyId);
+      if (!existing) throw new Error(`policy ${policyId} not generated`);
+      const policy: GeneratedPolicy = {
+        ...existing,
+        status: "deployed",
+        instance: { contractId: contractId || "", txHash, deployedAt: new Date().toISOString() },
+        deployment: { contractId, txHash, deployedAt: new Date().toISOString() },
+      };
+      POLICIES.set(policyId, policy);
+      return policy;
+    },
+  };
+}

--- a/contrib/examples/full-policy-flow/test.ts
+++ b/contrib/examples/full-policy-flow/test.ts
@@ -1,0 +1,37 @@
+import { createMockPolicyApi } from "./index";
+
+console.log("full-policy-flow tests:");
+
+{
+  const api = createMockPolicyApi();
+
+  // 1) list templates
+  const templates = await api.listTemplates();
+  console.assert(templates.length >= 1, "expected templates");
+  console.log("ok: listTemplates →", templates.length, "templates");
+
+  // 2) generate policy
+  const definition: Parameters<typeof api.generate>[0] = { version: "1", type: "spending-limit", owners: ["GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"] };
+  const generated = await api.generate(definition);
+  console.assert(generated.status === "generated", "expected generated");
+  console.log("ok: generate →", generated.id);
+
+  // 3) simulate accepted
+  const accepted = await api.simulate(generated.id, "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA");
+  console.assert(accepted.ok === true, "expected accepted simulation");
+  console.log("ok: simulate accepted → ok=true");
+
+  // 4) simulate rejected
+  const rejected = await api.simulate(generated.id, "GZZZxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx");
+  console.assert(rejected.ok === false, "expected rejected simulation");
+  console.log("ok: simulate rejected → ok=false, error=", rejected.error);
+
+  // 5) deploy instance + record
+  const { contractId } = await api.deployInstance(generated.id, "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA");
+  const recorded = await api.recordDeployment(generated.id, "tx-hash-123", contractId);
+  console.assert(recorded.status === "deployed", "expected deployed status");
+  console.assert(recorded.instance !== undefined, "expected instance");
+  console.log("ok: deployInstance + recordDeployment → status=deployed");
+}
+
+console.log("full-policy-flow tests passed");


### PR DESCRIPTION
- contrib/examples/full-policy-flow — full policy generate and simulate flow with a mocked policy API, demonstrating listTemplates, generate, simulate (accepted + rejected), deployInstance, and recordDeployment.
- contrib/examples/format-settlement-receipt — formats an x402 settlement object into a readable receipt with human-readable amount conversion.
- contrib/examples/full-payment-flow — full payment build, review, submit flow with mocked SAC and backend clients, demonstrating a first-attempt failure and successful retry.
- contrib/examples/full-create-connect — full create and connect wallet flow with mocked passkey kit and backend, demonstrating create, session building, simulated reload, and reconnect via keyId.

Each module includes a README and a runnable test script. All changes are confined to contrib/. Committed and pushed to the drips branch.

closes #71
closes #75
closes #76
closes #77