### PR TITLE
contrib: add reference examples for balance watcher, session key rotation, activity feed, and verification poller

### DIFF
--- a/contrib/examples/issue-88-balance-change-watcher/README.md
+++ b/contrib/examples/issue-88-balance-change-watcher/README.md
@@ -1,0 +1,36 @@
+# Balance Change Watcher
+
+A self-contained reference example that polls a balance source on an interval
+and emits a change event **only** when the returned value differs from the last
+observed value.
+
+## Flow
+
+1. `createBalanceWatcher(source, intervalMs)` starts an interval loop and
+   records the first balance silently (no event on the initial read).
+2. On every subsequent poll, if the new balance differs from the previous one,
+   all registered `ChangeHandler` callbacks are invoked with
+   `(newBalance, previousBalance)`.
+3. Call `watcher.subscribe(handler)` to register a listener.
+4. Call `watcher.stop()` to cancel the interval and end polling.
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| `balance-change-watcher.ts` | Core `createBalanceWatcher` implementation |
+| `demo.ts` | Script with a mock source whose value changes mid-run |
+
+## Running the demo
+
+```bash
+npx ts-node demo.ts
+```
+
+Expected output (values change at polls 4 and 6):
+
+```
+[change] 100.00 → 175.50
+[change] 175.50 → 200.00
+Watcher stopped.
+```

--- a/contrib/examples/issue-88-balance-change-watcher/balance-change-watcher.ts
+++ b/contrib/examples/issue-88-balance-change-watcher/balance-change-watcher.ts
@@ -1,0 +1,53 @@
+/**
+ * Balance change watcher (issue #88)
+ *
+ * Polls a balance source on a fixed interval and emits a "change" event only
+ * when the returned value differs from the previously observed value.
+ */
+
+export type BalanceSource = () => Promise<string>;
+export type ChangeHandler = (newBalance: string, previousBalance: string) => void;
+
+export interface BalanceWatcher {
+  subscribe: (handler: ChangeHandler) => void;
+  stop: () => void;
+}
+
+/**
+ * Create a watcher that polls `source` every `intervalMs` milliseconds.
+ * Call `subscribe` to register a handler; call `stop` to end polling.
+ */
+export function createBalanceWatcher(
+  source: BalanceSource,
+  intervalMs: number = 2000,
+): BalanceWatcher {
+  let lastBalance: string | null = null;
+  const handlers: ChangeHandler[] = [];
+  let timer: ReturnType<typeof setInterval> | null = null;
+
+  async function poll() {
+    const balance = await source();
+    if (lastBalance !== null && balance !== lastBalance) {
+      for (const handler of handlers) {
+        handler(balance, lastBalance);
+      }
+    }
+    lastBalance = balance;
+  }
+
+  // Run an initial poll immediately, then on the interval.
+  poll();
+  timer = setInterval(poll, intervalMs);
+
+  return {
+    subscribe(handler: ChangeHandler) {
+      handlers.push(handler);
+    },
+    stop() {
+      if (timer !== null) {
+        clearInterval(timer);
+        timer = null;
+      }
+    },
+  };
+}

--- a/contrib/examples/issue-88-balance-change-watcher/demo.ts
+++ b/contrib/examples/issue-88-balance-change-watcher/demo.ts
@@ -1,0 +1,31 @@
+/**
+ * Demo script for the balance change watcher (issue #88).
+ *
+ * A mock balance source returns a fixed value for the first few polls, then
+ * changes — showing that the watcher only fires when the value actually differs.
+ *
+ * Run: npx ts-node demo.ts
+ */
+
+import { createBalanceWatcher } from './balance-change-watcher';
+
+const VALUES = ['100.00', '100.00', '100.00', '175.50', '175.50', '200.00'];
+let callCount = 0;
+
+const mockSource = async (): Promise<string> => {
+  const value = VALUES[Math.min(callCount, VALUES.length - 1)];
+  callCount += 1;
+  return value;
+};
+
+const watcher = createBalanceWatcher(mockSource, 500);
+
+watcher.subscribe((newBalance, previousBalance) => {
+  console.log(`[change] ${previousBalance} → ${newBalance}`);
+});
+
+// Let the watcher run through all mock values then stop.
+setTimeout(() => {
+  watcher.stop();
+  console.log('Watcher stopped.');
+}, 3500);

