### PR TITLE
contrib: add CLI wallet balance printer example

### DIFF
--- a/contrib/examples/cli-balance-printer/README.md
+++ b/contrib/examples/cli-balance-printer/README.md
@@ -1,0 +1,91 @@
+# CLI: print a table of token balances
+
+A small command-line tool that prints an aligned table of balances for one
+account across one or more token contracts. It reads through the SDK's own
+`createBalanceService`, but wired to an in-memory mock `BalanceReader`, so it
+runs end to end with no live network call — no RPC, no Horizon, no keys.
+
+## Usage
+
+```sh
+npx tsx cli-balance-printer.ts <accountId> <tokenContractId...>
+```
+
+- `<accountId>` — the account whose balances are read. Any string works
+  against the mock; an account with no seeded balance simply reads as `0`.
+- `<tokenContractId...>` — one or more token contract ids. Rows appear in the
+  order given, and a repeated id is collapsed so no token is printed twice.
+
+## Running it with node
+
+Node cannot execute a `.ts` file on its own, so the tool runs through `tsx`,
+which is a TypeScript loader for node — `npx tsx <file>` starts node with that
+loader attached. If `tsx` is installed in the workspace you can spell the same
+thing out explicitly:
+
+```sh
+node --import tsx cli-balance-printer.ts <accountId> <tokenContractId...>
+```
+
+Everything else the tool needs is in node's standard library plus the SDK
+source, so there is nothing to configure and no network access involved.
+
+## Sample run
+
+```sh
+$ npx tsx cli-balance-printer.ts \
+    CMOCKACCOUNTXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX \
+    CXLMMOCKCONTRACTXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX \
+    CUSDCMOCKCONTRACTXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX \
+    CEURCMOCKCONTRACTXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+Account: CMOCKACCOUNTXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+
+TOKEN  CONTRACT                                                 BALANCE
+-----------------------------------------------------------------------
+XLM    CXLMMOCKCONTRACTXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX       42
+USDC   CUSDCMOCKCONTRACTXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX   1250.5
+EURC   CEURCMOCKCONTRACTXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX    18.75
+```
+
+Amounts are rendered by the SDK's `formatTokenAmount`, so each token uses its
+own `decimals` (EURC above has 6, the others 7) and the column is right
+aligned. Bad input exits non-zero with a one-line message:
+
+```sh
+$ npx tsx cli-balance-printer.ts CMOCKACCOUNTXXXX
+Error: At least one <tokenContractId> is required
+```
+
+## Known token contracts
+
+The mock ledger recognizes three fake contract ids. Reading an id outside this
+list fails before any balance is fetched, and the error lists the known ids.
+
+| Symbol | Contract id                                               | Decimals |
+| ------ | --------------------------------------------------------- | -------- |
+| USDC   | `CUSDCMOCKCONTRACTXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX`  | 7        |
+| XLM    | `CXLMMOCKCONTRACTXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX`  | 7        |
+| EURC   | `CEURCMOCKCONTRACTXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX`  | 6        |
+
+## How the mock is wired
+
+`createMockBalanceReader` returns a `BalanceReader` — the single-method seam
+`createBalanceService` reads through — backed by a plain object of raw amounts.
+An unknown token contract is rejected (a real token read against a non-token
+address fails too), while an unknown holder reads as `0n`, which is what a real
+token contract returns for an address that has never held the asset.
+
+Because the reader is just a parameter, `printBalances` accepts one: pass the
+RPC-backed reader from `src/balances-rpc.ts` instead and the same tool prints
+live balances.
+
+## Tests
+
+```sh
+npx vitest run contrib/examples/cli-balance-printer
+```
+
+Covers argument parsing (including the duplicate-token and missing-argument
+cases), contract id resolution, the mock reader's zero/unknown behavior, the
+table alignment and per-token decimals, and `printBalances` failing on an
+unknown contract before issuing any read.

