### PR TITLE
feat(examples): x402 spend report generator

### DIFF
--- a/contrib/examples/x402-spend-report/README.md
+++ b/contrib/examples/x402-spend-report/README.md
@@ -1,0 +1,36 @@
+# x402 spend report generator
+
+Generates a spend report from a list of completed x402 settlements
+(`X402Settlement`, `src/x402-types.ts`), grouped by asset with per-asset
+totals, plus an overall settlement count.
+
+## The flow
+
+1. `generateSpendReport(settlements)` groups settlements by `asset`,
+   summing `amount` per group and counting settlements per group.
+2. The result's `byAsset` array is sorted alphabetically by asset for a
+   stable, readable report.
+3. `totalSettlements` reports the overall count across every asset, so a
+   reader can see both the aggregate and the per-asset breakdown at once.
+
+## Run it
+
+```sh
+npx tsx x402-spend-report.ts
+```
+
+Expected output (4 sample settlements, two of them in CUSDC):
+
+```
+Total settlements: 4
+
+CAQUA: 750000 (1 settlement)
+CNATIVE: 50000000 (1 settlement)
+CUSDC: 3500000 (2 settlements)
+```
+
+## Tests
+
+```sh
+npx vitest run contrib/examples/x402-spend-report
+```

--- a/contrib/examples/x402-spend-report/x402-spend-report.test.ts
+++ b/contrib/examples/x402-spend-report/x402-spend-report.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+import type { X402Settlement } from "../../../src/x402-types";
+import { generateSpendReport } from "./x402-spend-report";
+
+const settlement = (overrides: Partial<X402Settlement>): X402Settlement => ({
+  transaction: "tx",
+  payer: "CPAYER",
+  asset: "CUSDC",
+  amount: 0n,
+  network: "testnet",
+  ...overrides,
+});
+
+describe("generateSpendReport", () => {
+  it("sums amounts within the same asset group", () => {
+    const report = generateSpendReport([
+      settlement({ asset: "CUSDC", amount: 100n }),
+      settlement({ asset: "CUSDC", amount: 250n }),
+    ]);
+    expect(report.byAsset).toEqual([{ asset: "CUSDC", totalAmount: 350n, settlementCount: 2 }]);
+  });
+
+  it("reports the overall settlement count alongside per-asset breakdown", () => {
+    const report = generateSpendReport([
+      settlement({ asset: "CUSDC", amount: 100n }),
+      settlement({ asset: "CNATIVE", amount: 200n }),
+      settlement({ asset: "CNATIVE", amount: 300n }),
+    ]);
+    expect(report.totalSettlements).toBe(3);
+    expect(report.byAsset).toHaveLength(2);
+  });
+
+  it("sorts the asset breakdown alphabetically", () => {
+    const report = generateSpendReport([
+      settlement({ asset: "CZ", amount: 1n }),
+      settlement({ asset: "CA", amount: 1n }),
+      settlement({ asset: "CM", amount: 1n }),
+    ]);
+    expect(report.byAsset.map((g) => g.asset)).toEqual(["CA", "CM", "CZ"]);
+  });
+
+  it("returns an empty report for an empty settlement list", () => {
+    expect(generateSpendReport([])).toEqual({ totalSettlements: 0, byAsset: [] });
+  });
+});

--- a/contrib/examples/x402-spend-report/x402-spend-report.ts
+++ b/contrib/examples/x402-spend-report/x402-spend-report.ts
@@ -1,0 +1,67 @@
+// Example: generate a spend report from a list of completed x402
+// settlements (vellar-sdk's X402Settlement shape, src/x402-types.ts),
+// grouped by asset with per-asset totals and an overall settlement count.
+//
+// Run with: npx tsx x402-spend-report.ts
+
+import type { X402Settlement } from "../../../src/x402-types";
+
+export interface AssetTotal {
+  asset: string;
+  totalAmount: bigint;
+  settlementCount: number;
+}
+
+export interface SpendReport {
+  totalSettlements: number;
+  byAsset: AssetTotal[];
+}
+
+/** Groups settlements by asset, summing amounts per group. byAsset is
+ * sorted alphabetically by asset for a stable, readable report. */
+export function generateSpendReport(settlements: X402Settlement[]): SpendReport {
+  const totals = new Map<string, AssetTotal>();
+
+  for (const settlement of settlements) {
+    const existing = totals.get(settlement.asset);
+    if (existing) {
+      existing.totalAmount += settlement.amount;
+      existing.settlementCount++;
+    } else {
+      totals.set(settlement.asset, {
+        asset: settlement.asset,
+        totalAmount: settlement.amount,
+        settlementCount: 1,
+      });
+    }
+  }
+
+  return {
+    totalSettlements: settlements.length,
+    byAsset: [...totals.values()].sort((a, b) => a.asset.localeCompare(b.asset)),
+  };
+}
+
+function formatReport(report: SpendReport): string {
+  const lines = [`Total settlements: ${report.totalSettlements}`, ""];
+  for (const group of report.byAsset) {
+    lines.push(`${group.asset}: ${group.totalAmount} (${group.settlementCount} settlement${group.settlementCount === 1 ? "" : "s"})`);
+  }
+  return lines.join("\n");
+}
+
+function main() {
+  const sampleSettlements: X402Settlement[] = [
+    { transaction: "tx1", payer: "CAGENT1", asset: "CUSDC", amount: 2_500_000n, network: "testnet" },
+    { transaction: "tx2", payer: "CAGENT1", asset: "CUSDC", amount: 1_000_000n, network: "testnet" },
+    { transaction: "tx3", payer: "CAGENT2", asset: "CNATIVE", amount: 50_000_000n, network: "testnet" },
+    { transaction: "tx4", payer: "CAGENT1", asset: "CAQUA", amount: 750_000n, network: "testnet" },
+  ];
+
+  const report = generateSpendReport(sampleSettlements);
+  console.log(formatReport(report));
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main();
+}


### PR DESCRIPTION
## Summary
A reference example generating a spend report from completed x402 settlements, grouped by asset with totals.

closes #99

## Changes
- **#99 — x402-spend-report**: `generateSpendReport()` groups a list of `X402Settlement` records by asset, summing `amount` per group and counting settlements per group, alongside an overall `totalSettlements` count. Output sorted alphabetically by asset for a stable, readable report.

## Test plan
- Colocated `*.test.ts` (vitest) — 4 new tests, all passing.
- Ran the script directly (`npx tsx x402-spend-report.ts`) and confirmed output matches the README exactly.
- `npm run typecheck`, `npm test` (538/538 passing on top of `drips`), and `npm run build` all clean on top of this branch.
- All changes are confined to `contrib/examples/`; verified `git status` shows no files touched outside `contrib/`.