--- a/contrib/examples/issue-93-session-key-rotation/README.md
+++ b/contrib/examples/issue-93-session-key-rotation/README.md
@@ -1,0 +1,49 @@
+# Session Key Rotation Helper
+
+A self-contained reference example that manages an in-memory registry of
+session keys where only one key is active at a time.
+
+## Flow
+
+1. `createSessionKeyRegistry()` returns a registry with no keys.
+2. `registry.rotate()` generates a new 32-byte hex key, marks the current
+   active key (if any) as `'retired'`, and returns the new key.
+3. `registry.activeKey()` returns the currently active key, or `null`.
+4. `registry.history()` returns all entries in chronological order, each with
+   `key`, `status`, `createdAt`, and (if retired) `retiredAt`.
+
+## Constraints
+
+- Only one key may be `'active'` at any time.
+- Retired keys remain in history and are never removed.
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| `session-key-rotation.ts` | Core `createSessionKeyRegistry` implementation |
+| `demo.ts` | Script that generates, rotates, and inspects keys |
+
+## Running the demo
+
+```bash
+npx ts-node demo.ts
+```
+
+Expected output:
+
+```
+--- Initial rotation ---
+Active key: <hex>
+
+--- Rotating to a new key ---
+Active key: <different hex>
+
+--- Key history ---
+  [retired] <key1 prefix>...  created=...  retired=...
+  [active ] <key2 prefix>...  created=...
+
+--- Confirming old key is retired ---
+key1 status: retired
+key2 is active: true
+```

--- a/contrib/examples/issue-93-session-key-rotation/demo.ts
+++ b/contrib/examples/issue-93-session-key-rotation/demo.ts
@@ -1,0 +1,29 @@
+/**
+ * Demo script for session key rotation (issue #93).
+ *
+ * Run: npx ts-node demo.ts
+ */
+
+import { createSessionKeyRegistry } from './session-key-rotation';
+
+const registry = createSessionKeyRegistry();
+
+console.log('--- Initial rotation ---');
+const key1 = registry.rotate();
+console.log('Active key:', key1);
+
+console.log('\n--- Rotating to a new key ---');
+const key2 = registry.rotate();
+console.log('Active key:', key2);
+
+console.log('\n--- Key history ---');
+for (const entry of registry.history()) {
+  const line = `  [${entry.status.padEnd(7)}] ${entry.key.slice(0, 16)}...  created=${entry.createdAt.toISOString()}`;
+  console.log(entry.retiredAt ? `${line}  retired=${entry.retiredAt.toISOString()}` : line);
+}
+
+console.log('\n--- Confirming old key is retired ---');
+const h = registry.history();
+const old = h.find(e => e.key === key1)!;
+console.log(`key1 status: ${old.status}`); // retired
+console.log(`key2 is active: ${registry.activeKey() === key2}`); // true

--- a/contrib/examples/issue-93-session-key-rotation/session-key-rotation.ts
+++ b/contrib/examples/issue-93-session-key-rotation/session-key-rotation.ts
@@ -1,0 +1,57 @@
+/**
+ * Session key rotation helper (issue #93)
+ *
+ * Maintains an in-memory registry of session keys. At most one key is active
+ * at a time; rotating to a new key marks the previous key as retired.
+ */
+
+import { randomBytes } from 'crypto';
+
+export type KeyStatus = 'active' | 'retired';
+
+export interface KeyEntry {
+  key: string;
+  status: KeyStatus;
+  createdAt: Date;
+  retiredAt?: Date;
+}
+
+export interface SessionKeyRegistry {
+  /** Generate and activate a new session key, retiring the current one. */
+  rotate: () => string;
+  /** Return the currently active key, or null if none exists yet. */
+  activeKey: () => string | null;
+  /** Return the full history of all keys in chronological order. */
+  history: () => KeyEntry[];
+}
+
+function generateKey(): string {
+  return randomBytes(32).toString('hex');
+}
+
+export function createSessionKeyRegistry(): SessionKeyRegistry {
+  const entries: KeyEntry[] = [];
+
+  return {
+    rotate() {
+      // Retire the current active key if one exists.
+      const current = entries.find(e => e.status === 'active');
+      if (current) {
+        current.status = 'retired';
+        current.retiredAt = new Date();
+      }
+
+      const newKey = generateKey();
+      entries.push({ key: newKey, status: 'active', createdAt: new Date() });
+      return newKey;
+    },
+
+    activeKey() {
+      return entries.find(e => e.status === 'active')?.key ?? null;
+    },
+
+    history() {
+      return [...entries];
+    },
+  };
+}

