### PR TITLE
contrib: add reference examples for issues 104, 106, 107, 108

### DIFF
--- a/contrib/examples/cleanup-plan-viewer/README.md
+++ b/contrib/examples/cleanup-plan-viewer/README.md
@@ -1,0 +1,52 @@
+# Cleanup plan viewer
+
+`renderCleanupPlan(plan)` takes a mock cleanup plan object and renders a
+readable, numbered, step-by-step view of its blockers. Each blocker is
+clearly marked `[RESOLVED]` or `[OUTSTANDING]`. A plan with **zero**
+blockers prints a clear all-clear message instead of an empty list.
+
+## Input shape
+
+```ts
+interface CleanupBlocker {
+  id: string;
+  description: string;
+  resolved: boolean;
+}
+
+interface CleanupPlan {
+  title: string;
+  blockers: CleanupBlocker[];
+}
+```
+
+Each rendered step follows the plan's `blockers` order:
+`<n>. [RESOLVED|OUTSTANDING] <description> (<id>)`.
+
+## Run it
+
+```sh
+npx tsx cleanup-plan-viewer.ts
+```
+
+Expected output (a plan with a mix of resolved and outstanding blockers,
+followed by a plan with zero blockers):
+
+```
+Testnet contract cleanup
+
+1. [RESOLVED] Revoke unused deployer signer key (blocker-1)
+2. [OUTSTANDING] Migrate policy-contract owners off the legacy multisig (blocker-2)
+3. [RESOLVED] Remove stale allowlist entries from spending-limit policy (blocker-3)
+4. [OUTSTANDING] Confirm no active sessions reference the retired signer (blocker-4)
+
+Mainnet migration cleanup
+
+All clear — no blockers remaining.
+```
+
+## Tests
+
+```sh
+npx vitest run contrib/examples/cleanup-plan-viewer
+```

--- a/contrib/examples/cleanup-plan-viewer/cleanup-plan-viewer.test.ts
+++ b/contrib/examples/cleanup-plan-viewer/cleanup-plan-viewer.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+import { renderCleanupPlan, type CleanupPlan } from "./cleanup-plan-viewer";
+
+describe("renderCleanupPlan", () => {
+  it("marks each blocker as resolved or outstanding", () => {
+    const plan: CleanupPlan = {
+      title: "Sample plan",
+      blockers: [
+        { id: "b1", description: "First step", resolved: true },
+        { id: "b2", description: "Second step", resolved: false },
+      ],
+    };
+
+    const output = renderCleanupPlan(plan);
+    expect(output).toContain("1. [RESOLVED] First step (b1)");
+    expect(output).toContain("2. [OUTSTANDING] Second step (b2)");
+  });
+
+  it("numbers steps in the given order starting at 1", () => {
+    const plan: CleanupPlan = {
+      title: "Sample plan",
+      blockers: [
+        { id: "b1", description: "A", resolved: true },
+        { id: "b2", description: "B", resolved: true },
+        { id: "b3", description: "C", resolved: false },
+      ],
+    };
+
+    const lines = renderCleanupPlan(plan).split("\n");
+    expect(lines).toContain("1. [RESOLVED] A (b1)");
+    expect(lines).toContain("2. [RESOLVED] B (b2)");
+    expect(lines).toContain("3. [OUTSTANDING] C (b3)");
+  });
+
+  it("prints a clear all-clear message for a plan with zero blockers", () => {
+    const output = renderCleanupPlan({ title: "Empty plan", blockers: [] });
+    expect(output).toBe("Empty plan\n\nAll clear — no blockers remaining.");
+    expect(output).not.toContain("RESOLVED");
+    expect(output).not.toContain("OUTSTANDING");
+  });
+
+  it("includes the plan title as a heading", () => {
+    const output = renderCleanupPlan({
+      title: "My cleanup plan",
+      blockers: [{ id: "b1", description: "Step", resolved: false }],
+    });
+    expect(output.startsWith("My cleanup plan")).toBe(true);
+  });
+});