--- a/contrib/examples/cli-balance-printer/cli-balance-printer.test.ts
+++ b/contrib/examples/cli-balance-printer/cli-balance-printer.test.ts
@@ -1,0 +1,144 @@
+import { describe, expect, it } from "vitest";
+import {
+  createMockBalanceReader,
+  formatBalanceTable,
+  parseArgs,
+  printBalances,
+  resolveTokens,
+} from "./cli-balance-printer";
+import type { BalanceReader } from "../../../src/balances";
+
+const ACCOUNT = "CMOCKACCOUNTXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX";
+const USDC = "CUSDCMOCKCONTRACTXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX";
+const XLM = "CXLMMOCKCONTRACTXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX";
+const EURC = "CEURCMOCKCONTRACTXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX";
+
+describe("parseArgs", () => {
+  it("takes the account id first and every remaining argument as a token", () => {
+    expect(parseArgs([ACCOUNT, USDC, XLM])).toEqual({
+      accountId: ACCOUNT,
+      tokenContractIds: [USDC, XLM],
+    });
+  });
+
+  it("accepts a single token", () => {
+    expect(parseArgs([ACCOUNT, USDC].map(String)).tokenContractIds).toEqual([USDC]);
+  });
+
+  it("collapses a repeated token contract id", () => {
+    expect(parseArgs([ACCOUNT, USDC, XLM, USDC]).tokenContractIds).toEqual([USDC, XLM]);
+  });
+
+  it("throws when no arguments are given at all", () => {
+    expect(() => parseArgs([])).toThrow(/Missing <accountId>/);
+  });
+
+  it("throws when the account id is given but no token is", () => {
+    expect(() => parseArgs([ACCOUNT])).toThrow(/At least one <tokenContractId>/);
+  });
+});
+
+describe("resolveTokens", () => {
+  it("resolves known contract ids to their token info", () => {
+    expect(resolveTokens([USDC, EURC])).toEqual([
+      { symbol: "USDC", contractId: USDC, decimals: 7 },
+      { symbol: "EURC", contractId: EURC, decimals: 6 },
+    ]);
+  });
+
+  it("rejects an unknown contract id and lists the known ones", () => {
+    expect(() => resolveTokens([USDC, "CNOTATOKEN"])).toThrow(/Unknown token contract "CNOTATOKEN"/);
+    expect(() => resolveTokens(["CNOTATOKEN"])).toThrow(new RegExp(USDC));
+  });
+});
+
+describe("createMockBalanceReader", () => {
+  it("returns the seeded balance for a known holder", async () => {
+    await expect(createMockBalanceReader().getTokenBalance(USDC, ACCOUNT)).resolves.toBe(
+      1_250_5000000n,
+    );
+  });
+
+  it("reads zero for a holder that has never held the token", async () => {
+    await expect(createMockBalanceReader().getTokenBalance(USDC, "CSOMEONEELSE")).resolves.toBe(0n);
+  });
+
+  it("rejects a read against an unknown token contract", async () => {
+    await expect(createMockBalanceReader().getTokenBalance("CNOTATOKEN", ACCOUNT)).rejects.toThrow(
+      /Unknown token contract/,
+    );
+  });
+});
+
+describe("formatBalanceTable", () => {
+  it("aligns columns and right-aligns the amounts", () => {
+    const table = formatBalanceTable(ACCOUNT, [
+      { symbol: "USDC", contractId: USDC, decimals: 7, amount: 1_250_5000000n },
+      { symbol: "XLM", contractId: XLM, decimals: 7, amount: 42_0000000n },
+    ]);
+    const [account, blank, header, rule, usdcRow, xlmRow] = table.split("\n");
+
+    expect(account).toBe(`Account: ${ACCOUNT}`);
+    expect(blank).toBe("");
+    expect(header).toMatch(/^TOKEN\s+CONTRACT\s+BALANCE$/);
+    expect(rule).toBe("-".repeat(header!.length));
+    expect(usdcRow).toContain("1250.5");
+    expect(xlmRow).toContain("42");
+    // Every row is padded to the same width, so the amount column lines up.
+    expect(new Set([header!.length, usdcRow!.length, xlmRow!.length]).size).toBe(1);
+  });
+
+  it("formats each token with its own decimals", () => {
+    const table = formatBalanceTable(ACCOUNT, [
+      { symbol: "EURC", contractId: EURC, decimals: 6, amount: 18_750000n },
+    ]);
+    expect(table).toContain("18.75");
+  });
+});
+
+describe("printBalances", () => {
+  it("prints a row per requested token, in the order given", async () => {
+    const table = await printBalances({ accountId: ACCOUNT, tokenContractIds: [XLM, USDC] });
+    const rows = table.split("\n").slice(4);
+
+    expect(rows).toHaveLength(2);
+    expect(rows[0]).toMatch(/^XLM\s/);
+    expect(rows[1]).toMatch(/^USDC\s/);
+    expect(rows[0]).toContain("42");
+    expect(rows[1]).toContain("1250.5");
+  });
+
+  it("shows a zero balance rather than omitting the token", async () => {
+    const table = await printBalances({ accountId: "CSTRANGER", tokenContractIds: [USDC] });
+    expect(table).toMatch(/USDC\s+\S+\s+0$/);
+  });
+
+  it("fails before any read when a token contract is unknown", async () => {
+    let reads = 0;
+    const counting: BalanceReader = {
+      async getTokenBalance() {
+        reads++;
+        return 0n;
+      },
+    };
+
+    await expect(
+      printBalances({ accountId: ACCOUNT, tokenContractIds: [USDC, "CNOTATOKEN"] }, counting),
+    ).rejects.toThrow(/Unknown token contract/);
+    expect(reads).toBe(0);
+  });
+
+  it("reads through an injected reader, so a caller can supply a live one", async () => {
+    const constant: BalanceReader = {
+      async getTokenBalance() {
+        return 7_0000000n;
+      },
+    };
+
+    const table = await printBalances(
+      { accountId: ACCOUNT, tokenContractIds: [USDC, XLM] },
+      constant,
+    );
+    expect(table.match(/\b7\b/g)).toHaveLength(2);
+  });
+});