--- a/contrib/examples/issue-94-activity-feed-aggregator/README.md
+++ b/contrib/examples/issue-94-activity-feed-aggregator/README.md
@@ -1,0 +1,47 @@
+# Wallet Activity Feed Aggregator
+
+A self-contained reference example that merges payment history and policy change
+history into a single chronologically ordered activity feed where every item has
+a consistent shape.
+
+## Flow
+
+1. `aggregateFeed(payments, policyChanges)` accepts two arrays of raw records.
+2. Each record is normalised into an `ActivityItem` with `id`, `kind`,
+   `timestamp`, `summary`, and `meta`.
+3. The combined list is sorted **newest first** by `timestamp`.
+
+## Consistent item shape
+
+```ts
+interface ActivityItem {
+  id: string;
+  kind: 'payment' | 'policy_change';
+  timestamp: Date;
+  summary: string;         // human-readable one-liner
+  meta: Record<string, unknown>; // source-specific fields
+}
+```
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| `activity-feed-aggregator.ts` | Core `aggregateFeed` implementation |
+| `demo.ts` | Script with sample payments and policy changes |
+
+## Running the demo
+
+```bash
+npx ts-node demo.ts
+```
+
+Expected output (newest first):
+
+```
+[2026-07-05T08:15:00.000Z] (payment) Sent 9.99 USDC to GDEF...
+[2026-07-04T11:45:00.000Z] (policy_change) Policy pol-42: limit_updated
+[2026-07-03T14:30:00.000Z] (payment) Sent 120.00 USDC to GABC...
+[2026-07-02T09:00:00.000Z] (policy_change) Policy pol-42: activated
+[2026-07-01T10:00:00.000Z] (payment) Sent 50.00 USDC to GBXYZ...
+```

--- a/contrib/examples/issue-94-activity-feed-aggregator/activity-feed-aggregator.ts
+++ b/contrib/examples/issue-94-activity-feed-aggregator/activity-feed-aggregator.ts
@@ -1,0 +1,69 @@
+/**
+ * Wallet activity feed aggregator (issue #94)
+ *
+ * Merges payment history and policy change history into a single
+ * chronologically ordered feed where every item has a consistent shape.
+ */
+
+export type ActivityKind = 'payment' | 'policy_change';
+
+export interface ActivityItem {
+  id: string;
+  kind: ActivityKind;
+  timestamp: Date;
+  summary: string;
+  meta: Record<string, unknown>;
+}
+
+export interface PaymentRecord {
+  id: string;
+  amount: string;
+  currency: string;
+  to: string;
+  at: Date;
+}
+
+export interface PolicyChangeRecord {
+  id: string;
+  policyId: string;
+  changeType: string;
+  at: Date;
+}
+
+function fromPayment(p: PaymentRecord): ActivityItem {
+  return {
+    id: p.id,
+    kind: 'payment',
+    timestamp: p.at,
+    summary: `Sent ${p.amount} ${p.currency} to ${p.to}`,
+    meta: { amount: p.amount, currency: p.currency, to: p.to },
+  };
+}
+
+function fromPolicyChange(c: PolicyChangeRecord): ActivityItem {
+  return {
+    id: c.id,
+    kind: 'policy_change',
+    timestamp: c.at,
+    summary: `Policy ${c.policyId}: ${c.changeType}`,
+    meta: { policyId: c.policyId, changeType: c.changeType },
+  };
+}
+
+/**
+ * Merge payment records and policy change records into a single feed sorted
+ * newest-first.
+ */
+export function aggregateFeed(
+  payments: PaymentRecord[],
+  policyChanges: PolicyChangeRecord[],
+): ActivityItem[] {
+  const items: ActivityItem[] = [
+    ...payments.map(fromPayment),
+    ...policyChanges.map(fromPolicyChange),
+  ];
+
+  items.sort((a, b) => b.timestamp.getTime() - a.timestamp.getTime());
+
+  return items;
+}