--- a/contrib/examples/cleanup-plan-viewer/cleanup-plan-viewer.ts
+++ b/contrib/examples/cleanup-plan-viewer/cleanup-plan-viewer.ts
@@ -1,0 +1,55 @@
+// Example: take a mock cleanup plan object and render a readable step by
+// step view of its blockers, each clearly marked as resolved or
+// outstanding.
+//
+// Run with: npx tsx cleanup-plan-viewer.ts
+
+export interface CleanupBlocker {
+  id: string;
+  description: string;
+  resolved: boolean;
+}
+
+export interface CleanupPlan {
+  title: string;
+  blockers: CleanupBlocker[];
+}
+
+/**
+ * Renders `plan` as a numbered, step-by-step list of its blockers, each
+ * marked `[RESOLVED]` or `[OUTSTANDING]`. A plan with zero blockers prints a
+ * clear all-clear message instead of an empty list.
+ */
+export function renderCleanupPlan(plan: CleanupPlan): string {
+  if (plan.blockers.length === 0) {
+    return `${plan.title}\n\nAll clear — no blockers remaining.`;
+  }
+
+  const lines = [plan.title, ""];
+  plan.blockers.forEach((blocker, index) => {
+    const status = blocker.resolved ? "RESOLVED" : "OUTSTANDING";
+    lines.push(`${index + 1}. [${status}] ${blocker.description} (${blocker.id})`);
+  });
+  return lines.join("\n");
+}
+
+function main() {
+  const plan: CleanupPlan = {
+    title: "Testnet contract cleanup",
+    blockers: [
+      { id: "blocker-1", description: "Revoke unused deployer signer key", resolved: true },
+      { id: "blocker-2", description: "Migrate policy-contract owners off the legacy multisig", resolved: false },
+      { id: "blocker-3", description: "Remove stale allowlist entries from spending-limit policy", resolved: true },
+      { id: "blocker-4", description: "Confirm no active sessions reference the retired signer", resolved: false },
+    ],
+  };
+
+  console.log(renderCleanupPlan(plan));
+
+  console.log();
+  console.log(renderCleanupPlan({ title: "Mainnet migration cleanup", blockers: [] }));
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main();
+}

--- a/contrib/examples/fee-comparison-tool/README.md
+++ b/contrib/examples/fee-comparison-tool/README.md
@@ -1,0 +1,55 @@
+# Transaction fee comparison tool
+
+`recommendFeeOption(maxWaitSeconds)` compares estimated fees for a payment
+across `low`, `medium`, and `high` priority levels and recommends the
+**cheapest** option whose estimated confirmation time still meets a
+caller-supplied maximum wait time. If no priority level confirms within the
+deadline, it returns `recommended: null` with a reason rather than silently
+picking an option that would miss it.
+
+## Fee table
+
+A hardcoded sample fee and expected confirmation time per priority level
+(a real integration would read this from a fee oracle):
+
+| Priority | Fee (stroops) | Est. confirmation |
+| -------- | ------------- | ------------------ |
+| low      | 100           | 300s                |
+| medium   | 10,000        | 60s                 |
+| high     | 1,000,000     | 5s                  |
+
+## Usage
+
+```ts
+import { recommendFeeOption } from "./fee-comparison-tool";
+
+const result = recommendFeeOption(120); // must confirm within 120s
+
+result.recommended?.priority; // "medium" (low misses the 120s deadline)
+result.reasoning;
+// '"medium" is the cheapest of 2 option(s) confirming within 120s (10000 stroops, ~60s).'
+```
+
+## Run it
+
+```sh
+npx tsx fee-comparison-tool.ts
+```
+
+Expected output (for a sample 120s deadline):
+
+```
+Comparing fee options for a deadline of 120s:
+  low          100 stroops, ~300s (misses deadline)
+  medium     10000 stroops, ~60s
+  high     1000000 stroops, ~5s
+
+Recommendation: medium
+Reasoning: "medium" is the cheapest of 2 option(s) confirming within 120s (10000 stroops, ~60s).
+```
+
+## Tests
+
+```sh
+npx vitest run contrib/examples/fee-comparison-tool
+```