--- a/contrib/examples/cli-balance-printer/cli-balance-printer.ts
+++ b/contrib/examples/cli-balance-printer/cli-balance-printer.ts
@@ -1,0 +1,158 @@
+// Example: a command-line tool that prints an aligned table of balances for
+// one account across one or more token contracts. It reads through the SDK's
+// own createBalanceService, but wired to an in-memory mock BalanceReader, so
+// it runs end to end with no live network call.
+//
+// Run with:
+//   node --experimental-strip-types cli-balance-printer.ts <accountId> <tokenContractId...>
+
+import { pathToFileURL } from "node:url";
+import {
+  createBalanceService,
+  formatTokenAmount,
+  type BalanceReader,
+  type TokenBalance,
+  type TokenInfo,
+} from "../../../src/balances";
+
+/** The token contracts the mock ledger knows about. Contract ids are obviously
+ * fake — this tool never touches a real network. */
+const MOCK_TOKENS: Record<string, TokenInfo> = {
+  CUSDCMOCKCONTRACTXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX: {
+    symbol: "USDC",
+    contractId: "CUSDCMOCKCONTRACTXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+    decimals: 7,
+  },
+  CXLMMOCKCONTRACTXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX: {
+    symbol: "XLM",
+    contractId: "CXLMMOCKCONTRACTXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+    decimals: 7,
+  },
+  CEURCMOCKCONTRACTXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX: {
+    symbol: "EURC",
+    contractId: "CEURCMOCKCONTRACTXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+    decimals: 6,
+  },
+};
+
+/** Raw balances the mock reader serves, keyed by `${contractId}:${holder}`.
+ * A holder with no entry reads as zero, which is what a real token contract
+ * returns for an address that has never held the asset. */
+const MOCK_LEDGER: Record<string, bigint> = {
+  "CUSDCMOCKCONTRACTXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX:CMOCKACCOUNTXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX":
+    1_250_5000000n,
+  "CXLMMOCKCONTRACTXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX:CMOCKACCOUNTXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX":
+    42_0000000n,
+  "CEURCMOCKCONTRACTXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX:CMOCKACCOUNTXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX":
+    18_750000n,
+};
+
+export interface CliArgs {
+  accountId: string;
+  tokenContractIds: string[];
+}
+
+/**
+ * Parses `<accountId> <tokenContractId...>`. Repeated contract ids are
+ * collapsed (first occurrence wins) so the table never shows the same token
+ * twice, and both the account id and at least one token are required.
+ */
+export function parseArgs(argv: string[]): CliArgs {
+  const positional = argv.filter((arg) => arg.trim() !== "");
+  const [accountId, ...tokenContractIds] = positional;
+
+  if (!accountId) {
+    throw new Error("Missing <accountId>. Usage: <accountId> <tokenContractId...>");
+  }
+  if (tokenContractIds.length === 0) {
+    throw new Error("At least one <tokenContractId> is required");
+  }
+
+  return { accountId, tokenContractIds: [...new Set(tokenContractIds)] };
+}
+
+/**
+ * A BalanceReader backed by MOCK_LEDGER. Unknown token contracts are rejected
+ * — a real token read against a non-token address fails too — while an unknown
+ * holder simply reads as zero.
+ */
+export function createMockBalanceReader(): BalanceReader {
+  return {
+    async getTokenBalance(tokenContractId: string, holder: string): Promise<bigint> {
+      if (!MOCK_TOKENS[tokenContractId]) {
+        throw new Error(`Unknown token contract ${tokenContractId}`);
+      }
+      return MOCK_LEDGER[`${tokenContractId}:${holder}`] ?? 0n;
+    },
+  };
+}
+
+/** Resolves contract ids to the TokenInfo the balance service needs, failing
+ * with the full list of known ids rather than a bare "not found". */
+export function resolveTokens(tokenContractIds: string[]): TokenInfo[] {
+  return tokenContractIds.map((contractId) => {
+    const token = MOCK_TOKENS[contractId];
+    if (!token) {
+      throw new Error(
+        `Unknown token contract "${contractId}". Known contracts:\n  ${Object.keys(MOCK_TOKENS).join("\n  ")}`,
+      );
+    }
+    return token;
+  });
+}
+
+/** Renders balances as an aligned text table: symbol and contract id left
+ * aligned, the formatted amount right aligned so decimal points line up. */
+export function formatBalanceTable(accountId: string, balances: TokenBalance[]): string {
+  const rows = balances.map((balance) => ({
+    token: balance.symbol,
+    contract: balance.contractId,
+    amount: formatTokenAmount(balance.amount, balance.decimals),
+  }));
+
+  const headers = { token: "TOKEN", contract: "CONTRACT", amount: "BALANCE" };
+  const width = (key: keyof typeof headers) =>
+    Math.max(headers[key].length, ...rows.map((row) => row[key].length));
+  const tokenWidth = width("token");
+  const contractWidth = width("contract");
+  const amountWidth = width("amount");
+
+  const line = (row: typeof headers) =>
+    `${row.token.padEnd(tokenWidth)}  ${row.contract.padEnd(contractWidth)}  ${row.amount.padStart(amountWidth)}`;
+
+  return [
+    `Account: ${accountId}`,
+    "",
+    line(headers),
+    "-".repeat(line(headers).length),
+    ...rows.map(line),
+  ].join("\n");
+}
+
+/**
+ * Runs one CLI invocation: resolve the tokens, read every balance through the
+ * SDK's balance service, and return the rendered table. Separated from `main`
+ * so it is directly testable without touching `process.argv`.
+ */
+export async function printBalances(
+  args: CliArgs,
+  reader: BalanceReader = createMockBalanceReader(),
+): Promise<string> {
+  const tokens = resolveTokens(args.tokenContractIds);
+  const balances = await createBalanceService(reader, tokens).getBalances(args.accountId);
+  return formatBalanceTable(args.accountId, balances);
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  console.log(await printBalances(args));
+}
+
+// pathToFileURL rather than a `file://` template so the entrypoint check also
+// holds on Windows, where argv[1] is a drive-letter path.
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main().catch((err) => {
+    console.error(`Error: ${(err as Error).message}`);
+    process.exitCode = 1;
+  });
+}