--- a/contrib/examples/issue-94-activity-feed-aggregator/demo.ts
+++ b/contrib/examples/issue-94-activity-feed-aggregator/demo.ts
@@ -1,0 +1,25 @@
+/**
+ * Demo script for the activity feed aggregator (issue #94).
+ *
+ * Run: npx ts-node demo.ts
+ */
+
+import { aggregateFeed, PaymentRecord, PolicyChangeRecord } from './activity-feed-aggregator';
+
+const payments: PaymentRecord[] = [
+  { id: 'pay-1', amount: '50.00', currency: 'USDC', to: 'GBXYZ...', at: new Date('2026-07-01T10:00:00Z') },
+  { id: 'pay-2', amount: '120.00', currency: 'USDC', to: 'GABC...', at: new Date('2026-07-03T14:30:00Z') },
+  { id: 'pay-3', amount: '9.99', currency: 'USDC', to: 'GDEF...', at: new Date('2026-07-05T08:15:00Z') },
+];
+
+const policyChanges: PolicyChangeRecord[] = [
+  { id: 'pc-1', policyId: 'pol-42', changeType: 'activated', at: new Date('2026-07-02T09:00:00Z') },
+  { id: 'pc-2', policyId: 'pol-42', changeType: 'limit_updated', at: new Date('2026-07-04T11:45:00Z') },
+];
+
+const feed = aggregateFeed(payments, policyChanges);
+
+console.log('Activity feed (newest first):\n');
+for (const item of feed) {
+  console.log(`[${item.timestamp.toISOString()}] (${item.kind}) ${item.summary}`);
+}

--- a/contrib/examples/issue-96-verification-status-poller/README.md
+++ b/contrib/examples/issue-96-verification-status-poller/README.md
@@ -1,0 +1,44 @@
+# Verification Status Poller
+
+A self-contained reference example that polls a mock verification job until it
+reaches a terminal state (`verified` or `failed`), with a configurable maximum
+wait time.
+
+## Flow
+
+1. `pollVerificationStatus(jobId, fetcher, options)` starts an interval loop.
+2. On each tick it calls `fetcher(jobId)` to retrieve the current job.
+3. If the job status is `'verified'` or `'failed'` the promise resolves with
+   the final `VerificationJob`.
+4. If `maxWaitMs` elapses before a terminal status is reached, the promise
+   rejects with a descriptive timeout error.
+
+## Options
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `intervalMs` | `1000` | Polling interval in milliseconds |
+| `maxWaitMs` | `30000` | Maximum total wait before rejection |
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| `verification-status-poller.ts` | Core `pollVerificationStatus` implementation |
+| `demo.ts` | Script showing both success and timeout paths |
+
+## Running the demo
+
+```bash
+npx ts-node demo.ts
+```
+
+Expected output:
+
+```
+--- Success path ---
+Job resolved: status=verified
+
+--- Timeout path ---
+Correctly rejected: Verification job job-002 timed out after 1000ms
+```

