### PR TITLE
contrib: add reference examples for issues 101, 102, 103, 105

### DIFF
--- a/contrib/examples/mock-device-pairing/README.md
+++ b/contrib/examples/mock-device-pairing/README.md
@@ -1,0 +1,60 @@
+# Mock device pairing flow for tests
+
+A mock version of the extension device pairing flow — **request**,
+**approve**, then **issue-session** — useful for wiring into a test suite
+that needs a "device is paired" scenario without a real browser extension.
+State is a plain in-memory `Map`; there's no network or WebAuthn involved.
+
+## Flow
+
+`createMockPairingFlow()` returns three functions sharing in-memory state:
+
+1. **`request(deviceLabel)`** — a device asks to be paired. Returns a
+   `PairingRequest` with `status: "pending"`.
+2. **`approve(requestId)`** — approves a pending request (in a real flow,
+   confirmed from an already-paired device). Throws for an unknown
+   `requestId`.
+3. **`issueSession(requestId)`** — issues a session for an **approved**
+   request only. Calling it on a request that is still `"pending"` (or
+   doesn't exist) **throws a clear error instead of returning a session** —
+   a real backend must never hand out a session before the paired device
+   confirms.
+
+## Usage
+
+```ts
+import { createMockPairingFlow } from "./mock-device-pairing";
+
+const flow = createMockPairingFlow();
+
+const req = flow.request("Chrome extension on laptop"); // status: "pending"
+flow.issueSession(req.requestId); // throws: not approved yet
+
+flow.approve(req.requestId); // status: "approved"
+const session = flow.issueSession(req.requestId); // { sessionId, requestId, deviceLabel, issuedAt }
+```
+
+## Run it
+
+```sh
+npx tsx mock-device-pairing.ts
+```
+
+Expected output:
+
+```
+Step 1: request pairing for 'Chrome extension on laptop'
+  requestId=req_1 status=pending
+Step 2: issue a session before approval (should fail)
+  error: Pairing request "req_1" is not approved yet (status: "pending")
+Step 3: approve the request
+  requestId=req_1 status=approved
+Step 4: issue the session now that it's approved
+  sessionId=sess_1 deviceLabel=Chrome extension on laptop
+```
+
+## Tests
+
+```sh
+npx vitest run contrib/examples/mock-device-pairing
+```

--- a/contrib/examples/mock-device-pairing/mock-device-pairing.test.ts
+++ b/contrib/examples/mock-device-pairing/mock-device-pairing.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "vitest";
+import { createMockPairingFlow } from "./mock-device-pairing";
+
+describe("createMockPairingFlow", () => {
+  it("starts a request as pending", () => {
+    const flow = createMockPairingFlow();
+    const req = flow.request("Test device");
+    expect(req.status).toBe("pending");
+    expect(req.deviceLabel).toBe("Test device");
+  });
+
+  it("issuing a session before approval throws instead of returning a session", () => {
+    const flow = createMockPairingFlow();
+    const req = flow.request("Test device");
+    expect(() => flow.issueSession(req.requestId)).toThrow(/not approved yet/);
+  });
+
+  it("approve marks a pending request as approved", () => {
+    const flow = createMockPairingFlow();
+    const req = flow.request("Test device");
+    const approved = flow.approve(req.requestId);
+    expect(approved.status).toBe("approved");
+  });
+
+  it("issues a session for an approved request", () => {
+    const flow = createMockPairingFlow();
+    const req = flow.request("Test device");
+    flow.approve(req.requestId);
+    const session = flow.issueSession(req.requestId);
+    expect(session.requestId).toBe(req.requestId);
+    expect(session.deviceLabel).toBe("Test device");
+    expect(session.sessionId).toBeTruthy();
+  });
+
+  it("approve throws for an unknown request id", () => {
+    const flow = createMockPairingFlow();
+    expect(() => flow.approve("does-not-exist")).toThrow(/No pairing request/);
+  });
+
+  it("issueSession throws for an unknown request id", () => {
+    const flow = createMockPairingFlow();
+    expect(() => flow.issueSession("does-not-exist")).toThrow(/No pairing request/);
+  });
+
+  it("issues distinct session ids for separate approved requests", () => {
+    const flow = createMockPairingFlow();
+    const reqA = flow.request("Device A");
+    const reqB = flow.request("Device B");
+    flow.approve(reqA.requestId);
+    flow.approve(reqB.requestId);
+    const sessionA = flow.issueSession(reqA.requestId);
+    const sessionB = flow.issueSession(reqB.requestId);
+    expect(sessionA.sessionId).not.toBe(sessionB.sessionId);
+  });
+
+  it("keeps requests from separate flow instances independent", () => {
+    const flowA = createMockPairingFlow();
+    const flowB = createMockPairingFlow();
+    const req = flowA.request("Device A");
+    expect(() => flowB.approve(req.requestId)).toThrow(/No pairing request/);
+  });
+});

--- a/contrib/examples/mock-device-pairing/mock-device-pairing.ts
+++ b/contrib/examples/mock-device-pairing/mock-device-pairing.ts
@@ -1,0 +1,104 @@
+// Example: a mock version of the extension device pairing flow — request,
+// approve, then issue a session — for use in tests without a real
+// extension. In-memory state only; no network or WebAuthn involved.
+//
+// Issuing a session for a pairing request that hasn't been approved yet
+// returns a clear error rather than a session, the same way a real backend
+// would refuse to hand out a session before the paired device confirms.
+//
+// Run with: npx tsx mock-device-pairing.ts
+
+export type PairingStatus = "pending" | "approved";
+
+export interface PairingRequest {
+  requestId: string;
+  deviceLabel: string;
+  status: PairingStatus;
+  requestedAt: string;
+}
+
+export interface PairedSession {
+  requestId: string;
+  sessionId: string;
+  deviceLabel: string;
+  issuedAt: string;
+}
+
+/** In-memory pairing authority: tracks requests by id and only issues a
+ * session once the matching request has been approved. */
+export function createMockPairingFlow() {
+  const requests = new Map<string, PairingRequest>();
+  let nextRequestSeq = 1;
+  let nextSessionSeq = 1;
+
+  return {
+    /** Step 1: a device asks to be paired. Starts out "pending". */
+    request(deviceLabel: string): PairingRequest {
+      const pairingRequest: PairingRequest = {
+        requestId: `req_${nextRequestSeq++}`,
+        deviceLabel,
+        status: "pending",
+        requestedAt: new Date().toISOString(),
+      };
+      requests.set(pairingRequest.requestId, pairingRequest);
+      return pairingRequest;
+    },
+
+    /** Step 2: approve a pending request (e.g. confirmed from an already
+     * paired device). Throws for an unknown request id. */
+    approve(requestId: string): PairingRequest {
+      const pairingRequest = requests.get(requestId);
+      if (!pairingRequest) {
+        throw new Error(`No pairing request with id "${requestId}"`);
+      }
+      pairingRequest.status = "approved";
+      return pairingRequest;
+    },
+
+    /** Step 3: issue a session for an approved request. Throws — rather
+     * than returning a session — if the request is unknown or still
+     * pending approval. */
+    issueSession(requestId: string): PairedSession {
+      const pairingRequest = requests.get(requestId);
+      if (!pairingRequest) {
+        throw new Error(`No pairing request with id "${requestId}"`);
+      }
+      if (pairingRequest.status !== "approved") {
+        throw new Error(`Pairing request "${requestId}" is not approved yet (status: "${pairingRequest.status}")`);
+      }
+      return {
+        requestId,
+        sessionId: `sess_${nextSessionSeq++}`,
+        deviceLabel: pairingRequest.deviceLabel,
+        issuedAt: new Date().toISOString(),
+      };
+    },
+  };
+}
+
+function main() {
+  const pairingFlow = createMockPairingFlow();
+
+  console.log("Step 1: request pairing for 'Chrome extension on laptop'");
+  const req = pairingFlow.request("Chrome extension on laptop");
+  console.log(`  requestId=${req.requestId} status=${req.status}`);
+
+  console.log("Step 2: issue a session before approval (should fail)");
+  try {
+    pairingFlow.issueSession(req.requestId);
+  } catch (err) {
+    console.log(`  error: ${(err as Error).message}`);
+  }
+
+  console.log("Step 3: approve the request");
+  const approved = pairingFlow.approve(req.requestId);
+  console.log(`  requestId=${approved.requestId} status=${approved.status}`);
+
+  console.log("Step 4: issue the session now that it's approved");
+  const session = pairingFlow.issueSession(req.requestId);
+  console.log(`  sessionId=${session.sessionId} deviceLabel=${session.deviceLabel}`);
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main();
+}

--- a/contrib/examples/policy-limit-recommender/README.md
+++ b/contrib/examples/policy-limit-recommender/README.md
@@ -1,0 +1,65 @@
+# Policy limit recommendation helper
+
+`recommendSpendingLimit()` suggests a spending limit value from a sample of
+an account's recent payment history, using a simple percentile-style
+calculation plus a headroom multiplier. It's an advisory number for a human
+to review before setting a real policy's `spendingLimits` value (see
+`src/types.ts`'s `PolicyDefinition`) — not a payment amount itself, so this
+example works in plain numbers rather than the fixed-point/bigint arithmetic
+other examples use for actual on-chain amounts.
+
+## The calculation
+
+1. Sort the sample ascending.
+2. Take the **90th percentile** (nearest-rank method) as the baseline —
+   "at or above 90% of past payments". Using a percentile instead of the raw
+   maximum means a single unusually large outlier payment doesn't single-handedly
+   set the limit.
+3. Multiply that baseline by a **1.5x headroom multiplier**, so the
+   recommended limit isn't a razor's edge against typical spend.
+
+Both the percentile and the headroom multiplier are configurable via
+`RecommendationOptions`.
+
+## Usage
+
+```ts
+import { recommendSpendingLimit } from "./policy-limit-recommender";
+
+const recommendation = recommendSpendingLimit([12, 8, 45, 15, 9, 60, 11, 14, 10, 13]);
+// {
+//   sampleSize: 10,
+//   percentile: 90,
+//   percentileValue: 45,
+//   headroomMultiplier: 1.5,
+//   recommendedLimit: 67.5,
+// }
+
+// Custom percentile / multiplier:
+recommendSpendingLimit(history, { percentile: 75, headroomMultiplier: 2 });
+```
+
+Throws for an empty sample, a negative or non-finite amount, or a percentile
+outside `(0, 100]` — a silently wrong recommendation would be worse than a
+loud failure here.
+
+## Run it
+
+```sh
+npx tsx policy-limit-recommender.ts
+```
+
+Expected output:
+
+```
+Sample: 10 payments
+P90 of sample: 45
+Headroom multiplier: 1.5x
+Recommended spending limit: 67.5
+```
+
+## Tests
+
+```sh
+npx vitest run contrib/examples/policy-limit-recommender
+```

--- a/contrib/examples/policy-limit-recommender/policy-limit-recommender.test.ts
+++ b/contrib/examples/policy-limit-recommender/policy-limit-recommender.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+import { recommendSpendingLimit } from "./policy-limit-recommender";
+
+describe("recommendSpendingLimit", () => {
+  it("uses the 90th percentile with 1.5x headroom by default", () => {
+    const amounts = [12, 8, 45, 15, 9, 60, 11, 14, 10, 13]; // sorted: 8 9 10 11 12 13 14 15 45 60
+    const result = recommendSpendingLimit(amounts);
+    expect(result.percentile).toBe(90);
+    expect(result.percentileValue).toBe(45); // rank = ceil(0.9*10) = 9 -> index 8 -> 45
+    expect(result.headroomMultiplier).toBe(1.5);
+    expect(result.recommendedLimit).toBe(67.5);
+    expect(result.sampleSize).toBe(10);
+  });
+
+  it("honors a custom percentile", () => {
+    const amounts = [10, 20, 30, 40, 50];
+    const result = recommendSpendingLimit(amounts, { percentile: 50 });
+    expect(result.percentileValue).toBe(30); // rank = ceil(0.5*5) = 3 -> index 2 -> 30
+  });
+
+  it("honors a custom headroom multiplier", () => {
+    const amounts = [100];
+    const result = recommendSpendingLimit(amounts, { headroomMultiplier: 2 });
+    expect(result.recommendedLimit).toBe(200);
+  });
+
+  it("uses the single value for a sample of one", () => {
+    const result = recommendSpendingLimit([42]);
+    expect(result.percentileValue).toBe(42);
+    expect(result.recommendedLimit).toBe(63);
+  });
+
+  it("does not mutate the input array", () => {
+    const amounts = [30, 10, 20];
+    recommendSpendingLimit(amounts);
+    expect(amounts).toEqual([30, 10, 20]);
+  });
+
+  it("throws for an empty sample", () => {
+    expect(() => recommendSpendingLimit([])).toThrow(/at least one historical payment/);
+  });
+
+  it("throws for a negative amount", () => {
+    expect(() => recommendSpendingLimit([10, -5])).toThrow(/not a valid non-negative payment amount/);
+  });
+
+  it("throws for a non-finite amount", () => {
+    expect(() => recommendSpendingLimit([10, Infinity])).toThrow(/not a valid non-negative payment amount/);
+  });
+
+  it("throws for a percentile of 0", () => {
+    expect(() => recommendSpendingLimit([10], { percentile: 0 })).toThrow(/percentile must be in/);
+  });
+
+  it("throws for a percentile above 100", () => {
+    expect(() => recommendSpendingLimit([10], { percentile: 101 })).toThrow(/percentile must be in/);
+  });
+});

--- a/contrib/examples/policy-limit-recommender/policy-limit-recommender.ts
+++ b/contrib/examples/policy-limit-recommender/policy-limit-recommender.ts
@@ -1,0 +1,87 @@
+// Example: suggest a spending limit value from a sample of an account's
+// recent payment history, using a simple percentile-style calculation plus
+// a headroom multiplier.
+//
+// This is an advisory number for a human to review before setting a real
+// policy.spendingLimits value (see src/types.ts's PolicyDefinition) — not a
+// payment amount itself, so plain numbers are fine here (contrast with
+// src/payments.ts's parseTokenAmount, which avoids floats because it
+// touches actual on-chain amounts).
+//
+// Run with: npx tsx policy-limit-recommender.ts
+
+export interface RecommendationOptions {
+  /** Percentile (0-100] of the sorted historical sample to use as the
+   * baseline before headroom is applied. Default: 90. */
+  percentile?: number;
+  /** Multiplier applied to the percentile value for headroom above typical
+   * spend. Default: 1.5. */
+  headroomMultiplier?: number;
+}
+
+export interface LimitRecommendation {
+  sampleSize: number;
+  percentile: number;
+  percentileValue: number;
+  headroomMultiplier: number;
+  recommendedLimit: number;
+}
+
+const DEFAULT_PERCENTILE = 90;
+const DEFAULT_HEADROOM_MULTIPLIER = 1.5;
+
+/** Nearest-rank percentile of a sample sorted ascending. */
+function percentileOf(sortedAmounts: number[], percentile: number): number {
+  const rank = Math.ceil((percentile / 100) * sortedAmounts.length);
+  const index = Math.min(Math.max(rank, 1), sortedAmounts.length) - 1;
+  return sortedAmounts[index]!;
+}
+
+/**
+ * Recommends a spending limit from a sample of historical payment amounts:
+ * takes the `percentile`-th value of the sorted sample (default 90th — "at
+ * or above 90% of past payments", which drops extreme outliers like a
+ * single unusually large payment), then multiplies it by
+ * `headroomMultiplier` (default 1.5x) so the limit isn't a razor's edge
+ * against typical activity.
+ */
+export function recommendSpendingLimit(
+  amounts: number[],
+  options: RecommendationOptions = {},
+): LimitRecommendation {
+  if (amounts.length === 0) {
+    throw new Error("amounts must contain at least one historical payment");
+  }
+  for (const amount of amounts) {
+    if (!Number.isFinite(amount) || amount < 0) {
+      throw new Error(`"${amount}" is not a valid non-negative payment amount`);
+    }
+  }
+
+  const percentile = options.percentile ?? DEFAULT_PERCENTILE;
+  if (percentile <= 0 || percentile > 100) {
+    throw new Error(`percentile must be in (0, 100], got ${percentile}`);
+  }
+  const headroomMultiplier = options.headroomMultiplier ?? DEFAULT_HEADROOM_MULTIPLIER;
+
+  const sorted = [...amounts].sort((a, b) => a - b);
+  const percentileValue = percentileOf(sorted, percentile);
+  const recommendedLimit = percentileValue * headroomMultiplier;
+
+  return { sampleSize: amounts.length, percentile, percentileValue, headroomMultiplier, recommendedLimit };
+}
+
+function main() {
+  const recentPayments = [12, 8, 45, 15, 9, 60, 11, 14, 10, 13];
+
+  const recommendation = recommendSpendingLimit(recentPayments);
+
+  console.log(`Sample: ${recommendation.sampleSize} payments`);
+  console.log(`P${recommendation.percentile} of sample: ${recommendation.percentileValue}`);
+  console.log(`Headroom multiplier: ${recommendation.headroomMultiplier}x`);
+  console.log(`Recommended spending limit: ${recommendation.recommendedLimit}`);
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main();
+}

--- a/contrib/examples/session-budget-dashboard-source/README.md
+++ b/contrib/examples/session-budget-dashboard-source/README.md
@@ -1,0 +1,66 @@
+# Session budget dashboard source
+
+A data source function, `buildSessionBudgetDashboardSource()`, that
+combines a mock session with a mock x402 budget tracker into a single flat
+object — session expiry info alongside remaining budget and recent spend —
+suitable for feeding a dashboard UI.
+
+## Returned shape
+
+```ts
+interface SessionBudgetDashboardSource {
+  accountId: string;
+  sessionExpiresAt: string;      // ISO timestamp, from the session
+  sessionStatus: "active" | "expiring_soon" | "expired";
+  totalBudget: bigint;           // from the budget tracker
+  remainingBudget: bigint;       // totalBudget - spent
+  recentSpend: { amount: bigint; at: string }[];
+}
+```
+
+`sessionStatus` is computed the same way as the `session-key-dashboard-source`
+example, given a simulated "now" (defaults to the real current time, but the
+demo and tests pass a fixed one for reproducibility):
+
+- **`expired`** — expiry is at or before now.
+- **`expiring_soon`** — expiry is within the next 24 hours.
+- **`active`** — expiry is more than 24 hours out.
+
+`remainingBudget` is simply `totalBudget - spent`; `recentSpend` is carried
+through from the input budget tracker unchanged.
+
+## Usage
+
+```ts
+import { buildSessionBudgetDashboardSource } from "./session-budget-dashboard-source";
+
+const source = buildSessionBudgetDashboardSource(
+  { accountId: "CACCOUNT...", expiresAt: "2026-07-01T00:00:00.000Z" },
+  { totalBudget: 1_000_000n, spent: 400_000n, recentSpend: [{ amount: 400_000n, at: "2026-06-15T10:00:00.000Z" }] },
+);
+// { accountId, sessionExpiresAt, sessionStatus: "active", totalBudget: 1000000n, remainingBudget: 600000n, recentSpend: [...] }
+```
+
+## Run it
+
+```sh
+npx tsx session-budget-dashboard-source.ts
+```
+
+Expected output (against a fixed `now` of `2026-06-15T12:00:00.000Z`, with
+a session expiring 8 hours later):
+
+```
+Account: CDASHBOARDDEMOACCOUNTXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+Session: expiring_soon (expires 2026-06-15T20:00:00.000Z)
+Budget: 350000 remaining of 1000000
+Recent spend:
+  300000 at 2026-06-15T09:00:00.000Z
+  350000 at 2026-06-15T11:30:00.000Z
+```
+
+## Tests
+
+```sh
+npx vitest run contrib/examples/session-budget-dashboard-source
+```

--- a/contrib/examples/session-budget-dashboard-source/session-budget-dashboard-source.test.ts
+++ b/contrib/examples/session-budget-dashboard-source/session-budget-dashboard-source.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "vitest";
+import { buildSessionBudgetDashboardSource, type MockBudgetTracker, type MockSession } from "./session-budget-dashboard-source";
+
+describe("buildSessionBudgetDashboardSource", () => {
+  const now = new Date("2026-06-15T12:00:00.000Z");
+
+  const session: MockSession = {
+    accountId: "CACCOUNT",
+    expiresAt: "2026-07-01T00:00:00.000Z", // well over 24h out
+  };
+
+  const budget: MockBudgetTracker = {
+    totalBudget: 1_000_000n,
+    spent: 400_000n,
+    recentSpend: [{ amount: 400_000n, at: "2026-06-15T10:00:00.000Z" }],
+  };
+
+  it("combines session and budget fields into one flat object", () => {
+    const result = buildSessionBudgetDashboardSource(session, budget, now);
+    expect(result).toEqual({
+      accountId: "CACCOUNT",
+      sessionExpiresAt: "2026-07-01T00:00:00.000Z",
+      sessionStatus: "active",
+      totalBudget: 1_000_000n,
+      remainingBudget: 600_000n,
+      recentSpend: [{ amount: 400_000n, at: "2026-06-15T10:00:00.000Z" }],
+    });
+  });
+
+  it("marks a session expiring within 24h as expiring_soon", () => {
+    const soon: MockSession = { accountId: "CACCOUNT", expiresAt: "2026-06-15T20:00:00.000Z" };
+    const result = buildSessionBudgetDashboardSource(soon, budget, now);
+    expect(result.sessionStatus).toBe("expiring_soon");
+  });
+
+  it("marks a session past its expiry as expired", () => {
+    const expired: MockSession = { accountId: "CACCOUNT", expiresAt: "2026-06-01T00:00:00.000Z" };
+    const result = buildSessionBudgetDashboardSource(expired, budget, now);
+    expect(result.sessionStatus).toBe("expired");
+  });
+
+  it("treats an expiry exactly at now as expired (inclusive boundary)", () => {
+    const atNow: MockSession = { accountId: "CACCOUNT", expiresAt: now.toISOString() };
+    const result = buildSessionBudgetDashboardSource(atNow, budget, now);
+    expect(result.sessionStatus).toBe("expired");
+  });
+
+  it("computes remainingBudget as totalBudget minus spent", () => {
+    const zeroSpent: MockBudgetTracker = { totalBudget: 500n, spent: 0n, recentSpend: [] };
+    const result = buildSessionBudgetDashboardSource(session, zeroSpent, now);
+    expect(result.remainingBudget).toBe(500n);
+  });
+
+  it("carries recentSpend through unchanged", () => {
+    const withHistory: MockBudgetTracker = {
+      totalBudget: 100n,
+      spent: 30n,
+      recentSpend: [
+        { amount: 10n, at: "2026-06-15T08:00:00.000Z" },
+        { amount: 20n, at: "2026-06-15T09:00:00.000Z" },
+      ],
+    };
+    const result = buildSessionBudgetDashboardSource(session, withHistory, now);
+    expect(result.recentSpend).toEqual(withHistory.recentSpend);
+  });
+});

--- a/contrib/examples/session-budget-dashboard-source/session-budget-dashboard-source.ts
+++ b/contrib/examples/session-budget-dashboard-source/session-budget-dashboard-source.ts
@@ -1,0 +1,100 @@
+// Example: a data source function that combines a mock session with a mock
+// x402 budget tracker into a single object suitable for feeding a
+// dashboard UI — session expiry info alongside remaining budget and recent
+// spend.
+//
+// Run with: npx tsx session-budget-dashboard-source.ts
+
+export type SessionExpiryStatus = "active" | "expiring_soon" | "expired";
+
+export interface MockSession {
+  accountId: string;
+  expiresAt: string;
+}
+
+export interface MockSpendRecord {
+  amount: bigint;
+  at: string;
+}
+
+export interface MockBudgetTracker {
+  totalBudget: bigint;
+  spent: bigint;
+  recentSpend: MockSpendRecord[];
+}
+
+export interface SessionBudgetDashboardSource {
+  accountId: string;
+  sessionExpiresAt: string;
+  sessionStatus: SessionExpiryStatus;
+  totalBudget: bigint;
+  remainingBudget: bigint;
+  recentSpend: MockSpendRecord[];
+}
+
+// A session within this window of expiry (but not yet expired) is
+// "expiring soon" — same 24h lead time as the session-key-dashboard-source
+// example, for the same reason: enough lead time for a dashboard to flag it.
+const EXPIRING_SOON_WINDOW_MS = 24 * 60 * 60 * 1000; // 24h
+
+function sessionStatusFor(expiresAt: string, now: Date): SessionExpiryStatus {
+  const msUntilExpiry = new Date(expiresAt).getTime() - now.getTime();
+  if (msUntilExpiry <= 0) return "expired";
+  if (msUntilExpiry <= EXPIRING_SOON_WINDOW_MS) return "expiring_soon";
+  return "active";
+}
+
+/**
+ * Combines a mock session and a mock budget tracker into a single flat
+ * object shaped for a dashboard UI: session expiry status alongside
+ * remaining budget and recent spend history. Given a simulated "now"
+ * (defaults to the real current time, but the demo and tests pass a fixed
+ * one for reproducibility).
+ */
+export function buildSessionBudgetDashboardSource(
+  session: MockSession,
+  budget: MockBudgetTracker,
+  now: Date = new Date(),
+): SessionBudgetDashboardSource {
+  return {
+    accountId: session.accountId,
+    sessionExpiresAt: session.expiresAt,
+    sessionStatus: sessionStatusFor(session.expiresAt, now),
+    totalBudget: budget.totalBudget,
+    remainingBudget: budget.totalBudget - budget.spent,
+    recentSpend: budget.recentSpend,
+  };
+}
+
+function main() {
+  // A fixed "now" so the example's output is reproducible.
+  const now = new Date("2026-06-15T12:00:00.000Z");
+
+  const session: MockSession = {
+    accountId: "CDASHBOARDDEMOACCOUNTXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+    expiresAt: "2026-06-15T20:00:00.000Z", // 8h out
+  };
+
+  const budget: MockBudgetTracker = {
+    totalBudget: 1_000_000n,
+    spent: 650_000n,
+    recentSpend: [
+      { amount: 300_000n, at: "2026-06-15T09:00:00.000Z" },
+      { amount: 350_000n, at: "2026-06-15T11:30:00.000Z" },
+    ],
+  };
+
+  const dashboardSource = buildSessionBudgetDashboardSource(session, budget, now);
+
+  console.log(`Account: ${dashboardSource.accountId}`);
+  console.log(`Session: ${dashboardSource.sessionStatus} (expires ${dashboardSource.sessionExpiresAt})`);
+  console.log(`Budget: ${dashboardSource.remainingBudget} remaining of ${dashboardSource.totalBudget}`);
+  console.log("Recent spend:");
+  for (const record of dashboardSource.recentSpend) {
+    console.log(`  ${record.amount} at ${record.at}`);
+  }
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main();
+}

--- a/contrib/examples/wallet-health-aggregator/README.md
+++ b/contrib/examples/wallet-health-aggregator/README.md
@@ -1,0 +1,68 @@
+# Wallet health check aggregator
+
+`runHealthAggregator()` runs three distinct mock health checks against a
+wallet and reports an overall status:
+
+1. **Session valid** — a session exists, is `connected`, and its
+   `expiresAt` is in the future (relative to the given "now").
+2. **Backend reachable** — a caller-supplied `pingBackend()` resolves
+   `true` (a `false` result and a thrown error are both reported as
+   distinct reasons).
+3. **RPC reachable** — same shape as the backend check, for a separate
+   `pingRpc()` — a wallet's server backend and its Soroban RPC node are
+   independent dependencies that can fail separately.
+
+## Overall status
+
+The overall status is **`"degraded"` if any single check fails** — there is
+no partial-credit state. It's only `"healthy"` when all three checks pass.
+
+## Usage
+
+```ts
+import { runHealthAggregator, formatReport } from "./wallet-health-aggregator";
+
+const report = await runHealthAggregator({
+  session: { connected: true, expiresAt: "2026-07-01T00:00:00.000Z" },
+  pingBackend: () => fetch("/health").then((r) => r.ok),
+  pingRpc: () => fetch(rpcUrl).then((r) => r.ok),
+});
+
+console.log(formatReport(report)); // "Overall status: HEALTHY" / "DEGRADED"
+```
+
+## Run it
+
+```sh
+npx tsx wallet-health-aggregator.ts
+```
+
+Runs the aggregator twice: once with every check passing, once with the RPC
+check deliberately failing.
+
+Expected output:
+
+```
+Run 1: all checks passing
+
+Overall status: HEALTHY
+
+  ✓ Session valid
+  ✓ Backend reachable
+  ✓ RPC reachable
+
+
+Run 2: RPC check deliberately failing
+
+Overall status: DEGRADED
+
+  ✓ Session valid
+  ✓ Backend reachable
+  ✗ RPC reachable — RPC ping returned false
+```
+
+## Tests
+
+```sh
+npx vitest run contrib/examples/wallet-health-aggregator
+```

--- a/contrib/examples/wallet-health-aggregator/wallet-health-aggregator.test.ts
+++ b/contrib/examples/wallet-health-aggregator/wallet-health-aggregator.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it } from "vitest";
+import { runHealthAggregator, formatReport, type MockSession } from "./wallet-health-aggregator";
+
+describe("runHealthAggregator", () => {
+  const now = new Date("2026-06-15T12:00:00.000Z");
+  const validSession: MockSession = { connected: true, expiresAt: "2026-07-01T00:00:00.000Z" };
+
+  it("reports healthy when all three checks pass", async () => {
+    const report = await runHealthAggregator({
+      session: validSession,
+      pingBackend: async () => true,
+      pingRpc: async () => true,
+      now,
+    });
+    expect(report.status).toBe("healthy");
+    expect(report.checks).toHaveLength(3);
+    expect(report.checks.every((c) => c.passed)).toBe(true);
+  });
+
+  it("reports degraded when the session is missing", async () => {
+    const report = await runHealthAggregator({
+      session: null,
+      pingBackend: async () => true,
+      pingRpc: async () => true,
+      now,
+    });
+    expect(report.status).toBe("degraded");
+    const sessionCheck = report.checks.find((c) => c.name === "Session valid");
+    expect(sessionCheck?.passed).toBe(false);
+    expect(sessionCheck?.reason).toMatch(/No active session/);
+  });
+
+  it("reports degraded when the session is not connected", async () => {
+    const report = await runHealthAggregator({
+      session: { connected: false, expiresAt: "2026-07-01T00:00:00.000Z" },
+      pingBackend: async () => true,
+      pingRpc: async () => true,
+      now,
+    });
+    expect(report.status).toBe("degraded");
+  });
+
+  it("reports degraded when the session is expired", async () => {
+    const report = await runHealthAggregator({
+      session: { connected: true, expiresAt: "2026-06-01T00:00:00.000Z" },
+      pingBackend: async () => true,
+      pingRpc: async () => true,
+      now,
+    });
+    expect(report.status).toBe("degraded");
+  });
+
+  it("reports degraded when the backend is unreachable", async () => {
+    const report = await runHealthAggregator({
+      session: validSession,
+      pingBackend: async () => false,
+      pingRpc: async () => true,
+      now,
+    });
+    expect(report.status).toBe("degraded");
+    const backendCheck = report.checks.find((c) => c.name === "Backend reachable");
+    expect(backendCheck?.passed).toBe(false);
+  });
+
+  it("reports degraded when the RPC ping throws", async () => {
+    const report = await runHealthAggregator({
+      session: validSession,
+      pingBackend: async () => true,
+      pingRpc: async () => {
+        throw new Error("connection reset");
+      },
+      now,
+    });
+    expect(report.status).toBe("degraded");
+    const rpcCheck = report.checks.find((c) => c.name === "RPC reachable");
+    expect(rpcCheck?.reason).toMatch(/connection reset/);
+  });
+
+  it("reports degraded when a single check out of three fails", async () => {
+    const report = await runHealthAggregator({
+      session: validSession,
+      pingBackend: async () => true,
+      pingRpc: async () => false,
+      now,
+    });
+    expect(report.status).toBe("degraded");
+    expect(report.checks.filter((c) => c.passed)).toHaveLength(2);
+  });
+});
+
+describe("formatReport", () => {
+  it("renders passing and failing checks with reasons", async () => {
+    const report = await runHealthAggregator({
+      session: null,
+      pingBackend: async () => true,
+      pingRpc: async () => true,
+      now: new Date("2026-06-15T12:00:00.000Z"),
+    });
+    const text = formatReport(report);
+    expect(text).toContain("Overall status: DEGRADED");
+    expect(text).toContain("✗ Session valid — No active session");
+    expect(text).toContain("✓ Backend reachable");
+  });
+});