--- a/contrib/examples/fee-comparison-tool/fee-comparison-tool.test.ts
+++ b/contrib/examples/fee-comparison-tool/fee-comparison-tool.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+import { FEE_TABLE, recommendFeeOption } from "./fee-comparison-tool";
+
+describe("recommendFeeOption", () => {
+  it("recommends the cheapest option that meets a generous deadline", () => {
+    const result = recommendFeeOption(600);
+    expect(result.recommended?.priority).toBe("low");
+    expect(result.eligibleOptions.map((o) => o.priority)).toEqual(["low", "medium", "high"]);
+  });
+
+  it("excludes options that miss a tighter deadline and recommends the cheapest remaining one", () => {
+    const result = recommendFeeOption(120);
+    expect(result.eligibleOptions.map((o) => o.priority)).toEqual(["medium", "high"]);
+    expect(result.recommended?.priority).toBe("medium");
+  });
+
+  it("recommends the only option meeting a very tight deadline", () => {
+    const result = recommendFeeOption(10);
+    expect(result.eligibleOptions.map((o) => o.priority)).toEqual(["high"]);
+    expect(result.recommended?.priority).toBe("high");
+  });
+
+  it("returns a null recommendation with a reason when no option meets the deadline", () => {
+    const result = recommendFeeOption(1);
+    expect(result.recommended).toBeNull();
+    expect(result.eligibleOptions).toEqual([]);
+    expect(result.reasoning).toMatch(/No priority level confirms within 1s/);
+  });
+
+  it("does not mutate the default FEE_TABLE export", () => {
+    const before = FEE_TABLE.map((o) => ({ ...o }));
+    recommendFeeOption(60);
+    expect(FEE_TABLE).toEqual(before);
+  });
+
+  it("accepts a custom fee table instead of the default one", () => {
+    const customTable = [
+      { priority: "low" as const, feeStroops: 50n, estimatedConfirmationSeconds: 400 },
+      { priority: "high" as const, feeStroops: 900n, estimatedConfirmationSeconds: 20 },
+    ];
+    const result = recommendFeeOption(30, customTable);
+    expect(result.recommended?.priority).toBe("high");
+  });
+});

--- a/contrib/examples/fee-comparison-tool/fee-comparison-tool.ts
+++ b/contrib/examples/fee-comparison-tool/fee-comparison-tool.ts
@@ -1,0 +1,85 @@
+// Example: compare estimated fees for a payment across a few sample
+// priority levels and recommend the cheapest option that still confirms
+// within a caller-supplied maximum wait time.
+//
+// Run with: npx tsx fee-comparison-tool.ts
+
+export type FeePriority = "low" | "medium" | "high";
+
+export interface FeeOption {
+  priority: FeePriority;
+  /** Estimated fee, in stroops. */
+  feeStroops: bigint;
+  /** Estimated confirmation time, in seconds. */
+  estimatedConfirmationSeconds: number;
+}
+
+/** Hardcoded sample fee and expected confirmation time table, one entry per
+ * priority level (a real integration would read this from a fee oracle). */
+export const FEE_TABLE: FeeOption[] = [
+  { priority: "low", feeStroops: 100n, estimatedConfirmationSeconds: 300 },
+  { priority: "medium", feeStroops: 10_000n, estimatedConfirmationSeconds: 60 },
+  { priority: "high", feeStroops: 1_000_000n, estimatedConfirmationSeconds: 5 },
+];
+
+export interface FeeRecommendation {
+  /** null when no option in the table confirms within maxWaitSeconds. */
+  recommended: FeeOption | null;
+  /** Every option that meets the maxWaitSeconds deadline, in table order. */
+  eligibleOptions: FeeOption[];
+  reasoning: string;
+}
+
+/**
+ * Recommends the lowest-fee option in `table` whose estimated confirmation
+ * time is at or under `maxWaitSeconds`. Returns `recommended: null` (with a
+ * reason) rather than silently picking an option that misses the deadline —
+ * the whole point of a deadline constraint is that it's not optional.
+ */
+export function recommendFeeOption(maxWaitSeconds: number, table: FeeOption[] = FEE_TABLE): FeeRecommendation {
+  const eligibleOptions = table.filter((option) => option.estimatedConfirmationSeconds <= maxWaitSeconds);
+
+  if (eligibleOptions.length === 0) {
+    return {
+      recommended: null,
+      eligibleOptions: [],
+      reasoning: `No priority level confirms within ${maxWaitSeconds}s (fastest available is ${Math.min(...table.map((o) => o.estimatedConfirmationSeconds))}s).`,
+    };
+  }
+
+  const recommended = eligibleOptions.reduce((cheapest, option) =>
+    option.feeStroops < cheapest.feeStroops ? option : cheapest,
+  );
+
+  return {
+    recommended,
+    eligibleOptions,
+    reasoning: `"${recommended.priority}" is the cheapest of ${eligibleOptions.length} option(s) confirming within ${maxWaitSeconds}s (${recommended.feeStroops} stroops, ~${recommended.estimatedConfirmationSeconds}s).`,
+  };
+}
+
+function main() {
+  const maxWaitSeconds = 120;
+  const result = recommendFeeOption(maxWaitSeconds);
+
+  console.log(`Comparing fee options for a deadline of ${maxWaitSeconds}s:`);
+  for (const option of FEE_TABLE) {
+    const meetsDeadline = option.estimatedConfirmationSeconds <= maxWaitSeconds;
+    console.log(
+      `  ${option.priority.padEnd(6)} ${option.feeStroops.toString().padStart(9)} stroops, ~${option.estimatedConfirmationSeconds}s` +
+        (meetsDeadline ? "" : " (misses deadline)"),
+    );
+  }
+
+  console.log();
+  if (result.recommended) {
+    console.log(`Recommendation: ${result.recommended.priority}`);
+  } else {
+    console.log("Recommendation: none");
+  }
+  console.log(`Reasoning: ${result.reasoning}`);
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main();
+}