### PR DESCRIPTION
closes #72

## What this adds

A self-contained example under `contrib/examples/cli-balance-printer/` implementing a small command line tool that prints a formatted table of balances for a list of tokens given on the command line.

- `cli-balance-printer.ts` - the tool, with each stage exported so it is testable without touching `process.argv`.
- `cli-balance-printer.test.ts` - vitest coverage.
- `README.md` - usage, a note on running it with node, a sample run, and the mock contract table.

## Usage

```sh
npx tsx cli-balance-printer.ts <accountId> <tokenContractId...>
```

```
$ npx tsx cli-balance-printer.ts \
    CMOCKACCOUNTXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX \
    CXLMMOCKCONTRACTXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX \
    CUSDCMOCKCONTRACTXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX \
    CEURCMOCKCONTRACTXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
Account: CMOCKACCOUNTXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX

TOKEN  CONTRACT                                                 BALANCE
-----------------------------------------------------------------------
XLM    CXLMMOCKCONTRACTXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX       42
USDC   CUSDCMOCKCONTRACTXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX   1250.5
EURC   CEURCMOCKCONTRACTXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX    18.75
```

The README documents running it with node: node cannot execute a `.ts` file on its own, so the tool runs through the `tsx` loader - `npx tsx <file>` starts node with that loader attached, and `node --import tsx cli-balance-printer.ts ...` spells the same thing out when `tsx` is installed in the workspace. Nothing else is needed and no network access is involved.