--- a/contrib/examples/issue-96-verification-status-poller/demo.ts
+++ b/contrib/examples/issue-96-verification-status-poller/demo.ts
@@ -1,0 +1,49 @@
+/**
+ * Demo script for the verification status poller (issue #96).
+ *
+ * Demonstrates both the success path (job resolves in time) and the timeout
+ * path (job never reaches a terminal state within maxWaitMs).
+ *
+ * Run: npx ts-node demo.ts
+ */
+
+import { pollVerificationStatus, VerificationJob, JobStatus } from './verification-status-poller';
+
+// --- Success path: job transitions to 'verified' after a few polls ---
+
+function makeMockFetcher(transitions: JobStatus[], delayMs: number) {
+  let call = 0;
+  return async (_jobId: string): Promise<VerificationJob> => {
+    await new Promise(r => setTimeout(r, delayMs));
+    const status = transitions[Math.min(call, transitions.length - 1)];
+    call += 1;
+    return { id: _jobId, status };
+  };
+}
+
+async function main() {
+  console.log('--- Success path ---');
+  const successFetcher = makeMockFetcher(['pending', 'processing', 'verified'], 300);
+  try {
+    const result = await pollVerificationStatus('job-001', successFetcher, {
+      intervalMs: 400,
+      maxWaitMs: 5000,
+    });
+    console.log(`Job resolved: status=${result.status}`);
+  } catch (err) {
+    console.error('Unexpected error:', err);
+  }
+
+  console.log('\n--- Timeout path ---');
+  const stalledFetcher = makeMockFetcher(['pending', 'pending', 'pending'], 200);
+  try {
+    await pollVerificationStatus('job-002', stalledFetcher, {
+      intervalMs: 300,
+      maxWaitMs: 1000,
+    });
+  } catch (err) {
+    console.log(`Correctly rejected: ${(err as Error).message}`);
+  }
+}
+
+main();

--- a/contrib/examples/issue-96-verification-status-poller/verification-status-poller.ts
+++ b/contrib/examples/issue-96-verification-status-poller/verification-status-poller.ts
@@ -1,0 +1,61 @@
+/**
+ * Verification status poller (issue #96)
+ *
+ * Polls a mock verification job on an interval and resolves once the job
+ * reaches a terminal state. Rejects if the maximum wait time is exceeded.
+ */
+
+export type JobStatus = 'pending' | 'processing' | 'verified' | 'failed';
+
+export interface VerificationJob {
+  id: string;
+  status: JobStatus;
+}
+
+export type StatusFetcher = (jobId: string) => Promise<VerificationJob>;
+
+const TERMINAL_STATUSES: JobStatus[] = ['verified', 'failed'];
+
+export interface PollOptions {
+  /** How often to check, in milliseconds. Default: 1000 */
+  intervalMs?: number;
+  /** Maximum total wait time before rejecting, in milliseconds. Default: 30000 */
+  maxWaitMs?: number;
+}
+
+/**
+ * Poll `fetcher` for `jobId` until it reaches a terminal status or
+ * `maxWaitMs` elapses. Returns the final `VerificationJob` on success,
+ * or rejects with a timeout error.
+ */
+export function pollVerificationStatus(
+  jobId: string,
+  fetcher: StatusFetcher,
+  options: PollOptions = {},
+): Promise<VerificationJob> {
+  const intervalMs = options.intervalMs ?? 1000;
+  const maxWaitMs = options.maxWaitMs ?? 30000;
+
+  return new Promise((resolve, reject) => {
+    const start = Date.now();
+    let timer: ReturnType<typeof setInterval> | null = null;
+
+    async function check() {
+      if (Date.now() - start >= maxWaitMs) {
+        if (timer) clearInterval(timer);
+        reject(new Error(`Verification job ${jobId} timed out after ${maxWaitMs}ms`));
+        return;
+      }
+
+      const job = await fetcher(jobId);
+      if (TERMINAL_STATUSES.includes(job.status)) {
+        if (timer) clearInterval(timer);
+        resolve(job);
+      }
+    }
+
+    // First check immediately, then on interval.
+    check();
+    timer = setInterval(check, intervalMs);
+  });
+}


### PR DESCRIPTION
Closes #88
Closes #93
Closes #94
Closes #96

Adds four self-contained reference examples under `contrib/examples/`, each with an implementation file, a runnable demo script, and a README. All changes are entirely inside `contrib/`.

| Issue | Folder | What it does |
|-------|--------|-------------|
| #88 | `issue-88-balance-change-watcher/` | Polls a balance source on an interval; fires a change event only when the value differs from the last observed value |
| #93 | `issue-93-session-key-rotation/` | In-memory registry that generates session keys and retires the previous key on each rotation; only one key is active at a time |
| #94 | `issue-94-activity-feed-aggregator/` | Merges payment records and policy change records into a single feed with a consistent item shape, sorted newest first |
| #96 | `issue-96-verification-status-poller/` | Polls a mock verification job until it reaches a terminal state; rejects with a clear error if `maxWaitMs` elapses first |