### PR TITLE
feat(examples): add policy template picker CLI

### DIFF
--- a/contrib/examples/issue-95-policy-template-picker/README.md
+++ b/contrib/examples/issue-95-policy-template-picker/README.md
@@ -1,0 +1,61 @@
+# Policy Template Picker CLI
+
+A self-contained reference example that lists mock Vellar policy templates and prints the parameter schema for a caller-selected template.
+
+## How to run
+
+```bash
+# From the repo root — list all templates
+npx ts-node contrib/examples/issue-95-policy-template-picker/picker.ts
+
+# Pick a specific template by zero-based index
+npx ts-node contrib/examples/issue-95-policy-template-picker/picker.ts 0
+npx ts-node contrib/examples/issue-95-policy-template-picker/picker.ts 2
+
+# Run the bundled sample (list + two valid picks + one out-of-range)
+npx ts-node contrib/examples/issue-95-policy-template-picker/run-sample.ts
+```
+
+## Sample output — listing
+
+```
+Available policy templates:
+
+  [0] Daily Spending Limit (spending-limit-daily)
+      Caps total spend per rolling 24-hour window; enforced on-chain by a deployed policy contract.
+  [1] Session-Key Signer Limits (session-key-only)
+      Restricts a session key to a fixed set of contract calls; enforced by the wallet's signer limits.
+  [2] Multi-Signer Approval (multi-signer-approval)
+      Requires M-of-N signers to approve a transaction before it is submitted.
+  [3] No Policy (unrestricted)
+      No spending restriction is attached; the wallet's normal signer thresholds apply.
+
+Run with an index (0–3) to view that template's parameter schema.
+```
+
+## Sample output — valid index (`picker.ts 0`)
+
+```
+Template [0]: Daily Spending Limit
+Type        : spending-limit-daily
+Description : Caps total spend per rolling 24-hour window; enforced on-chain by a deployed policy contract.
+Enforcement : {"kind":"policy-contract","wasmHash":"mock-wasm-hash-spending-limit","constructorArgs":{"dailyLimitStroops":"10000000","windowSeconds":86400}}
+
+Parameter schema:
+  dailyLimitStroops
+    type     : string (stroops)
+    required : required
+    desc     : Maximum spend in stroops per rolling 24-hour window (1 XLM = 10,000,000 stroops).
+  windowSeconds
+    type     : number
+    required : optional
+    desc     : Length of the rolling window in seconds. Defaults to 86400 (24 hours).
+```
+
+## Sample output — out-of-range index (`picker.ts 9`)
+
+```
+Error: index "9" is out of range. Valid range is 0–3.
+```
+
+The process exits with code 1 on an out-of-range index.

--- a/contrib/examples/issue-95-policy-template-picker/picker.ts
+++ b/contrib/examples/issue-95-policy-template-picker/picker.ts
@@ -1,0 +1,138 @@
+// Policy Template Picker CLI
+//
+// Usage: npx ts-node picker.ts <index>
+//
+// Lists available mock policy templates (index 0-based).
+// Provide an index to print that template's parameter schema.
+
+import type { PolicyTemplateInfo, Enforcement } from "../../../src/policy-types";
+
+interface TemplateWithParams extends PolicyTemplateInfo {
+  params: Record<string, { type: string; required: boolean; description: string }>;
+}
+
+export const POLICY_TEMPLATES: TemplateWithParams[] = [
+  {
+    type: "spending-limit-daily",
+    title: "Daily Spending Limit",
+    description:
+      "Caps total spend per rolling 24-hour window; enforced on-chain by a deployed policy contract.",
+    enforcement: {
+      kind: "policy-contract",
+      wasmHash: "mock-wasm-hash-spending-limit",
+      constructorArgs: { dailyLimitStroops: "10000000", windowSeconds: 86400 },
+    },
+    params: {
+      dailyLimitStroops: {
+        type: "string (stroops)",
+        required: true,
+        description: "Maximum spend in stroops per rolling 24-hour window (1 XLM = 10,000,000 stroops).",
+      },
+      windowSeconds: {
+        type: "number",
+        required: false,
+        description: "Length of the rolling window in seconds. Defaults to 86400 (24 hours).",
+      },
+    },
+  },
+  {
+    type: "session-key-only",
+    title: "Session-Key Signer Limits",
+    description:
+      "Restricts a session key to a fixed set of contract calls; enforced by the wallet's signer limits.",
+    enforcement: { kind: "signer-limits" },
+    params: {
+      allowedContractIds: {
+        type: "string[]",
+        required: true,
+        description: "List of contract IDs the session key is permitted to invoke.",
+      },
+      allowedFunctionNames: {
+        type: "string[]",
+        required: false,
+        description: "Optional allowlist of function names. Omit to permit all functions on the allowed contracts.",
+      },
+      expiresAt: {
+        type: "number (unix timestamp)",
+        required: false,
+        description: "Unix timestamp after which the session key is considered expired.",
+      },
+    },
+  },
+  {
+    type: "multi-signer-approval",
+    title: "Multi-Signer Approval",
+    description:
+      "Requires M-of-N signers to approve a transaction before it is submitted.",
+    enforcement: { kind: "policy-contract", wasmHash: "mock-wasm-hash-multisig" },
+    params: {
+      threshold: {
+        type: "number",
+        required: true,
+        description: "Minimum number of signers whose approval is required (M).",
+      },
+      signers: {
+        type: "string[] (Stellar public keys)",
+        required: true,
+        description: "Complete list of authorised signer public keys (N).",
+      },
+    },
+  },
+  {
+    type: "unrestricted",
+    title: "No Policy",
+    description:
+      "No spending restriction is attached; the wallet's normal signer thresholds apply.",
+    enforcement: { kind: "none" },
+    params: {},
+  },
+];
+
+export function listTemplates(): void {
+  console.log("Available policy templates:\n");
+  POLICY_TEMPLATES.forEach((t, i) => {
+    console.log(`  [${i}] ${t.title} (${t.type})`);
+    console.log(`      ${t.description}`);
+  });
+  console.log(`\nRun with an index (0–${POLICY_TEMPLATES.length - 1}) to view that template's parameter schema.`);
+}
+
+export function printTemplateSchema(indexStr: string): void {
+  const index = Number(indexStr);
+  if (!Number.isInteger(index) || index < 0 || index >= POLICY_TEMPLATES.length) {
+    console.error(
+      `Error: index "${indexStr}" is out of range. Valid range is 0–${POLICY_TEMPLATES.length - 1}.`
+    );
+    process.exitCode = 1;
+    return;
+  }
+
+  const template = POLICY_TEMPLATES[index];
+  console.log(`\nTemplate [${index}]: ${template.title}`);
+  console.log(`Type        : ${template.type}`);
+  console.log(`Description : ${template.description}`);
+  console.log(`Enforcement : ${JSON.stringify(template.enforcement)}`);
+
+  const paramEntries = Object.entries(template.params);
+  if (paramEntries.length === 0) {
+    console.log("\nParameter schema: (none — this template takes no parameters)");
+  } else {
+    console.log("\nParameter schema:");
+    for (const [name, meta] of paramEntries) {
+      const req = meta.required ? "required" : "optional";
+      console.log(`  ${name}`);
+      console.log(`    type     : ${meta.type}`);
+      console.log(`    required : ${req}`);
+      console.log(`    desc     : ${meta.description}`);
+    }
+  }
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  const arg = process.argv[2];
+  if (arg === undefined) {
+    listTemplates();
+  } else {
+    printTemplateSchema(arg);
+  }
+}

