### PR TITLE
docs: link the public transaction explorer from the docs topbar

### DIFF
--- a/website/app/docs/layout.tsx
+++ b/website/app/docs/layout.tsx
@@ -16,6 +16,14 @@ export default function DocsLayout({ children }: { children: ReactNode }) {
         </Link>
         <div className="docs-topbar-spacer" />
         <a
+          href="https://explorer.vellar.xyz"
+          className="docs-toplink"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          Explorer
+        </a>
+        <a
           href="https://github.com/Vellar-Wallet/vellar-sdk"
           className="docs-toplink"
           target="_blank"


### PR DESCRIPTION
Adds explorer.vellar.xyz to the docs topbar (next to GitHub), same styling as the existing external links.

Verified locally: next build succeeds (34/34 pages), and the link is confirmed present in the generated HTML output.