--- a/contrib/examples/wallet-health-aggregator/wallet-health-aggregator.ts
+++ b/contrib/examples/wallet-health-aggregator/wallet-health-aggregator.ts
@@ -1,0 +1,109 @@
+// Example: an aggregator that runs a handful of mock health checks —
+// session validity, backend reachability, and RPC reachability — and
+// reports an overall "healthy" or "degraded" status for a wallet.
+//
+// The overall status is "degraded" if ANY individual check fails; there is
+// no partial-credit state.
+//
+// Run with: npx tsx wallet-health-aggregator.ts
+
+export type HealthStatus = "healthy" | "degraded";
+
+export interface HealthCheckResult {
+  name: string;
+  passed: boolean;
+  /** Present only when passed is false. */
+  reason?: string;
+}
+
+export interface HealthReport {
+  status: HealthStatus;
+  checks: HealthCheckResult[];
+}
+
+export interface MockSession {
+  connected: boolean;
+  expiresAt: string;
+}
+
+export interface HealthAggregatorDeps {
+  session: MockSession | null;
+  pingBackend: () => Promise<boolean>;
+  pingRpc: () => Promise<boolean>;
+  now?: Date;
+}
+
+function checkSessionValid(session: MockSession | null, now: Date): HealthCheckResult {
+  const name = "Session valid";
+  if (!session) {
+    return { name, passed: false, reason: "No active session" };
+  }
+  if (!session.connected) {
+    return { name, passed: false, reason: "Session exists but is not connected" };
+  }
+  if (new Date(session.expiresAt).getTime() <= now.getTime()) {
+    return { name, passed: false, reason: `Session expired at ${session.expiresAt}` };
+  }
+  return { name, passed: true };
+}
+
+async function checkReachable(name: string, pingLabel: string, ping: () => Promise<boolean>): Promise<HealthCheckResult> {
+  try {
+    const ok = await ping();
+    if (!ok) return { name, passed: false, reason: `${pingLabel} ping returned false` };
+    return { name, passed: true };
+  } catch (err) {
+    return { name, passed: false, reason: `${pingLabel} ping threw: ${(err as Error).message}` };
+  }
+}
+
+/**
+ * Runs three mock health checks — session validity, backend reachability,
+ * RPC reachability — and reports the account "degraded" if any of them
+ * failed, "healthy" only if all of them passed.
+ */
+export async function runHealthAggregator(deps: HealthAggregatorDeps): Promise<HealthReport> {
+  const now = deps.now ?? new Date();
+  const checks = [
+    checkSessionValid(deps.session, now),
+    await checkReachable("Backend reachable", "Backend", deps.pingBackend),
+    await checkReachable("RPC reachable", "RPC", deps.pingRpc),
+  ];
+  return { status: checks.every((c) => c.passed) ? "healthy" : "degraded", checks };
+}
+
+/** Renders a HealthReport as readable text. */
+export function formatReport(report: HealthReport): string {
+  const lines: string[] = [`Overall status: ${report.status.toUpperCase()}`, ""];
+  for (const check of report.checks) {
+    lines.push(check.passed ? `  ✓ ${check.name}` : `  ✗ ${check.name} — ${check.reason}`);
+  }
+  return lines.join("\n");
+}
+
+async function main() {
+  const now = new Date("2026-06-15T12:00:00.000Z");
+  const validSession: MockSession = { connected: true, expiresAt: "2026-07-01T00:00:00.000Z" };
+
+  console.log("Run 1: all checks passing\n");
+  const healthy = await runHealthAggregator({
+    session: validSession,
+    pingBackend: async () => true,
+    pingRpc: async () => true,
+    now,
+  });
+  console.log(formatReport(healthy));
+
+  console.log("\n\nRun 2: RPC check deliberately failing\n");
+  const degraded = await runHealthAggregator({
+    session: validSession,
+    pingBackend: async () => true,
+    pingRpc: async () => false,
+    now,
+  });
+  console.log(formatReport(degraded));
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main();
+}


