### PR TITLE
chore(mcp): mark @vellar/mcp-x402-payer private

### DIFF
--- a/packages/mcp-x402-payer/package.json
+++ b/packages/mcp-x402-payer/package.json
@@ -1,6 +1,8 @@
 {
   "name": "@vellar/mcp-x402-payer",
   "version": "0.1.0",
+  "//private": "NOT publishable: `vellar-sdk` below is a `file:../..` workspace link, which installs broken from a registry. Publishing this needs that swapped for a real version range first. Until then `private` stops a stray `npm publish --workspaces` from shipping it.",
+  "private": true,
   "description": "MCP server that lets an AI agent pay for x402 resources on Stellar. Holds exactly one key, runs locally over stdio.",
   "license": "Apache-2.0",
   "type": "module",


### PR DESCRIPTION
`@vellar/mcp-x402-payer` declares `"vellar-sdk": "file:../.."` — correct as a workspace link, unresolvable from a registry. The package was not marked `private`, so `npm publish --workspaces` would have shipped it.

Before: `npm publish --workspaces --dry-run` packs the tarball.
After: `npm warn publish Skipping workspace @vellar/mcp-x402-payer, marked as private`.

The root publish is unaffected — still one tarball, `vellar-sdk`, 47 files. 501 tests, both typechecks clean.

Publishing this package for real needs the `file:` link replaced with a version range; the `//private` note in package.json records that.