--- a/contrib/examples/policy-audit-trail/README.md
+++ b/contrib/examples/policy-audit-trail/README.md
@@ -1,0 +1,43 @@
+# Policy audit trail formatter
+
+`formatAuditTrail(events)` takes a list of policy change events (`create`,
+`update`, `remove`) and renders them as a readable chronological audit
+trail — **oldest first**. Input order is never assumed to already be
+sorted: events are sorted by `timestamp` before rendering, so passing them
+in any order (e.g. as fetched newest-first from an API) still produces a
+correct trail.
+
+## Input shape
+
+```ts
+interface PolicyChangeEvent {
+  action: "create" | "update" | "remove";
+  policyId: string;
+  timestamp: string; // ISO 8601
+}
+```
+
+Each rendered line includes the action, the policy id, and the timestamp:
+`[<timestamp>] <Action> policy (<policyId>)`.
+
+## Run it
+
+```sh
+npx tsx policy-audit-trail.ts
+```
+
+Expected output (the sample events are given out of order; the trail is
+still oldest-first):
+
+```
+[2026-01-10T12:00:00Z] Created policy (spending-limit-policy)
+[2026-01-20T16:45:00Z] Created policy (signer-threshold-policy)
+[2026-02-14T08:30:00Z] Updated policy (signer-threshold-policy)
+[2026-03-03T09:15:00Z] Removed policy (spending-limit-policy)
+```
+
+## Tests
+
+```sh
+npx vitest run contrib/examples/policy-audit-trail
+```

--- a/contrib/examples/policy-audit-trail/policy-audit-trail.test.ts
+++ b/contrib/examples/policy-audit-trail/policy-audit-trail.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+import { formatAuditTrail, type PolicyChangeEvent } from "./policy-audit-trail";
+
+describe("formatAuditTrail", () => {
+  it("renders each entry with action, policy id, and timestamp", () => {
+    const events: PolicyChangeEvent[] = [
+      { action: "create", policyId: "policy-1", timestamp: "2026-01-01T00:00:00Z" },
+    ];
+    expect(formatAuditTrail(events)).toBe("[2026-01-01T00:00:00Z] Created policy (policy-1)");
+  });
+
+  it("labels update and remove actions distinctly from create", () => {
+    const events: PolicyChangeEvent[] = [
+      { action: "update", policyId: "policy-1", timestamp: "2026-01-01T00:00:00Z" },
+      { action: "remove", policyId: "policy-2", timestamp: "2026-01-02T00:00:00Z" },
+    ];
+    const trail = formatAuditTrail(events);
+    expect(trail).toContain("Updated policy (policy-1)");
+    expect(trail).toContain("Removed policy (policy-2)");
+  });
+
+  it("orders entries oldest first regardless of input order", () => {
+    const events: PolicyChangeEvent[] = [
+      { action: "remove", policyId: "b", timestamp: "2026-03-01T00:00:00Z" },
+      { action: "create", policyId: "a", timestamp: "2026-01-01T00:00:00Z" },
+      { action: "update", policyId: "c", timestamp: "2026-02-01T00:00:00Z" },
+    ];
+
+    const lines = formatAuditTrail(events).split("\n");
+    expect(lines[0]).toContain("(a)");
+    expect(lines[1]).toContain("(c)");
+    expect(lines[2]).toContain("(b)");
+  });
+
+  it("does not mutate the input array", () => {
+    const events: PolicyChangeEvent[] = [
+      { action: "remove", policyId: "b", timestamp: "2026-03-01T00:00:00Z" },
+      { action: "create", policyId: "a", timestamp: "2026-01-01T00:00:00Z" },
+    ];
+    const original = [...events];
+    formatAuditTrail(events);
+    expect(events).toEqual(original);
+  });
+
+  it("returns an empty string for an empty event list", () => {
+    expect(formatAuditTrail([])).toBe("");
+  });
+});