--- a/contrib/examples/issue-95-policy-template-picker/run-sample.ts
+++ b/contrib/examples/issue-95-policy-template-picker/run-sample.ts
@@ -1,0 +1,16 @@
+// Sample runner: demonstrates listing templates and picking a valid index,
+// then shows the error path for an out-of-range index.
+
+import { listTemplates, printTemplateSchema, POLICY_TEMPLATES } from "./picker";
+
+console.log("=== Listing all templates ===\n");
+listTemplates();
+
+console.log("\n=== Selecting template at index 0 ===");
+printTemplateSchema("0");
+
+console.log("\n=== Selecting template at index 2 ===");
+printTemplateSchema("2");
+
+console.log(`\n=== Out-of-range index (${POLICY_TEMPLATES.length}) ===`);
+printTemplateSchema(String(POLICY_TEMPLATES.length));


### PR DESCRIPTION
Closes #95
Closes #100
Closes #98
Closes #97

## Summary

Adds a self-contained CLI reference example under `contrib/examples/issue-95-policy-template-picker/` that lists four mock policy templates and prints the full parameter schema for a caller-selected template by zero-based index.

## Files added (all inside `contrib/`)

| File | Purpose |
|------|---------|
| `contrib/examples/issue-95-policy-template-picker/picker.ts` | Core CLI — lists templates when run with no arg; prints parameter schema for a given index; exits with code 1 and a clear error message for out-of-range indices |
| `contrib/examples/issue-95-policy-template-picker/run-sample.ts` | Sample runner that exercises listing, two valid picks, and one out-of-range error |
| `contrib/examples/issue-95-policy-template-picker/README.md` | Usage instructions and sample output for both the list view and schema view |

## What the CLI does

- **No argument** — prints an indexed list of all templates with type, title, and description
- **`picker.ts <index>`** — prints the selected template's type, description, enforcement info, and full parameter schema (name, type, required/optional, description for each param)
- **Out-of-range index** — prints `Error: index "N" is out of range. Valid range is 0–3.` and sets `process.exitCode = 1`

## Templates included

| Index | Type | Enforcement |
|-------|------|-------------|
| 0 | `spending-limit-daily` | policy-contract |
| 1 | `session-key-only` | signer-limits |
| 2 | `multi-signer-approval` | policy-contract |
| 3 | `unrestricted` | none |

## Sample run

```
$ npx ts-node contrib/examples/issue-95-policy-template-picker/picker.ts 0

Template [0]: Daily Spending Limit
Type        : spending-limit-daily
Enforcement : {"kind":"policy-contract","wasmHash":"mock-wasm-hash-spending-limit",...}

Parameter schema:
  dailyLimitStroops
    type     : string (stroops)
    required : required
    desc     : Maximum spend in stroops per rolling 24-hour window
  windowSeconds
    type     : number
    required : optional
    desc     : Length of the rolling window in seconds. Defaults to 86400.

$ npx ts-node contrib/examples/issue-95-policy-template-picker/picker.ts 9
Error: index "9" is out of range. Valid range is 0–3.
```