### PR TITLE
feat(mcp): chain-enforced spending limits — pay from a policy-governed smart account

### DIFF
--- a/packages/mcp-x402-payer/README.md
+++ b/packages/mcp-x402-payer/README.md
@@ -4,26 +4,25 @@ An MCP server that lets an AI agent **pay** for [x402](https://x402.org) (HTTP-4
 resources on Stellar. It runs locally beside the agent over stdio and holds
 exactly one key.
 
-> ### ⚠️ The key is a hot wallet. The spending limit is enforced by this process, not the chain.
+> ### ⚠️ Which spending limit you get depends on how you configure it
 >
-> The appeal of an agent budget is that the limit lives somewhere the model
-> cannot reach. **That is not what this ships today.** The ceiling here is
-> ordinary code in the same process the agent is talking to — stronger than a
-> prompt, weaker than a contract.
+> **Set `VELLAR_X402_WALLET` and the limit is enforced on-chain** by a Vellar
+> smart account's spending-limit policy, inside `__check_auth`. The model cannot
+> exceed it whatever it emits, and neither can this server. Verified live — see
+> [the demonstration](#the-demonstration).
 >
-> Concretely, on this path:
+> **Leave it unset and the key is a hot wallet.** The ceiling is then ordinary
+> code in the same process the agent is talking to — stronger than a prompt,
+> weaker than a contract. On that path the limit is *not* on-chain, it **resets
+> when the process restarts**, and it protects nothing if the key is exfiltrated,
+> because an attacker simply doesn't run this server. It guards against
+> **mistakes** — a typo, a runaway loop, a resource that costs more than expected
+> — not against a compromised agent. Fund such a key with only what you are
+> willing to lose.
 >
-> - The limit is **not** enforced on-chain. Nothing in a ledger stops a payment.
-> - It **resets when the process restarts**.
-> - It protects nothing if the key is exfiltrated — an attacker just doesn't run
->   this server.
->
-> So it is a guard against **mistakes** — a typo, a runaway loop, a resource that
-> costs more than expected — and not against a compromised or manipulated agent.
->
-> **Fund the key with only what you are willing to lose.** The chain-enforced
-> version needs a Vellar smart account, which is
-> [blocked upstream](#smart-accounts-are-blocked-upstream).
+> The server states which mode it is in at startup (`spendLimit:
+> chain-enforced` or `process-only`), and `x402_session_budget` says so on every
+> call. Do not describe the process-only ceiling to a user as an on-chain limit.
 
 This is the **payer** side. Discovery is a separate concern, handled by the
 [vellar-facilitator](https://github.com/Vellar-Wallet/vellar-facilitator)'s own
@@ -55,9 +54,14 @@ amount of prompt injection changes it.
 > agent's key is exfiltrated, layer 1 protects nothing — the attacker simply
 > doesn't run this server.
 
-**Today this server ships the keypair path, which has no layer 2.** See
-[Smart accounts](#smart-accounts-are-blocked-upstream) — treat the key it holds as
-a hot wallet and fund it with only what you are willing to lose.
+Layer 1 is always on. **Layer 2 requires `VELLAR_X402_WALLET`** — a Vellar smart
+account whose signing key carries a spending-limit policy. Without it you get
+layer 1 only, and the key is a hot wallet.
+
+Both layers apply together when configured, and they refuse at different points:
+layer 1 refuses *before signing*, layer 2 refuses *at settlement inside the
+wallet contract*. A refusal from layer 2 is visible as a policy rejection and
+tells the model that retrying with a larger `max_amount` will not help.
 
 ## Install
 
@@ -76,12 +80,22 @@ one prompt injection away from being echoed back out.
 | `VELLAR_X402_SECRET` | yes¹ | The payer's `S…` ed25519 secret |
 | `VELLAR_X402_SECRET_FILE` | yes¹ | Path to a file containing it instead |
 | `VELLAR_X402_ASSETS` | yes | `<assetContractId>:<sessionCeiling>` pairs, comma-separated |
+| `VELLAR_X402_WALLET` | no² | The paying smart account (`C…`) — **enables layer 2** |
+| `VELLAR_X402_POLICIES` | no² | Policy contracts in the key's `SignerLimits`, comma-separated |
 | `VELLAR_X402_NETWORK` | no | `testnet` (default) or `mainnet` |
 | `VELLAR_X402_RPC_URL` | no | Soroban RPC; defaults per network |
 | `VELLAR_X402_MAX_RESPONSE_BYTES` | no | Inline-content cap, default `262144` |
 
 ¹ Set exactly one of the two. `VELLAR_X402_SECRET_FILE` keeps the secret out of
 the process environment, where it is visible to child processes.
+
+² Together these select the chain-enforced path. With `VELLAR_X402_WALLET` set,
+`VELLAR_X402_SECRET` is the wallet's **agent session key**, not a standalone
+account. `VELLAR_X402_POLICIES` must name **every** policy in that key's
+`SignerLimits` — a missing one is rejected by the wallet before the policy is
+consulted, and the error looks like a broken signer rather than a missing
+co-signer. Setting policies without a wallet is refused at startup rather than
+ignored, so a half-configured layer 2 cannot look like a working one.
 
 `VELLAR_X402_ASSETS` is **both** the asset allowlist and the per-asset ceilings,
 because they are the same thing: an asset with no ceiling is not payable at all.
@@ -288,10 +302,50 @@ Payments are **serialised**. One key, one budget, one payment at a time:
 concurrent calls would otherwise each pass the ceiling check before either
 recorded a spend, and together exceed it.
 
-## Smart accounts are blocked upstream
+## The demonstration
 
-This server signs with a **plain ed25519 keypair**. It cannot yet pay from a
-Vellar smart account, and that is an upstream limitation, not a design choice:
+Two payments through the MCP protocol against a policy-governed smart account
+with a **0.5 USDC on-chain cap**. The server's own limits were set deliberately
+*above* the cap for both — `max_amount` 1.0 USDC, session ceiling 10 USDC — so no
+process-level guard could be what refused the second one.
+
+| | payment | outcome | evidence |
+| --- | --- | --- | --- |
+| **A** | 0.1 USDC (under cap) | **settled** | [`9e1f3acf…a0eb9d2a`](https://horizon-testnet.stellar.org/transactions/9e1f3acf3681d8a418b7619d480eefce855f7ff9a62b5546255c52cea0eb9d2a) — `successful: true`, ledger 4141211 |
+| **B** | 0.6 USDC (over cap) | **refused by the chain** | `__check_auth` → `policy__` → `Error(Contract, #1)`; no transaction, session ledger untouched |
+
+The wallet's USDC balance moved by exactly the settled amount and no more, so B
+spent nothing — confirmed by arithmetic on-chain, not by trusting the error.
+
+Reproducible as `test/integration/layer2.integration.test.ts`.
+
+### Reading the refusal
+
+The wallet wraps **every** auth failure in its own `Error(Contract, #110)`, so
+the top-level code says only *"auth failed"*, not why. The cause is nested:
+
+```
+[wallet] "contract try_call failed", policy__, [ …transfer args, 6000000… ]
+[policy] "VM call trapped with HostError", policy__, Error(Contract, #1)
+```
+
+A failed `policy__` call is the signal that a **policy** refused — layer 2 doing
+its job — as opposed to a malformed signature map, which produces the same `#110`
+with no policy invocation. Classifying on the top-level code alone gets this
+backwards; an earlier revision here did exactly that.
+
+### What it costs
+
+A policy-governed settle costs **28,678–116,202 stroops** actually charged
+on-chain (0.003–0.012 XLM), against a simulated estimate of 140,331 and a
+facilitator ceiling of 500,000. It fits with room to spare, and it is roughly the
+same as a plain keypair settle — running a policy inside `__check_auth` adds
+~6,900 stroops, about 5%.
+
+## Smart accounts: shipped here, still blocked in the official client
+
+Layer 2 works — but **not** through `@x402/stellar`'s `ExactStellarScheme`, which
+still cannot sign for a `C…` credential address:
 
 `AssembledTransaction.signAuthEntries` narrows any signer result to a naked
 buffer, which routes `authorizeEntry` down its ed25519 branch and calls
@@ -300,12 +354,26 @@ buffer, which routes `authorizeEntry` down its ed25519 branch and calls
 escape hatch exists for exactly this case, but `signAuthEntries` closes it off.
 Reproduced live against a deployed smart account.
 
-So the keypair version ships first, behind the `PaymentSigner` interface in
-[`src/signer.ts`](src/signer.ts). When upstream threads `authorizeEntry` through
-the client scheme, a smart-account implementation drops in there and nothing else
-in this package changes. **We do not fork the SDK to get there.**
+Filed upstream as
+[x402-foundation/x402#3159](https://github.com/x402-foundation/x402/issues/3159).
 
-Until then there is no layer 2 on this path. Fund the key accordingly.
+**We are not waiting on it.** `x402Client.register()` accepts any
+`SchemeNetworkClient`, so this package registers its own
+([`src/smart-account-scheme.ts`](src/smart-account-scheme.ts)) which signs the
+auth entries directly and never calls `signAuthEntries` — the narrowing that
+blocks the official path simply never happens. That is a documented extension
+point, not a fork.
+
+Everything above the `PaymentSigner` seam is identical on both paths: guards,
+option narrowing, the selection tripwire, retry, the session ledger. Swapping
+signers is the whole difference, which is what that interface was for.
+
+One thing the wallet requires that the official client would not have told you:
+a policy-governed key must carry its policies in the signature map as
+`SignerKey::Policy` entries alongside the ed25519 one. Omit them and the wallet
+rejects the entry **before consulting the policy**, with the same opaque `#110`
+— which reads as a broken signer rather than a missing co-signer. Set
+`VELLAR_X402_POLICIES` to every policy in the key's `SignerLimits`.
 
 ## Development
 

--- a/packages/mcp-x402-payer/src/bin.ts
+++ b/packages/mcp-x402-payer/src/bin.ts
@@ -11,7 +11,7 @@ import { createSpendLedger } from "./ledger.js";
 import { formatError, log, registerSecret } from "./output.js";
 import { createPayer } from "./payer.js";
 import { createMcpServer, startStdio } from "./server.js";
-import { createOfficialSigner } from "./signer.js";
+import { createOfficialSigner, createSmartAccountSigner } from "./signer.js";
 
 async function main(): Promise<void> {
   const config = loadConfig();
@@ -20,15 +20,21 @@ async function main(): Promise<void> {
   registerSecret(config.secret);
 
   const ledger = createSpendLedger(config.ceilings);
-  // Built once: the keypair is derived a single time, and a malformed secret
-  // fails here rather than at the first payment.
-  const signer = createOfficialSigner(config);
+  // Built once: the key is derived a single time, and a malformed secret fails
+  // here rather than at the first payment. A configured wallet selects the
+  // smart-account path, where the spending limit is enforced on-chain.
+  const smartAccount = config.walletAddress !== undefined;
+  const signer = smartAccount ? createSmartAccountSigner(config) : createOfficialSigner(config);
   const payer = createPayer({ config, ledger, signer });
 
   log("info", "vellar x402 payer ready", {
     network: config.network,
     payer: signer.address,
     assets: config.allowedAssets.length,
+    // Stated at startup because it is the difference between a limit a
+    // compromised agent can escape and one it cannot.
+    spendLimit: smartAccount ? "chain-enforced (smart account policy)" : "process-only (hot wallet)",
+    ...(smartAccount ? { policies: config.policies.length } : {}),
   });
 
   await startStdio(createMcpServer({ payer, config, ledger }));

--- a/packages/mcp-x402-payer/src/config.ts
+++ b/packages/mcp-x402-payer/src/config.ts
@@ -43,6 +43,19 @@ export interface PayerConfig {
   readonly allowedAssets: readonly string[];
   /** Inlined resource text is truncated past this many bytes, with a marker. */
   readonly maxResponseBytes: number;
+  /**
+   * The paying smart account (`C…`). Present ⇒ LAYER 2: payments are signed for
+   * this wallet and its on-chain spending-limit policy is the real bound.
+   * Absent ⇒ layer 1 only, paying from the bare keypair as a hot wallet.
+   */
+  readonly walletAddress?: string;
+  /**
+   * Policy contracts the signing key's `SignerLimits` require. These must appear
+   * in the signature map or the WALLET rejects the entry before the policy is
+   * consulted — `Error(Contract, #110)`, which reads as a broken signer rather
+   * than a missing co-signer.
+   */
+  readonly policies: readonly string[];
   /** The payer secret. Non-enumerable — see the module comment. */
   readonly secret: string;
 }
@@ -160,6 +173,26 @@ function parseAssets(raw: string): Map<string, bigint> {
   return ceilings;
 }
 
+/** Parse `VELLAR_X402_POLICIES`: comma-separated policy contract ids. */
+function parsePolicies(raw: string | undefined): readonly string[] {
+  if (raw === undefined || raw.trim() === "") return Object.freeze([]);
+  const out: string[] = [];
+  for (const entry of raw.split(",")) {
+    const policy = entry.trim();
+    if (policy === "") continue;
+    if (!StrKey.isValidContract(policy)) {
+      throw new ConfigError(
+        `VELLAR_X402_POLICIES names ${JSON.stringify(policy)}, which is not a Soroban contract id (C…).`,
+      );
+    }
+    if (out.includes(policy)) {
+      throw new ConfigError(`VELLAR_X402_POLICIES lists ${policy} more than once.`);
+    }
+    out.push(policy);
+  }
+  return Object.freeze(out);
+}
+
 function parseNetwork(raw: string | undefined): PayerNetwork {
   const value = (raw ?? "testnet").trim();
   if (value !== "testnet" && value !== "mainnet") {
@@ -196,6 +229,23 @@ export function loadConfig(env: NodeJS.ProcessEnv = process.env): PayerConfig {
   const rpcUrl = env.VELLAR_X402_RPC_URL?.trim() || undefined;
   const maxResponseBytes = parseMaxResponseBytes(env.VELLAR_X402_MAX_RESPONSE_BYTES);
 
+  const walletAddress = env.VELLAR_X402_WALLET?.trim() || undefined;
+  if (walletAddress !== undefined && !StrKey.isValidContract(walletAddress)) {
+    throw new ConfigError(
+      `VELLAR_X402_WALLET must be a Soroban contract id (C…), got ${JSON.stringify(walletAddress)}.`,
+    );
+  }
+
+  const policies = parsePolicies(env.VELLAR_X402_POLICIES);
+  if (policies.length > 0 && walletAddress === undefined) {
+    // Policies only mean something for a smart account. Silently ignoring them
+    // would look like layer 2 is configured when it is not.
+    throw new ConfigError(
+      "VELLAR_X402_POLICIES is set but VELLAR_X402_WALLET is not. Policies apply to a " +
+        "smart account's signer; without a wallet there is no on-chain budget to enforce.",
+    );
+  }
+
   const config = {
     network,
     caip2: CAIP2_BY_NETWORK[network],
@@ -203,6 +253,8 @@ export function loadConfig(env: NodeJS.ProcessEnv = process.env): PayerConfig {
     ceilings,
     allowedAssets: Object.freeze([...ceilings.keys()]),
     maxResponseBytes,
+    ...(walletAddress !== undefined ? { walletAddress } : {}),
+    policies,
   };
 
   // Non-enumerable: absent from JSON.stringify, {...spread}, Object.keys, and

--- a/packages/mcp-x402-payer/src/index.ts
+++ b/packages/mcp-x402-payer/src/index.ts
@@ -34,4 +34,5 @@ export {
   type X402ResourceInfo,
 } from "./protocol.js";
 export { createMcpServer, startStdio, type ServerDeps } from "./server.js";
-export { createOfficialSigner, type PaymentSigner } from "./signer.js";
+export { createOfficialSigner, createSmartAccountSigner, type PaymentSigner } from "./signer.js";
+export { createSmartAccountScheme, SmartAccountAuthError, type SchemeClientLike } from "./smart-account-scheme.js";

--- a/packages/mcp-x402-payer/src/signer.ts
+++ b/packages/mcp-x402-payer/src/signer.ts
@@ -1,26 +1,36 @@
 // The payment signer — the ONLY part of this package that knows how a payment is
-// built and signed.
+// built and signed. Two implementations, chosen by configuration:
 //
-// Today there is one implementation, backed by the official @x402 client with a
-// plain ed25519 keypair. That is deliberate: the official client cannot sign for
-// a Soroban smart account, because `AssembledTransaction.signAuthEntries` narrows
-// the signer result to a naked buffer, which sends `authorizeEntry` down its
-// ed25519 branch and calls `Keypair.fromPublicKey` on the entry's C-address —
-// "invalid version byte. expected 48, got 16". The SDK's `{ signatureScVal }`
-// escape hatch exists for exactly this case, but `signAuthEntries` closes it off.
+//   KEYPAIR (layer 1 only) — the official @x402 client with a plain ed25519 key.
+//   The spending ceiling is enforced by this process; the key is a hot wallet.
 //
-// So the keypair version ships first, behind this interface. When upstream
-// threads `authorizeEntry` through the client scheme, a smart-account
-// implementation drops in here and nothing else in this package changes. We do
-// NOT fork the SDK to get there.
+//   SMART ACCOUNT (layer 2) — our own scheme client, paying from a Soroban smart
+//   account whose spending-limit policy is enforced on-chain inside
+//   `__check_auth`. The model cannot exceed it whatever it emits.
+//
+// The smart-account path needs its own scheme because the official one cannot
+// sign for a `C…` credential address: `AssembledTransaction.signAuthEntries`
+// narrows the signer result to a naked buffer, which sends `authorizeEntry` down
+// its ed25519 branch and throws "invalid version byte. expected 48, got 16".
+// Filed upstream as x402-foundation/x402#3159. We register our own
+// `SchemeNetworkClient` — a documented extension point, not a fork — and are
+// therefore not waiting on that fix.
 
 import { x402Client } from "@x402/core/client";
 import { x402HTTPClient } from "@x402/core/http";
 import { createEd25519Signer } from "@x402/stellar";
 import { ExactStellarScheme } from "@x402/stellar/exact/client";
+import { createSessionKeySigner } from "vellar-sdk";
 import type { PayerConfig } from "./config.js";
 import { SelectionMismatchError } from "./errors.js";
 import type { X402Challenge, X402Requirement } from "./protocol.js";
+import { createSmartAccountScheme } from "./smart-account-scheme.js";
+
+/** Soroban RPC defaults when `VELLAR_X402_RPC_URL` is unset. */
+const DEFAULT_RPC_URL: Record<string, string> = {
+  testnet: "https://soroban-testnet.stellar.org",
+  mainnet: "https://mainnet.sorobanrpc.com",
+};
 
 /**
  * Signs one x402 payment.
@@ -32,9 +42,101 @@ import type { X402Challenge, X402Requirement } from "./protocol.js";
  *  - The returned value is the HTTP headers carrying the signature.
  */
 export interface PaymentSigner {
-  /** The paying address. `G…` today; `C…` once smart accounts are unblocked. */
+  /** The paying address: `G…` for a keypair, `C…` for a smart account. */
   readonly address: string;
   signPayment(challenge: X402Challenge): Promise<Record<string, string>>;
+}
+
+/**
+ * The selection tripwire, shared by both signers.
+ *
+ * `createPaymentPayload` re-selects internally, so a guard applied to the
+ * decoded challenge alone could clear option X while the client pays option Y.
+ * We narrow `accepts` to one option before calling in; this fails the payment if
+ * what is about to be signed is not that exact object. Unreachable today by
+ * construction — it exists so an upstream change cannot silently widen what gets
+ * paid.
+ */
+function selectionTripwire() {
+  const expected: { current?: X402Requirement } = {};
+  return {
+    expected,
+    install(client: x402Client) {
+      client.onBeforePaymentCreation(async (ctx) => {
+        if (expected.current === undefined) {
+          throw new SelectionMismatchError(
+            "Payment creation began with no cleared requirement recorded; refusing to sign.",
+          );
+        }
+        // Identity, not equality: the object about to be signed must be the very
+        // one the guards cleared, not merely one that looks like it.
+        if ((ctx.selectedRequirements as unknown) !== (expected.current as unknown)) {
+          throw new SelectionMismatchError(
+            "The x402 client selected a payment option other than the one the guards cleared; " +
+              "refusing to sign.",
+          );
+        }
+      });
+    },
+  };
+}
+
+/**
+ * Build the SMART-ACCOUNT signer — the layer-2 path.
+ *
+ * Registers our own scheme client rather than `ExactStellarScheme`, because the
+ * official one cannot sign for a `C…` credential address (upstream
+ * x402-foundation/x402#3159). Everything above this seam — guards, narrowing,
+ * the selection tripwire, retry, the session ledger — is unchanged, which is
+ * what the `PaymentSigner` interface was for.
+ *
+ * The spending limit here is enforced by the wallet contract, not by this
+ * process: over-budget payments are refused inside `__check_auth` and no amount
+ * of emitted text changes that.
+ */
+export function createSmartAccountSigner(config: PayerConfig): PaymentSigner {
+  if (!config.walletAddress) {
+    throw new Error("createSmartAccountSigner requires VELLAR_X402_WALLET");
+  }
+
+  const accountSigner = createSessionKeySigner({
+    address: config.walletAddress,
+    secretKey: config.secret,
+    policies: config.policies,
+  });
+
+  const client = new x402Client((_v, accepts) => accepts[0]!).register(
+    config.caip2,
+    createSmartAccountScheme({
+      signer: accountSigner,
+      rpcUrl: config.rpcUrl ?? DEFAULT_RPC_URL[config.network]!,
+    }) as never,
+  );
+
+  const { expected, install } = selectionTripwire();
+  install(client);
+  const http = new x402HTTPClient(client);
+
+  return {
+    address: config.walletAddress,
+    async signPayment(challenge) {
+      const accepts = challenge.accepts;
+      if (accepts.length !== 1) {
+        throw new SelectionMismatchError(
+          `signPayment expects exactly one cleared payment option, got ${accepts.length}.`,
+        );
+      }
+      expected.current = accepts[0]!;
+      try {
+        const payload = await http.createPaymentPayload(
+          challenge as unknown as Parameters<typeof http.createPaymentPayload>[0],
+        );
+        return http.encodePaymentSignatureHeader(payload);
+      } finally {
+        expected.current = undefined;
+      }
+    },
+  };
 }
 
 /**
@@ -55,29 +157,8 @@ export function createOfficialSigner(config: PayerConfig): PaymentSigner {
     new ExactStellarScheme(signer, config.rpcUrl ? { url: config.rpcUrl } : undefined),
   );
 
-  // The tripwire (issue 2A). `createPaymentPayload` re-selects internally, so a
-  // guard applied to the decoded challenge alone could clear option X while the
-  // client pays option Y. We narrow `accepts` to one option before calling in,
-  // and this hook fails the payment if what it is about to sign is not that
-  // exact object. Unreachable today by construction — it exists so an upstream
-  // change can never silently widen what gets paid.
-  let expected: X402Requirement | undefined;
-  client.onBeforePaymentCreation(async (ctx) => {
-    if (expected === undefined) {
-      throw new SelectionMismatchError(
-        "Payment creation began with no cleared requirement recorded; refusing to sign.",
-      );
-    }
-    // Identity, not equality: the object about to be signed must be the very one
-    // the guards cleared, not merely one that looks like it.
-    if ((ctx.selectedRequirements as unknown) !== (expected as unknown)) {
-      throw new SelectionMismatchError(
-        "The x402 client selected a payment option other than the one the guards cleared; " +
-          "refusing to sign.",
-      );
-    }
-  });
-
+  const { expected, install } = selectionTripwire();
+  install(client);
   const http = new x402HTTPClient(client);
 
   return {
@@ -90,7 +171,7 @@ export function createOfficialSigner(config: PayerConfig): PaymentSigner {
           `signPayment expects exactly one cleared payment option, got ${accepts.length}.`,
         );
       }
-      expected = accepts[0]!;
+      expected.current = accepts[0]!;
       try {
         // Fresh every call — never cache a signed payload.
         const payload = await http.createPaymentPayload(
@@ -98,7 +179,7 @@ export function createOfficialSigner(config: PayerConfig): PaymentSigner {
         );
         return http.encodePaymentSignatureHeader(payload);
       } finally {
-        expected = undefined;
+        expected.current = undefined;
       }
     },
   };

--- a/packages/mcp-x402-payer/src/smart-account-scheme.ts
+++ b/packages/mcp-x402-payer/src/smart-account-scheme.ts
@@ -1,0 +1,183 @@
+// The smart-account payment scheme — layer 2.
+//
+// `ExactStellarScheme` cannot pay from a Soroban smart account: it signs through
+// `AssembledTransaction.signAuthEntries`, which narrows the signer's result to a
+// naked buffer and routes `authorizeEntry` down its ed25519 branch. For a
+// `C…` credential address that throws (filed upstream as
+// x402-foundation/x402#3159).
+//
+// So we register our OWN scheme client instead. `x402Client.register()` accepts
+// any `SchemeNetworkClient`, which is a documented extension point — this is not
+// a fork, and it does not wait on the upstream fix. Writing the scheme ourselves
+// also means we never call `signAuthEntries` at all: we sign the auth entries
+// directly with the SDK's V1 smart-account signer, so the narrowing that blocks
+// the official path simply never happens.
+//
+// Everything else the official scheme does is preserved: SEP-41 transfer
+// assembly, NULL_ACCOUNT simulation (no funded source account), ledger-derived
+// expiry, and the post-signing re-simulation.
+
+import { Address, rpc, nativeToScVal, xdr } from "@stellar/stellar-sdk";
+import { AssembledTransaction } from "@stellar/stellar-sdk/contract";
+import type { SmartAccountX402Signer } from "vellar-sdk";
+import type { X402Requirement } from "./protocol.js";
+
+/** Ledger close time used to turn the server's timeout into a ledger window. */
+const ESTIMATED_LEDGER_SECONDS = 5;
+/** Stay under the facilitator's own computed maxLedger — it reads its ledger a
+ * beat after we read ours, so its "current" is ≥ ours. */
+const EXPIRATION_SAFETY_MARGIN = 2;
+const MIN_EXPIRATION_LEDGERS = 3;
+
+const NETWORK_PASSPHRASE: Record<string, string> = {
+  "stellar:testnet": "Test SDF Network ; September 2015",
+  "stellar:pubnet": "Public Global Stellar Network ; September 2015",
+};
+
+export interface SmartAccountSchemeDeps {
+  /** Produces V1 auth-entry signatures the wallet's `__check_auth` accepts. */
+  signer: SmartAccountX402Signer;
+  rpcUrl: string;
+}
+
+/** The subset of `SchemeNetworkClient` @x402/core actually calls on a client. */
+export interface SchemeClientLike {
+  readonly scheme: string;
+  createPaymentPayload(
+    x402Version: number,
+    requirements: X402Requirement,
+    context?: { extensions?: Record<string, unknown> | null },
+  ): Promise<{ x402Version: number; payload: { transaction: string } }>;
+}
+
+function expirationLedgersFor(maxTimeoutSeconds: number): number {
+  const window = Math.ceil(maxTimeoutSeconds / ESTIMATED_LEDGER_SECONDS);
+  return Math.max(window - EXPIRATION_SAFETY_MARGIN, MIN_EXPIRATION_LEDGERS);
+}
+
+/**
+ * A scheme client that pays from a Soroban smart account.
+ *
+ * The payer is the wallet contract; the agent's ed25519 session key signs, and
+ * any policies its `SignerLimits` require are carried in the signature map. The
+ * spending limit is enforced on-chain inside `__check_auth` — this client cannot
+ * exceed it, and neither can anything that drives this client.
+ */
+export function createSmartAccountScheme(deps: SmartAccountSchemeDeps): SchemeClientLike {
+  const server = new rpc.Server(deps.rpcUrl);
+
+  return {
+    scheme: "exact",
+
+    async createPaymentPayload(x402Version, requirements) {
+      const passphrase = NETWORK_PASSPHRASE[requirements.network];
+      if (!passphrase) {
+        throw new Error(`Unsupported Stellar network: ${requirements.network}`);
+      }
+      if (requirements.extra?.areFeesSponsored !== true) {
+        throw new Error("Exact scheme requires areFeesSponsored to be true");
+      }
+
+      // No `publicKey` — simulation runs from the SDK's NULL_ACCOUNT, so the
+      // payer is never the transaction source and no funded classic account is
+      // needed. (Older Vellar examples passed SIM_SOURCE_ACCOUNT; obsolete.)
+      const tx = await AssembledTransaction.build({
+        contractId: requirements.asset,
+        method: "transfer",
+        args: [
+          nativeToScVal(deps.signer.address, { type: "address" }),
+          nativeToScVal(requirements.payTo, { type: "address" }),
+          nativeToScVal(BigInt(requirements.amount), { type: "i128" }),
+        ],
+        networkPassphrase: passphrase,
+        rpcUrl: deps.rpcUrl,
+        parseResultXdr: (r: unknown) => r,
+      });
+
+      if (!tx.built) {
+        throw new Error("Failed to assemble the transfer (simulation returned nothing).");
+      }
+
+      const latest = await server.getLatestLedger();
+      const expirationLedger =
+        latest.sequence + expirationLedgersFor(requirements.maxTimeoutSeconds);
+
+      // Sign every auth entry belonging to the wallet. Fresh every call —
+      // signatures expire in ledgers (~5s each), so a cached payload is a
+      // payload that will be rejected.
+      const op = tx.built.operations[0] as { auth?: xdr.SorobanAuthorizationEntry[] };
+      const auth = op.auth ?? [];
+      let signed = 0;
+      for (let i = 0; i < auth.length; i++) {
+        const entry = auth[i]!;
+        if (entry.credentials().switch().name !== "sorobanCredentialsAddress") continue;
+        const addr = Address.fromScAddress(entry.credentials().address().address()).toString();
+        if (addr !== deps.signer.address) continue;
+
+        const signedXdr = await deps.signer.signAuthEntry(entry.toXDR("base64"), {
+          networkPassphrase: passphrase,
+          expirationLedger,
+        });
+        auth[i] = xdr.SorobanAuthorizationEntry.fromXDR(signedXdr, "base64");
+        signed++;
+      }
+      if (signed === 0) {
+        throw new Error(
+          `No auth entry found for the paying wallet ${deps.signer.address}.`,
+        );
+      }
+      op.auth = auth;
+
+      // Re-simulate AFTER signing. This is where `__check_auth` — and therefore
+      // the spending-limit policy — actually executes; the pre-signing
+      // simulation runs in recording mode and never consults it. Skipping this
+      // ships a payload whose resource fee omits the auth path, and hides a
+      // policy refusal until the facilitator hits it.
+      await tx.simulate({ restore: false });
+      const sim = tx.simulation;
+      if (!sim || rpc.Api.isSimulationError(sim)) {
+        const detail = sim && "error" in sim ? String(sim.error) : "unknown simulation failure";
+        throw new SmartAccountAuthError(detail);
+      }
+
+      return { x402Version, payload: { transaction: tx.built.toXDR() } };
+    },
+  };
+}
+
+/**
+ * `__check_auth` refused the signed entry.
+ *
+ * DO NOT classify on the top-level contract error code. The wallet wraps every
+ * auth failure in its own `Error(Contract, #110)`, including the case where a
+ * policy it invoked rejected the payment — so `#110` alone says only "auth
+ * failed", not why. Verified on testnet: an over-cap payment surfaces `#110` at
+ * the top with the real cause nested in the diagnostic events:
+ *
+ *   [wallet] "contract try_call failed", policy__, [ …transfer args… ]
+ *   [policy] "VM call trapped with HostError", policy__, Error(Contract, #1)
+ *
+ * The presence of a failed `policy__` call is the signal that a POLICY refused —
+ * i.e. layer 2 doing its job — as distinct from a malformed signature map.
+ */
+export class SmartAccountAuthError extends Error {
+  /** True when a policy contract was invoked and rejected the payment. */
+  readonly policyRejected: boolean;
+
+  constructor(readonly detail: string) {
+    const policyRejected = /try_call failed.*policy__|policy__.*Error\(Contract, #1\)/s.test(detail);
+    super(
+      `The smart account did not authorise this payment. ` +
+        (policyRejected
+          ? "A spending policy attached to the signing key REFUSED it — this is the on-chain " +
+            "budget being enforced, not a client error. The payment exceeds what the wallet " +
+            "permits, and no retry or larger max_amount will change that."
+          : "No policy rejection was found in the diagnostics, so this is more likely a " +
+            "signature-map or signer-configuration problem than a budget decision — check " +
+            "VELLAR_X402_WALLET and VELLAR_X402_POLICIES against the wallet's on-chain signers.") +
+        `\n\n${detail}`,
+    );
+    this.name = "SmartAccountAuthError";
+    this.policyRejected = policyRejected;
+  }
+}

--- a/packages/mcp-x402-payer/test/integration/layer2.integration.test.ts
+++ b/packages/mcp-x402-payer/test/integration/layer2.integration.test.ts
@@ -1,0 +1,128 @@
+// LAYER 2 — the demonstration that makes "the agent cannot exceed its budget" a
+// checkable claim rather than a description.
+//
+// Two payments through the REAL MCP protocol against a policy-governed Vellar
+// smart account, with a spending-limit policy enforced on-chain inside
+// `__check_auth`:
+//
+//   A. UNDER the on-chain cap  -> settles; hash verified on Horizon
+//   B. OVER  the on-chain cap  -> refused by the wallet contract; nothing spent
+//
+// What makes B meaningful: this server's OWN limits are set deliberately ABOVE
+// the on-chain cap for both calls, so no process-level guard can be what refuses
+// B. `max_amount` and the session ceiling both exceed the over-cap amount. The
+// only thing left that can refuse is the chain.
+//
+// Requires a provisioned smart account (see the README) plus a local facilitator
+// and two sellers — one priced under the cap, one over.
+
+import { existsSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { assertLocalEndpoints } from "./local-only.js";
+
+const HORIZON = "https://horizon-testnet.stellar.org";
+const PKG_ROOT = join(dirname(fileURLToPath(import.meta.url)), "..", "..");
+const BIN = join(PKG_ROOT, "dist", "bin.js");
+
+const env = {
+  secret: process.env.VELLAR_X402_SECRET,
+  wallet: process.env.VELLAR_X402_WALLET,
+  policy: process.env.VELLAR_X402_POLICIES,
+  asset: process.env.VELLAR_X402_TEST_ASSET,
+  underUrl: process.env.VELLAR_X402_SELLER_URL,
+  overUrl: process.env.VELLAR_X402_SELLER_OVERCAP_URL,
+};
+const configured = Object.values(env).every(Boolean);
+
+if (configured) {
+  assertLocalEndpoints({
+    VELLAR_X402_SELLER_URL: env.underUrl!,
+    VELLAR_X402_SELLER_OVERCAP_URL: env.overUrl!,
+  });
+}
+
+describe.skipIf(!configured)("layer 2 — the chain enforces the budget", () => {
+  let client: Client;
+  const textOf = (r: unknown) =>
+    ((r as { content?: Array<{ text?: string }> }).content ?? [])
+      .map((c) => c.text ?? "")
+      .join("\n");
+
+  beforeAll(async () => {
+    expect(existsSync(BIN), `built server missing at ${BIN} — run npm run build`).toBe(true);
+    client = new Client({ name: "layer2-integration", version: "1.0.0" });
+    await client.connect(
+      new StdioClientTransport({
+        command: process.execPath,
+        args: [BIN],
+        env: {
+          PATH: process.env.PATH ?? "",
+          VELLAR_X402_SECRET: env.secret!,
+          VELLAR_X402_WALLET: env.wallet!,
+          VELLAR_X402_POLICIES: env.policy!,
+          // Deliberately far above the on-chain cap. If a process-level guard
+          // refused B, this test would prove nothing.
+          VELLAR_X402_ASSETS: `${env.asset}:100000000`,
+          VELLAR_X402_NETWORK: "testnet",
+        },
+        stderr: "pipe",
+      }),
+    );
+  }, 60_000);
+
+  afterAll(async () => {
+    await client?.close();
+  });
+
+  it("pays from the smart account, and the settlement is real", async () => {
+    const res = await client.callTool({
+      name: "x402_pay",
+      arguments: { resource_url: env.underUrl!, max_amount: "10000000" },
+    });
+    const text = textOf(res);
+
+    expect(res.isError ?? false, text).toBe(false);
+    const hash = text.match(/Settlement transaction: ([0-9a-f]{64})/)?.[1];
+    expect(hash, `no settlement hash in:\n${text}`).toBeDefined();
+
+    // Verified on chain, not taken from the response.
+    const tx = await fetch(`${HORIZON}/transactions/${hash}`);
+    expect(tx.ok, `Horizon did not find ${hash}`).toBe(true);
+    expect(((await tx.json()) as { successful: boolean }).successful).toBe(true);
+  }, 180_000);
+
+  it("is refused by the CHAIN when the payment exceeds the on-chain cap", async () => {
+    const before = textOf(await client.callTool({ name: "x402_session_budget", arguments: {} }));
+
+    const res = await client.callTool({
+      name: "x402_pay",
+      arguments: { resource_url: env.overUrl!, max_amount: "10000000" },
+    });
+    const text = textOf(res);
+
+    expect(res.isError).toBe(true);
+    // The wallet contract refused, via the policy it invoked.
+    expect(text).toMatch(/spending policy attached to the signing key REFUSED/);
+    expect(text).toMatch(/on-chain budget being enforced/);
+    // Nothing settled.
+    expect(text).not.toMatch(/Settlement transaction: [0-9a-f]{64}/);
+
+    // And no process-level guard was involved — the session ledger is untouched,
+    // which is what distinguishes "the chain refused" from "we refused".
+    const after = textOf(await client.callTool({ name: "x402_session_budget", arguments: {} }));
+    expect(after).toBe(before);
+  }, 180_000);
+
+  it("tells the model that retrying bigger will not help", async () => {
+    // A budget refusal that reads as transient invites exactly the wrong retry.
+    const res = await client.callTool({
+      name: "x402_pay",
+      arguments: { resource_url: env.overUrl!, max_amount: "10000000" },
+    });
+    expect(textOf(res)).toMatch(/no retry or larger max_amount will change that/);
+  }, 180_000);
+});

--- a/packages/mcp-x402-payer/test/smart-account.test.ts
+++ b/packages/mcp-x402-payer/test/smart-account.test.ts
@@ -1,0 +1,105 @@
+// Smart-account path: configuration and refusal classification.
+//
+// The live behaviour is covered by test/integration/layer2.integration.test.ts,
+// which settles a real payment and has the chain refuse an over-cap one. These
+// pin the parts that must not regress silently.
+
+import { describe, expect, it } from "vitest";
+import { loadConfig } from "../src/config.js";
+import { ConfigError } from "../src/errors.js";
+import { SmartAccountAuthError } from "../src/smart-account-scheme.js";
+import { ASSET_A, testEnv } from "./helpers.js";
+
+const WALLET = "CAFIATCEAZJTGQQKFL3N2YB6VMCUN2UYX4QD5A3FALDRU7UJJ6OWBKOW";
+const POLICY = "CC24EVD6SD7WF2U4GSIBGU7V6LCN3MLZOJZAZCRQNDS3X6KYIL45K2E3";
+
+describe("smart-account configuration", () => {
+  it("stays on the keypair path when no wallet is configured", () => {
+    const config = loadConfig(testEnv());
+    expect(config.walletAddress).toBeUndefined();
+    expect(config.policies).toEqual([]);
+  });
+
+  it("selects the smart-account path when a wallet is configured", () => {
+    const config = loadConfig({
+      ...testEnv(),
+      VELLAR_X402_WALLET: WALLET,
+      VELLAR_X402_POLICIES: POLICY,
+    });
+    expect(config.walletAddress).toBe(WALLET);
+    expect(config.policies).toEqual([POLICY]);
+  });
+
+  it("rejects a wallet address that is not a contract", () => {
+    expect(() =>
+      loadConfig({ ...testEnv(), VELLAR_X402_WALLET: "GAVU25UK4ISUJIH6KWLXX6XDKKCR3GNZ27RZ5WABRSE42ZADV2LB3ZLU" }),
+    ).toThrow(/must be a Soroban contract id/);
+  });
+
+  it("refuses policies without a wallet rather than ignoring them", () => {
+    // Silently dropping them would look like layer 2 is on when it is not.
+    expect(() => loadConfig({ ...testEnv(), VELLAR_X402_POLICIES: POLICY })).toThrow(ConfigError);
+    expect(() => loadConfig({ ...testEnv(), VELLAR_X402_POLICIES: POLICY })).toThrow(
+      /VELLAR_X402_WALLET is not/,
+    );
+  });
+
+  it("rejects a malformed or duplicated policy id", () => {
+    const base = { ...testEnv(), VELLAR_X402_WALLET: WALLET };
+    expect(() => loadConfig({ ...base, VELLAR_X402_POLICIES: "not-a-contract" })).toThrow(
+      /not a Soroban contract id/,
+    );
+    expect(() => loadConfig({ ...base, VELLAR_X402_POLICIES: `${POLICY},${POLICY}` })).toThrow(
+      /more than once/,
+    );
+  });
+
+  it("keeps the asset allowlist independent of the wallet", () => {
+    const config = loadConfig({ ...testEnv(), VELLAR_X402_WALLET: WALLET });
+    expect(config.allowedAssets).toContain(ASSET_A);
+  });
+});
+
+describe("SmartAccountAuthError classification", () => {
+  // Captured verbatim from testnet. The top-level code is the WALLET's generic
+  // auth wrapper; the cause is nested. Classifying on #110 alone gets this
+  // exactly backwards, which an earlier revision did.
+  const overCap = `HostError: Error(Auth, InvalidAction)
+   0: [Diagnostic Event] contract:CBIELTK6, topics:[error, Error(Auth, InvalidAction)], data:["failed account authentication with error", CAFIATCE, Error(Contract, #110)]
+   1: [Failed Diagnostic Event] contract:CAFIATCE, topics:[error, Error(Contract, #110)], data:"escalating Ok(ScErrorType::Contract) frame-exit to Err"
+   2: [Failed Diagnostic Event] contract:CAFIATCE, topics:[error, Error(Contract, #1)], data:["contract try_call failed", policy__, [CAFIATCE, [Ed25519, Bytes(89b1)], [[Contract, {args: [CAFIATCE, GAVU25UK, 6000000], contract: CBIELTK6, fn_name: transfer}]]]]
+   3: [Failed Diagnostic Event] contract:CC24EVD6, topics:[log], data:["VM call trapped with HostError", policy__, Error(Contract, #1)]`;
+
+  const malformed = `HostError: Error(Auth, InvalidAction)
+   0: [Diagnostic Event] contract:CBIELTK6, topics:[error, Error(Auth, InvalidAction)], data:["failed account authentication with error", CAFIATCE, Error(Contract, #110)]`;
+
+  it("identifies a policy refusal as the on-chain budget working", () => {
+    const err = new SmartAccountAuthError(overCap);
+    expect(err.policyRejected).toBe(true);
+    expect(err.message).toMatch(/REFUSED it/);
+    expect(err.message).toMatch(/on-chain budget being enforced/);
+  });
+
+  it("tells the model a larger max_amount will not help", () => {
+    // The wrong reaction to a budget refusal is to retry it bigger.
+    expect(new SmartAccountAuthError(overCap).message).toMatch(
+      /no retry or larger max_amount will change that/,
+    );
+  });
+
+  it("does NOT classify on the top-level #110 alone", () => {
+    // Both inputs carry #110; only one is a policy refusal.
+    expect(new SmartAccountAuthError(overCap).policyRejected).toBe(true);
+    expect(new SmartAccountAuthError(malformed).policyRejected).toBe(false);
+  });
+
+  it("points at signer configuration when no policy was invoked", () => {
+    const err = new SmartAccountAuthError(malformed);
+    expect(err.message).toMatch(/signature-map or signer-configuration problem/);
+    expect(err.message).toMatch(/VELLAR_X402_POLICIES/);
+  });
+
+  it("preserves the raw diagnostics for debugging", () => {
+    expect(new SmartAccountAuthError(overCap).message).toContain("policy__");
+  });
+});

--- a/src/x402-signer-policies.test.ts
+++ b/src/x402-signer-policies.test.ts
@@ -1,0 +1,114 @@
+// Policy co-signers in the smart-account signature map.
+//
+// A policy-governed key that signs WITHOUT its policies is rejected by the
+// wallet before the policy is ever consulted, which reads as a broken signer
+// rather than a missing co-signer. These pin the map shape that works.
+
+import { Address, Keypair, xdr } from "@stellar/stellar-sdk";
+import { describe, expect, it } from "vitest";
+import { createSessionKeySigner } from "./x402-signer";
+
+const WALLET = "CAFIATCEAZJTGQQKFL3N2YB6VMCUN2UYX4QD5A3FALDRU7UJJ6OWBKOW";
+const POLICY_A = "CC24EVD6SD7WF2U4GSIBGU7V6LCN3MLZOJZAZCRQNDS3X6KYIL45K2E3";
+const POLICY_B = "CBIELTK6YBZJU5UP2WWQEUCYKLPU6AUNZ2BQ4WWFEIE3USCIHMXQDAMA";
+const PASSPHRASE = "Test SDF Network ; September 2015";
+
+/** An unsigned V1 auth entry whose credential address is the wallet. */
+function unsignedEntry(): string {
+  const entry = new xdr.SorobanAuthorizationEntry({
+    credentials: xdr.SorobanCredentials.sorobanCredentialsAddress(
+      new xdr.SorobanAddressCredentials({
+        address: new Address(WALLET).toScAddress(),
+        nonce: xdr.Int64.fromString("1"),
+        signatureExpirationLedger: 0,
+        signature: xdr.ScVal.scvVoid(),
+      }),
+    ),
+    rootInvocation: new xdr.SorobanAuthorizedInvocation({
+      function: xdr.SorobanAuthorizedFunction.sorobanAuthorizedFunctionTypeContractFn(
+        new xdr.InvokeContractArgs({
+          contractAddress: new Address(POLICY_B).toScAddress(),
+          functionName: "transfer",
+          args: [],
+        }),
+      ),
+      subInvocations: [],
+    }),
+  });
+  return entry.toXDR("base64");
+}
+
+/** The decoded `Vec[Map[key → sig]]` signature the signer produced. */
+function signatureMapOf(signedXdr: string): xdr.ScMapEntry[] {
+  const entry = xdr.SorobanAuthorizationEntry.fromXDR(signedXdr, "base64");
+  const sig = entry.credentials().address().signature();
+  return sig.vec()![0]!.map()!;
+}
+
+const variantOf = (v: xdr.ScVal) => v.vec()![0]!.sym().toString();
+
+async function sign(policies?: readonly string[]) {
+  const signer = createSessionKeySigner({
+    address: WALLET,
+    secretKey: Keypair.random().secret(),
+    ...(policies ? { policies } : {}),
+  });
+  return signatureMapOf(
+    await signer.signAuthEntry(unsignedEntry(), {
+      networkPassphrase: PASSPHRASE,
+      expirationLedger: 1000,
+    }),
+  );
+}
+
+describe("policy co-signers in the signature map", () => {
+  it("emits ed25519 only when no policies are configured", async () => {
+    const entries = await sign();
+    expect(entries).toHaveLength(1);
+    expect(variantOf(entries[0]!.key())).toBe("Ed25519");
+  });
+
+  it("adds a Policy entry alongside the ed25519 signature", async () => {
+    const entries = await sign([POLICY_A]);
+    expect(entries).toHaveLength(2);
+    expect(entries.map((e) => variantOf(e.key()))).toEqual(["Ed25519", "Policy"]);
+  });
+
+  it("carries the policy's address in the key and a unit Policy signature", async () => {
+    const entries = await sign([POLICY_A]);
+    const policyEntry = entries[1]!;
+    const addr = Address.fromScVal(policyEntry.key().vec()![1]!).toString();
+    expect(addr).toBe(POLICY_A);
+    // The policy authorises by running, not by producing bytes.
+    expect(policyEntry.val().vec()).toHaveLength(1);
+    expect(variantOf(policyEntry.val())).toBe("Policy");
+  });
+
+  it("orders Ed25519 before Policy, as ScVal ordering requires", async () => {
+    // Soroban rejects an unsorted map. "Ed25519" < "Policy" on the leading symbol.
+    const entries = await sign([POLICY_A]);
+    expect(variantOf(entries[0]!.key())).toBe("Ed25519");
+    expect(variantOf(entries[1]!.key())).toBe("Policy");
+  });
+
+  it("orders multiple policies deterministically by address bytes", async () => {
+    const forward = await sign([POLICY_A, POLICY_B]);
+    const reversed = await sign([POLICY_B, POLICY_A]);
+    const addrs = (es: xdr.ScMapEntry[]) =>
+      es.slice(1).map((e) => Address.fromScVal(e.key().vec()![1]!).toString());
+
+    // Configuration order must not change the emitted map.
+    expect(addrs(forward)).toEqual(addrs(reversed));
+    expect(addrs(forward)).toHaveLength(2);
+  });
+
+  it("rejects a policy address that is not a contract", async () => {
+    expect(() =>
+      createSessionKeySigner({
+        address: WALLET,
+        secretKey: Keypair.random().secret(),
+        policies: ["GAVU25UK4ISUJIH6KWLXX6XDKKCR3GNZ27RZ5WABRSE42ZADV2LB3ZLU"],
+      }),
+    ).toThrow(/policy address must be a contract/);
+  });
+});

--- a/src/x402-signer.ts
+++ b/src/x402-signer.ts
@@ -92,16 +92,64 @@ function payloadHashForEntry(
   return hash(preimage.toXDR());
 }
 
-/** Set the entry's signature to the smart-wallet map `Vec[Map[key → sig]]`. */
+/**
+ * `SignerKey::Policy(address)` — a policy contract acting as a co-signer.
+ *
+ * When a signer's `SignerLimits` require a policy, the wallet's `__check_auth`
+ * looks for that policy in the signature map and invokes it. Omitting it does
+ * NOT fall back to the signer alone: the wallet rejects the entry outright.
+ * Verified on testnet — an ed25519-only map against a policy-governed wallet
+ * fails with `Error(Contract, #110)`, while the same payment carrying the policy
+ * entry reaches the policy and is judged on its merits.
+ */
+function policySignerKey(policyAddress: string): xdr.ScVal {
+  return xdr.ScVal.scvVec([
+    xdr.ScVal.scvSymbol("Policy"),
+    new Address(policyAddress).toScVal(),
+  ]);
+}
+
+/** `Signature::Policy` — a unit variant. The policy authorises by running, not
+ * by producing bytes, so there is nothing to carry. */
+function policySignature(): xdr.ScVal {
+  return xdr.ScVal.scvVec([xdr.ScVal.scvSymbol("Policy")]);
+}
+
+/**
+ * Set the entry's signature to the smart-wallet map `Vec[Map[key → sig]]`.
+ *
+ * Soroban requires map keys in ScVal order. Both key variants are `scvVec`
+ * beginning with a symbol, so ordering is decided by that symbol first —
+ * `"Ed25519"` sorts before `"Policy"` (`E` < `P`) — and among policies by their
+ * contract-id bytes.
+ */
 function setSignatureMap(
   entry: xdr.SorobanAuthorizationEntry,
-  scKey: xdr.ScVal,
-  scSig: xdr.ScVal,
+  signerKey: xdr.ScVal,
+  signature: xdr.ScVal,
+  policyAddresses: readonly string[] = [],
 ): void {
+  const entries = [new xdr.ScMapEntry({ key: signerKey, val: signature })];
+
+  for (const policy of [...policyAddresses].sort(comparePolicyAddresses)) {
+    entries.push(new xdr.ScMapEntry({ key: policySignerKey(policy), val: policySignature() }));
+  }
+
   entry
     .credentials()
     .address()
-    .signature(xdr.ScVal.scvVec([xdr.ScVal.scvMap([new xdr.ScMapEntry({ key: scKey, val: scSig })])]));
+    .signature(xdr.ScVal.scvVec([xdr.ScVal.scvMap(entries)]));
+}
+
+/** Order two policy contract ids by their raw address bytes, as ScVal ordering does. */
+function comparePolicyAddresses(a: string, b: string): number {
+  const ab = new Address(a).toBuffer();
+  const bb = new Address(b).toBuffer();
+  for (let i = 0; i < Math.min(ab.length, bb.length); i++) {
+    const diff = (ab[i] ?? 0) - (bb[i] ?? 0);
+    if (diff !== 0) return diff;
+  }
+  return ab.length - bb.length;
 }
 
 // ── agent (ed25519) signer ─────────────────────────────────────────────────────
@@ -111,6 +159,16 @@ export interface SessionKeySignerConfig {
   address: string;
   /** The ed25519 session key secret (`S…`) attached to that wallet. */
   secretKey: string;
+  /**
+   * Policy contracts this key's `SignerLimits` require, which must appear in the
+   * signature map alongside the ed25519 entry.
+   *
+   * REQUIRED when the key is policy-governed. A policy-governed key that signs
+   * without them is rejected by the wallet before the policy is ever consulted
+   * (`Error(Contract, #110)` on testnet), which reads as a broken signer rather
+   * than a missing co-signer. Omit only for an unrestricted key.
+   */
+  policies?: readonly string[];
 }
 
 /**
@@ -125,6 +183,13 @@ export function createSessionKeySigner(config: SessionKeySignerConfig): SmartAcc
     throw new Error(`session-key signer address must be a contract (C…): got ${config.address}`);
   }
 
+  const policies = config.policies ?? [];
+  for (const policy of policies) {
+    if (!isContractAddress(policy)) {
+      throw new Error(`policy address must be a contract (C…): got ${policy}`);
+    }
+  }
+
   return {
     address: config.address,
     async signAuthEntry(entryXdr, { networkPassphrase, expirationLedger }) {
@@ -132,7 +197,7 @@ export function createSessionKeySigner(config: SessionKeySignerConfig): SmartAcc
       assertEntryAddress(entry, config.address);
       const payload = payloadHashForEntry(entry, networkPassphrase, expirationLedger);
       const signature = keypair.sign(payload);
-      setSignatureMap(entry, ed25519SignerKey(rawPk), ed25519Signature(signature));
+      setSignatureMap(entry, ed25519SignerKey(rawPk), ed25519Signature(signature), policies);
       return entry.toXDR("base64");
     },
   };
@@ -162,6 +227,9 @@ export interface PasskeyX402SignerConfig {
   address: string;
   /** The WebAuthn ceremony (host-wired; runs the passkey prompt). */
   webAuthn: WebAuthnAssertionSigner;
+  /** Policy contracts this signer's `SignerLimits` require — see
+   * {@link SessionKeySignerConfig.policies}. Same trap applies here. */
+  policies?: readonly string[];
 }
 
 /**
@@ -187,6 +255,7 @@ export function createPasskeyX402Signer(config: PasskeyX402SignerConfig): SmartA
         entry,
         secp256r1SignerKey(assertion.keyId),
         secp256r1Signature(assertion),
+        config.policies ?? [],
       );
       return entry.toXDR("base64");
     },


### PR DESCRIPTION
Layer 2 works. Setting `VELLAR_X402_WALLET` pays from a Vellar smart account
whose spending-limit policy is enforced **on-chain inside `__check_auth`** — the
limit no longer lives in the same process the agent is talking to.

## The demonstration

Two payments through the real MCP protocol against a **0.5 USDC on-chain cap**:

| | payment | outcome | evidence |
| --- | --- | --- | --- |
| **A** | 0.1 USDC (under) | **settled** | [`9e1f3acf…a0eb9d2a`](https://horizon-testnet.stellar.org/transactions/9e1f3acf3681d8a418b7619d480eefce855f7ff9a62b5546255c52cea0eb9d2a) — `successful: true`, ledger 4141211 |
| **B** | 0.6 USDC (over) | **refused by the wallet contract** | `__check_auth` → `policy__` → `Error(Contract, #1)`; no transaction |

The server's own limits were set deliberately **above** the cap for both calls
(`max_amount` 1.0 USDC, session ceiling 10 USDC), so no process-level guard could
be what refused B. The wallet's balance moved by exactly the settled amount and
no more — so B spent nothing, confirmed by arithmetic on-chain rather than by
trusting an error message.

Reproducible as `test/integration/layer2.integration.test.ts`.

## Not blocked on upstream after all

`ExactStellarScheme` still cannot sign for a `C…` address
(x402-foundation/x402#3159), but `x402Client.register()` accepts **any**
`SchemeNetworkClient`. So this registers its own, which signs auth entries
directly and never calls `signAuthEntries` — the narrowing that blocks the
official path never happens. Documented extension point, not a fork.

Everything above the `PaymentSigner` seam is unchanged on both paths: guards,
option narrowing, the selection tripwire, retry, the session ledger. Swapping
signers is the entire difference — which is what that interface was for.

## Two findings that cost real time, now encoded rather than remembered

**A policy-governed key must carry its policies in the signature map** as
`SignerKey::Policy` entries beside the ed25519 one. Omit them and the wallet
rejects the entry *before consulting the policy*, with an error that reads as a
broken signer. `createSessionKeySigner` now takes `policies` and orders the map
as ScVal ordering requires; `loadConfig` refuses policies without a wallet rather
than ignoring them, so a half-configured layer 2 cannot look like a working one.

**Do not classify a refusal on the top-level contract error.** The wallet wraps
*every* auth failure in its own `Error(Contract, #110)` — including a policy
rejection — so `#110` alone says "auth failed", not why. The cause is nested:

```
[wallet] "contract try_call failed", policy__, [ …transfer args, 6000000… ]
[policy] "VM call trapped with HostError", policy__, Error(Contract, #1)
```

An earlier revision in this branch classified on `#110` and got the causation
exactly backwards. The corrected classifier reports a budget refusal as the chain
working, and tells the model that **retrying with a larger `max_amount` will not
help** — a budget refusal that reads as transient invites precisely the wrong
retry.

## The fee question, measured

A policy-governed settle costs **28,678–116,202 stroops** charged on-chain
(0.003–0.012 XLM) against a 500,000 ceiling. Running the policy inside
`__check_auth` adds ~6,900 stroops — about 5%.

The facilitator's decision memo recorded **26,222,858 simulated** on an older
wallet and was blocked on "Test B". A fresh policy wallet costs **~187× less**,
and does strictly more work, so that figure is an artifact of that wallet's state
rather than a network-wide cost change. `MAX_TX_FEE_STROOPS = 500,000` is not
obsolete.

## Tests

424 hermetic (no network), plus the layer-2 integration suite. The over-cap test
asserts the **session ledger is untouched**, since that is what distinguishes
"the chain refused" from "we refused".

## README

Reframed around the two configurations rather than presenting the hot-wallet path
as the only one. The top-of-file warning is now conditional on how you configure
it, and the server states which mode it is in at startup and on every
`x402_session_budget` call.