### PR DESCRIPTION
 ## Summary

  Four self-contained reference examples for the contrib sandbox, each in its own folder under `contrib/examples/` with
  an implementation, tests, and a README documenting its exact shape/behavior.

  - **Policy limit recommendation helper** (`contrib/examples/policy-limit-recommender/`): `recommendSpendingLimit()`
  suggests a spending limit from a sample of historical payment amounts — 90th percentile of the sorted sample
  (nearest-rank method) multiplied by a 1.5x headroom factor. Both are configurable. Throws on an empty sample,
  negative/non-finite amounts, or an out-of-range percentile.

  - **Mock device pairing flow** (`contrib/examples/mock-device-pairing/`): `createMockPairingFlow()` implements
  `request()` / `approve()` / `issueSession()` over in-memory state. Issuing a session for a request that hasn't been
  approved yet throws a clear error instead of returning a session.

  - **Session budget dashboard source** (`contrib/examples/session-budget-dashboard-source/`):
  `buildSessionBudgetDashboardSource()` combines a mock session and a mock x402 budget tracker into one flat object —
  session expiry status (`active` / `expiring_soon` / `expired`), remaining budget, and recent spend — suitable for a
  dashboard UI. Returned shape is documented in the README.

  - **Wallet health check aggregator** (`contrib/examples/wallet-health-aggregator/`): `runHealthAggregator()` runs
  three distinct mock checks (session validity, backend reachability, RPC reachability) and reports `healthy` only if
  all pass, `degraded` if any fail — documented in the README.

  ## Test plan

  - [x] All new example scripts run via `npx tsx <file>.ts` and produce the output documented in each README
  - [x] `npx vitest run contrib/examples/policy-limit-recommender contrib/examples/mock-device-pairing
  contrib/examples/session-budget-dashboard-source contrib/examples/wallet-health-aggregator` — 32/32 passing
  - [x] `npm run typecheck` and `npm run build` pass unaffected
  - [x] Change is entirely inside `contrib/` — no files outside it touched

  Closes #101
  Closes #102
  Closes #103
  Closes #105