## Design notes

- **It uses the real SDK path.** Balances are read through `createBalanceService` from `src/balances.ts` and rendered with `formatTokenAmount`, so each token is formatted with its own `decimals` (EURC has 6, the others 7) instead of the example reimplementing the conversion. That also means the example keeps working as a demonstration of the actual API rather than of a parallel one.
- **The mock is a seam, not a fork of the code path.** `createMockBalanceReader()` returns a `BalanceReader` - the single-method interface the balance service already reads through - backed by a plain object of raw amounts. An unknown token contract is rejected, since a real token read against a non-token address fails too, while an unknown holder reads as `0n`, which is what a real token contract returns for an address that has never held the asset. Because the reader is just a parameter of `printBalances`, passing the RPC-backed reader instead makes the same tool print live balances.
- **Unknown contracts fail before any read.** `resolveTokens` runs first and lists the known contract ids in the error, so a typo produces an actionable message rather than a table of zeros. There is a test asserting no read is issued in that case.
- **Repeated contract ids are collapsed** so the table never shows the same token twice, and amounts are right-aligned so decimal points line up.
- The entrypoint check uses `pathToFileURL(process.argv[1])` rather than a `file://` template literal, so the tool also runs on Windows, where `argv[1]` is a drive-letter path.

## Tests

```sh
npx vitest run contrib/examples/cli-balance-printer
# 16 passed
```

Covers argument parsing (including duplicate tokens and both missing-argument cases), contract id resolution, the mock reader's zero and unknown-contract behaviour, table alignment and per-token decimals, row order matching argument order, a zero balance being shown rather than omitted, the unknown-contract short circuit, and reading through an injected reader.

## Conventions and scope

Follows the existing `contrib/examples/` layout (`<name>.ts` / `<name>.test.ts` / `README.md`), the type-only imports from `src/`, and the exported-stages-plus-guarded-`main` structure used by the neighbouring CLI examples.

Every file is inside `contrib/`, and the PR is based on and targets `drips`.