--- a/contrib/examples/policy-audit-trail/policy-audit-trail.ts
+++ b/contrib/examples/policy-audit-trail/policy-audit-trail.ts
@@ -1,0 +1,57 @@
+// Example: format a list of sample policy change events (create, update,
+// remove) as a readable chronological audit trail — oldest first. Input
+// order is never assumed to already be sorted: events are sorted by
+// timestamp before rendering, so passing them in any order (e.g. as fetched
+// newest-first from an API) still produces a correct trail.
+//
+// Run with: npx tsx policy-audit-trail.ts
+
+export type PolicyChangeAction = "create" | "update" | "remove";
+
+export interface PolicyChangeEvent {
+  action: PolicyChangeAction;
+  policyId: string;
+  /** ISO 8601 timestamp. */
+  timestamp: string;
+}
+
+function actionLabel(action: PolicyChangeAction): string {
+  switch (action) {
+    case "create":
+      return "Created";
+    case "update":
+      return "Updated";
+    case "remove":
+      return "Removed";
+  }
+}
+
+/**
+ * Formats `events` as a readable chronological audit trail, **oldest
+ * first**. Input order is never assumed to already be sorted — events are
+ * sorted by `timestamp` before rendering, so a caller can pass them in any
+ * order and get a correct trail regardless.
+ */
+export function formatAuditTrail(events: PolicyChangeEvent[]): string {
+  const sorted = [...events].sort((a, b) => a.timestamp.localeCompare(b.timestamp));
+  return sorted
+    .map((event) => `[${event.timestamp}] ${actionLabel(event.action)} policy (${event.policyId})`)
+    .join("\n");
+}
+
+function main() {
+  // Deliberately out of chronological order, to demonstrate that
+  // formatAuditTrail sorts rather than trusting input order.
+  const events: PolicyChangeEvent[] = [
+    { action: "remove", policyId: "spending-limit-policy", timestamp: "2026-03-03T09:15:00Z" },
+    { action: "create", policyId: "spending-limit-policy", timestamp: "2026-01-10T12:00:00Z" },
+    { action: "update", policyId: "signer-threshold-policy", timestamp: "2026-02-14T08:30:00Z" },
+    { action: "create", policyId: "signer-threshold-policy", timestamp: "2026-01-20T16:45:00Z" },
+  ];
+
+  console.log(formatAuditTrail(events));
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main();
+}

--- a/contrib/examples/x402-agent-demo/README.md
+++ b/contrib/examples/x402-agent-demo/README.md
@@ -1,0 +1,58 @@
+# x402 agent demo (end to end, mock)
+
+A self-contained, end-to-end demo of an agent using a session key signer to
+pay a mock x402 resource within a tracked budget. Combines three pieces in
+one script:
+
+- a **mock session key signer** (`createMockSessionKeySigner`) — signs
+  payment payloads with a fake signature, no real cryptography;
+- a **mock x402 resource server** (`requestResource`) — returns 402 until a
+  `PAYMENT-SIGNATURE` header is present, then 200;
+- a **budget tracker** (`BudgetTracker`) — a client-side spending guard that
+  approves or rejects each payment against a fixed total budget.
+
+These mirror the ideas in the `mock-x402-resource`, `headless-agent-signer`,
+and `x402-budget-tracker` examples, reimplemented here as self-contained
+mocks so this demo has no dependency on any other example directory.
+
+## Flow
+
+`runAgentPayments(signer, budget, resources)` pays for each resource in
+order:
+
+1. Request the resource with no payment header — expect `402`.
+2. Ask the budget tracker to approve the resource's quoted price.
+   - If **rejected** (would exceed the remaining budget), stop here — no
+     signature is produced and no paid request is ever sent.
+   - If **approved**, continue.
+3. Sign a payment payload with the session key signer.
+4. Retry the request with the signature in the `PAYMENT-SIGNATURE` header —
+   expect `200`.
+
+## Run it
+
+```sh
+npx tsx x402-agent-demo.ts
+```
+
+The sample run pays for one resource (600,000 stroops, fits in a
+1,000,000-stroop budget) and is rejected for a second identically-priced
+resource (would exceed the 400,000 stroops left):
+
+```
+x402 agent demo (mock signer + mock resource server + budget tracker)
+
+1. Agent wallet : CAGENTWALLETXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+2. Total budget : 1000000 stroops
+
+3. weather-api: PAID — Paid 600000 stroops, remaining budget 400000 stroops
+4. market-data-api: REJECTED — Payment of 600000 stroops would exceed remaining budget of 400000 stroops (total 1000000)
+
+Final remaining budget: 400000 stroops
+```
+
+## Tests
+
+```sh
+npx vitest run contrib/examples/x402-agent-demo
+```

--- a/contrib/examples/x402-agent-demo/x402-agent-demo.test.ts
+++ b/contrib/examples/x402-agent-demo/x402-agent-demo.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from "vitest";
+import {
+  BudgetTracker,
+  createMockSessionKeySigner,
+  requestResource,
+  runAgentPayments,
+  type MockResource,
+} from "./x402-agent-demo";
+
+describe("requestResource", () => {
+  const resource: MockResource = { name: "sample-api", priceStroops: 1_000n };
+
+  it("returns 402 without a payment header", () => {
+    const response = requestResource(resource, { headers: {} });
+    expect(response.status).toBe(402);
+  });
+
+  it("returns 200 once a payment header is present", () => {
+    const response = requestResource(resource, { headers: { "PAYMENT-SIGNATURE": "sig" } });
+    expect(response.status).toBe(200);
+  });
+});
+
+describe("createMockSessionKeySigner", () => {
+  it("signs with the configured address and never returns an empty signature", () => {
+    const signer = createMockSessionKeySigner("CADDR");
+    const signature = signer.sign("payload");
+    expect(signature).toContain("CADDR");
+    expect(signature.length).toBeGreaterThan(0);
+  });
+});
+
+describe("runAgentPayments", () => {
+  it("pays for a resource within budget and rejects one that would exceed it", () => {
+    const signer = createMockSessionKeySigner("CADDR");
+    const budget = new BudgetTracker(1_000_000n);
+    const resources: MockResource[] = [
+      { name: "weather-api", priceStroops: 600_000n },
+      { name: "market-data-api", priceStroops: 600_000n },
+    ];
+
+    const attempts = runAgentPayments(signer, budget, resources);
+
+    expect(attempts).toHaveLength(2);
+    expect(attempts[0]).toMatchObject({ resource: "weather-api", outcome: "paid" });
+    expect(attempts[1]).toMatchObject({ resource: "market-data-api", outcome: "rejected" });
+    expect(attempts[1]?.detail).toMatch(/would exceed remaining budget/);
+  });
+
+  it("leaves the budget unchanged when a payment is rejected", () => {
+    const signer = createMockSessionKeySigner("CADDR");
+    const budget = new BudgetTracker(1_000_000n);
+    const resources: MockResource[] = [
+      { name: "weather-api", priceStroops: 600_000n },
+      { name: "market-data-api", priceStroops: 600_000n },
+    ];
+
+    runAgentPayments(signer, budget, resources);
+
+    expect(budget.remainingBudget).toBe(400_000n);
+  });
+
+  it("pays for every resource when the total budget covers them all", () => {
+    const signer = createMockSessionKeySigner("CADDR");
+    const budget = new BudgetTracker(1_000_000n);
+    const resources: MockResource[] = [
+      { name: "resource-a", priceStroops: 300_000n },
+      { name: "resource-b", priceStroops: 300_000n },
+    ];
+
+    const attempts = runAgentPayments(signer, budget, resources);
+
+    expect(attempts.every((a) => a.outcome === "paid")).toBe(true);
+    expect(budget.remainingBudget).toBe(400_000n);
+  });
+});
+
+describe("BudgetTracker", () => {
+  it("throws for a negative total budget", () => {
+    expect(() => new BudgetTracker(-1n)).toThrow(RangeError);
+  });
+
+  it("throws for a negative payment amount", () => {
+    expect(() => new BudgetTracker(100n).tryRecordPayment(-1n)).toThrow(RangeError);
+  });
+});

--- a/contrib/examples/x402-agent-demo/x402-agent-demo.ts
+++ b/contrib/examples/x402-agent-demo/x402-agent-demo.ts
@@ -1,0 +1,188 @@
+// Example: an end-to-end mock x402 agent demo. An agent holding a mock
+// session key signer pays for a series of mock x402-protected resources
+// while a budget tracker enforces a spending cap client-side. Demonstrates
+// both a successful payment and a payment rejected for exceeding the
+// remaining budget.
+//
+// Ties together the ideas behind the mock-x402-resource,
+// headless-agent-signer, and x402-budget-tracker examples into a single
+// self-contained script.
+//
+// Run with: npx tsx x402-agent-demo.ts
+
+// ---- Mock session key signer ----
+
+export interface MockSessionKeySigner {
+  address: string;
+  /** Signs a payment payload, returning a mock signature string. Never does
+   * real cryptography — this is a reference mock, not a real signer. */
+  sign(payload: string): string;
+}
+
+export function createMockSessionKeySigner(address: string): MockSessionKeySigner {
+  return {
+    address,
+    sign(payload: string) {
+      return `mock-sig:${address}:${payload.length}`;
+    },
+  };
+}
+
+// ---- Mock x402 resource server ----
+
+export interface MockResource {
+  name: string;
+  /** Price of this resource, in stroops. */
+  priceStroops: bigint;
+}
+
+export interface ResourceRequest {
+  headers: Record<string, string>;
+}
+
+export interface ResourceResponse {
+  status: number;
+  body: unknown;
+}
+
+const PAYMENT_HEADER = "PAYMENT-SIGNATURE";
+
+/** Handles a request to a mock protected resource: 402 without a payment
+ * header, 200 with the resource once one is present. Never validates the
+ * signature itself — a real facilitator would. */
+export function requestResource(resource: MockResource, request: ResourceRequest): ResourceResponse {
+  const paymentHeader = request.headers[PAYMENT_HEADER];
+  if (!paymentHeader) {
+    return {
+      status: 402,
+      body: { error: "Payment required", priceStroops: resource.priceStroops.toString() },
+    };
+  }
+  return { status: 200, body: { data: `${resource.name} content` } };
+}
+
+// ---- Budget tracker ----
+
+export interface BudgetDecision {
+  approved: boolean;
+  /** Present only when approved is false. */
+  reason?: string;
+  /** Remaining allowance after this decision (unchanged if rejected). */
+  remainingBudget: bigint;
+}
+
+/** Tracks spend against a fixed total budget (in stroops). A rejected
+ * payment is never partially recorded — the tracked spend only changes on
+ * approval. */
+export class BudgetTracker {
+  private spent = 0n;
+
+  constructor(private readonly totalBudget: bigint) {
+    if (totalBudget < 0n) {
+      throw new RangeError("totalBudget must not be negative");
+    }
+  }
+
+  get remainingBudget(): bigint {
+    return this.totalBudget - this.spent;
+  }
+
+  tryRecordPayment(amount: bigint): BudgetDecision {
+    if (amount < 0n) {
+      throw new RangeError("amount must not be negative");
+    }
+    if (amount > this.remainingBudget) {
+      return {
+        approved: false,
+        reason: `Payment of ${amount} stroops would exceed remaining budget of ${this.remainingBudget} stroops (total ${this.totalBudget})`,
+        remainingBudget: this.remainingBudget,
+      };
+    }
+    this.spent += amount;
+    return { approved: true, remainingBudget: this.remainingBudget };
+  }
+}
+
+// ---- Agent flow ----
+
+export interface AgentPaymentAttempt {
+  resource: string;
+  outcome: "paid" | "rejected";
+  detail: string;
+}
+
+/**
+ * Runs an agent through paying for `resources` in order, using `signer` to
+ * sign each payment and `budget` to guard spend. For each resource: request
+ * without payment (expect 402), check the quoted price against the
+ * remaining budget, and only if the budget approves it, sign a payment and
+ * retry the request (expect 200). A resource whose price would exceed the
+ * remaining budget is rejected by the budget tracker *before* a signature
+ * is ever produced or a paid request ever sent.
+ */
+export function runAgentPayments(
+  signer: MockSessionKeySigner,
+  budget: BudgetTracker,
+  resources: MockResource[],
+): AgentPaymentAttempt[] {
+  const attempts: AgentPaymentAttempt[] = [];
+
+  for (const resource of resources) {
+    const unpaidResponse = requestResource(resource, { headers: {} });
+    if (unpaidResponse.status !== 402) {
+      throw new Error(`Expected 402 for an unpaid request to ${resource.name}`);
+    }
+
+    const decision = budget.tryRecordPayment(resource.priceStroops);
+    if (!decision.approved) {
+      attempts.push({ resource: resource.name, outcome: "rejected", detail: decision.reason ?? "rejected" });
+      continue;
+    }
+
+    const signature = signer.sign(`pay:${resource.name}:${resource.priceStroops}`);
+    const paidResponse = requestResource(resource, { headers: { [PAYMENT_HEADER]: signature } });
+    if (paidResponse.status !== 200) {
+      throw new Error(`Expected 200 for a paid request to ${resource.name}`);
+    }
+
+    attempts.push({
+      resource: resource.name,
+      outcome: "paid",
+      detail: `Paid ${resource.priceStroops} stroops, remaining budget ${decision.remainingBudget} stroops`,
+    });
+  }
+
+  return attempts;
+}
+
+function main() {
+  console.log("x402 agent demo (mock signer + mock resource server + budget tracker)\n");
+
+  const signer = createMockSessionKeySigner("CAGENTWALLETXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX");
+  const budget = new BudgetTracker(1_000_000n);
+  const resources: MockResource[] = [
+    { name: "weather-api", priceStroops: 600_000n },
+    { name: "market-data-api", priceStroops: 600_000n },
+  ];
+
+  console.log(`1. Agent wallet : ${signer.address}`);
+  console.log(`2. Total budget : ${budget.remainingBudget} stroops`);
+  console.log();
+
+  const attempts = runAgentPayments(signer, budget, resources);
+  attempts.forEach((attempt, i) => {
+    const step = i + 3;
+    if (attempt.outcome === "paid") {
+      console.log(`${step}. ${attempt.resource}: PAID — ${attempt.detail}`);
+    } else {
+      console.log(`${step}. ${attempt.resource}: REJECTED — ${attempt.detail}`);
+    }
+  });
+
+  console.log();
+  console.log(`Final remaining budget: ${budget.remainingBudget} stroops`);
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main();
+}


### PR DESCRIPTION
  Summary

  Adds four self-contained reference examples under contrib/examples/, closing #104, #106, #107,
  #108.

  - policy-audit-trail/ — formatAuditTrail(events) renders a list of policy change events
  (create/update/remove) as a readable chronological trail, oldest first. Sorts by timestamp
  rather than trusting input order. README documents the input shape and ordering.
  - fee-comparison-tool/ — recommendFeeOption(maxWaitSeconds) compares a hardcoded
  fee/confirmation-time table across low/medium/high priority levels and recommends the cheapest
  option that still meets a caller-supplied deadline, with reasoning. Returns a null
  recommendation (with reason) when nothing meets the deadline.
  - cleanup-plan-viewer/ — renderCleanupPlan(plan) renders a mock cleanup plan's blockers as a
  numbered step-by-step list, each marked [RESOLVED] or [OUTSTANDING]. Prints a clear all-clear
  message for a plan with zero blockers.
  - x402-agent-demo/ — end-to-end mock demo combining a mock session-key signer, a mock x402
  resource server, and a budget tracker: an agent pays for one resource within budget and is
  rejected for a second that would exceed it.

  Each folder has its own README.md, implementation script (runnable via npx tsx), and a vitest
  test file.

  Closes

  Closes #104
  Closes #106
  Closes #107
  Closes #108