### PR TITLE
docs: upto scheme page + facilitator page corrections from live-site verification

### DIFF
--- a/website/content/docs/facilitator.md
+++ b/website/content/docs/facilitator.md
@@ -75,6 +75,14 @@ Soroban smart accounts are supported.
 Wire-compatible with the canonical x402 clients — `HTTPFacilitatorClient`
 and the `withBazaar` extension work unmodified.
 
+`/verify` and `/settle` accept two schemes: `exact` (price known and signed
+upfront — what everything on this page assumes) and the experimental
+`upto` (buyer signs a ceiling, facilitator settles the metered actual,
+enforced on-ledger) — see [`upto` — Metered Payments](./upto.md).
+
+Want to see real settlements instead of trusting this page? [explorer.vellar.xyz](https://explorer.vellar.xyz)
+is a public transaction explorer for this facilitator.
+
 ## For sellers
 
 Point your resource server's facilitator client at the URL and your API
@@ -172,9 +180,11 @@ node provision-testnet.mjs
 # 2. Start a seller advertising it, with the PAYTO/ASSET it just printed
 PAYTO=G... ASSET=C... PRICE_ATOMIC=1000000 node seller.mjs
 
-# 3. Pay it — classic keypair, no extra dependencies
+# 3. Pay it — classic keypair, no extra dependencies. No second funded
+#    account needed: the official client simulates from the SDK's own null
+#    account, so the payer is never the transaction source.
 RESOURCE_URL=http://127.0.0.1:4031/quote \
-PAYER_SECRET=S... SIM_SOURCE_ACCOUNT=G... \
+PAYER_SECRET=S... \
 node buyer-classic.mjs
 
 # (or buyer.mjs, for a Vellar smart-account payer with an on-chain budget —
@@ -216,7 +226,11 @@ a resource before paying:
   deployment.** These read from an external attestation service that is
   deployed nowhere — that's architectural, not an outage, and it will not
   change on its own. **Don't filter on `?verified_only=true`** — it filters
-  on this field, so it always returns an empty list.
+  on this field, and since the field can never be anything but `"unknown"`
+  here, the facilitator refuses the filter outright rather than silently
+  hand back an empty list: `400 { "error": "verified_only_unavailable",
+  "reason": "no_verdict_source_configured" }`, with `ownerVerified` named in
+  the response as the signal that does work.
 - `ownerVerified` — a **different, working** field, computed by the
   facilitator itself with no external dependency. `true` only when the
   facilitator fetched your resource's own URL and found your `payTo` in its
@@ -246,19 +260,30 @@ on `…/quote` fails verification against the URL it's actually checked at.
 
 Things a developer building against the hosted instance should know up front:
 
-- **Expect roughly one settle in three to fail on testnet — retry, don't
-  debug.** `/settle` sometimes returns an empty `transaction` field with one
-  of two reason codes: `settle_exact_stellar_transaction_submission_failed`
-  or `settle_exact_stellar_transaction_failed`. Both mean the same thing —
-  the transaction was **never submitted**, so nothing was spent and a retry
+- **Settlement can still fail on testnet — retry, don't debug.** `/settle`
+  occasionally returns an empty `transaction` field with one of two reason
+  codes: `settle_exact_stellar_transaction_submission_failed` or
+  `settle_exact_stellar_transaction_failed`. Both mean the same thing — the
+  transaction was **never submitted**, so nothing was spent and a retry
   cannot double-pay. Sign a fresh payload and retry (signatures expire in
-  ledgers, not wall-clock, so a cached one won't work anyway). This is
-  measured, not assumed: 13 attempts, 6 failures in one session, and the
-  merchant's on-chain balance afterward was exactly successes × price, with
-  no partial or duplicate transfers. The rate isn't stable — earlier
-  sessions saw 3/11 and 3/9 — so treat retry as mandatory, not a rare edge
-  case. This looks like testnet RPC instability, not a facilitator defect;
-  self-hosting doesn't fix it.
+  ledgers, not wall-clock, so a cached one won't work anyway). Root cause:
+  the underlying Soroban RPC occasionally answers `TRY_AGAIN_LATER` to a
+  perfectly valid transaction, for reasons it doesn't state (not sponsor
+  contention, not sequence numbers — see
+  [`diagnosis-settle-failures.md`](https://github.com/Vellar-Wallet/vellar-facilitator/blob/main/docs/diagnosis-settle-failures.md)
+  in the repo for the ruled-out list). **Since 2026-08-15 the facilitator
+  retries this itself** before giving up (two attempts, 6s apart, plus a
+  separate one-retry guard for a related ledger-skew failure on `/verify`
+  and `/settle`) — so you should see this less often than earlier sessions
+  did, though not never: an automated probe that ships with the retry,
+  running a controlled comparison (identical conditions, with and without
+  the retry) every few hours, has recorded **zero settlement failures in
+  either arm across its full run history so far** — meaning the RPC hasn't
+  been misbehaving during that window in a way this measurement caught, not
+  that the underlying issue is confirmed gone. Earlier, pre-retry sessions
+  saw failure rates as high as 1-in-3. Keep "sign fresh, retry once" as the
+  correct client-side handling regardless — it costs nothing when nothing
+  fails.
 - **The catalog is ephemeral.** The free tier has no persistent disk, so
   catalog entries and URL ownership bindings vanish on every restart or idle
   sleep — cold start doesn't just mean latency, it means data loss. A
@@ -284,10 +309,21 @@ Things a developer building against the hosted instance should know up front:
   healthy catalog doesn't carry the key at all — check for its presence,
   not its value, or "no such field" reads as "the endpoint doesn't report
   this" when it actually means everything is fine.
-- **No reliable warm window, at any hour.** Send a warming `GET /health`
-  (rate-limit-exempt) with a ~120s timeout ahead of a real request, rather
-  than let a user's first call eat the cold start. It then stays warm for
-  15 minutes past your last call.
+- **`/health` also reports `reverifyPending`** — the count of ownership
+  re-verification checks still in flight after a restart (see
+  `ownerVerified` above: it's rebuilt on the next settlement after any
+  restart, not stored). `0` means the catalog's trust state is settled;
+  anything higher means check back shortly rather than treat what you just
+  read as final.
+- **No guaranteed warm window, but the odds are better on weekdays.** A
+  best-effort keep-warm job pings the facilitator and demo seller every 10
+  minutes, **07:00–21:00 UTC on weekdays** — that narrows how often you'll
+  hit a cold instance during that window, but GitHub Actions scheduling is
+  best-effort and can slip past the 15-minute idle timeout, so it is not a
+  promise. Outside that window, or if a ping slips, assume cold. Send a
+  warming `GET /health` (rate-limit-exempt) with a ~120s timeout ahead of a
+  real request rather than let a user's first call eat the cold start. It
+  then stays warm for 15 minutes past your last call.
 
 ## Proven end to end
 
@@ -299,4 +335,5 @@ and runnable seller/buyer examples:
 [`docs/decisions.md`](https://github.com/Vellar-Wallet/vellar-facilitator/blob/main/docs/decisions.md)
 and
 [`examples/`](https://github.com/Vellar-Wallet/vellar-facilitator/tree/main/examples)
-in the repo.
+in the repo — or skip the hashes and browse real settlements yourself at
+[explorer.vellar.xyz](https://explorer.vellar.xyz), including `upto` ones.

--- a/website/content/docs/upto.md
+++ b/website/content/docs/upto.md
@@ -1,0 +1,183 @@
+# `upto` — Metered Payments
+
+A second payment scheme alongside `exact`: the buyer authorizes a **spending
+ceiling** with one signature, and the facilitator settles for the **actual
+metered amount** — usage-based pricing without a signature per unit consumed.
+
+> **Status: experimental.** This is a Vellar-specific extension of x402 v2,
+> not yet part of the finalized spec. The wire shape may change before
+> upstream settles on one — see [x402-foundation/x402 #3134](https://github.com/x402-foundation/x402/pull/3134),
+> which proposes standardizing an `upto` scheme for Stellar and is open,
+> alongside a competing proposal. Don't build against this expecting the wire
+> format to be stable yet.
+
+## Why this exists
+
+`exact` needs the price known and signed before the resource is served — fine
+for a flat-rate API call, wrong for anything metered: tokens generated,
+seconds of compute, rows returned. `upto` lets a seller charge for what was
+actually used, capped by what the buyer agreed to risk.
+
+## How it's enforced
+
+The buyer signs one authorization: `(token, from, to, max_amount, expiration,
+nonce)` — notably **not** the actual amount. At settlement, the facilitator
+supplies the metered `actual_amount`, and a Soroban contract checks
+`actual <= max` **on-ledger** before it moves anything. The facilitator
+cannot settle more than the ceiling the buyer signed, because the chain
+refuses the transaction if it tries — this isn't a promise the facilitator
+makes, it's a bound the contract enforces regardless of what the facilitator
+does.
+
+## Using it
+
+`GET /supported` now advertises both schemes for `stellar:testnet`:
+
+```json
+{
+  "kinds": [
+    { "scheme": "exact", "network": "stellar:testnet", "extra": { "areFeesSponsored": true } },
+    {
+      "scheme": "upto",
+      "network": "stellar:testnet",
+      "extra": {
+        "uptoContract": "CDHPA64M73TUTEM4MMHIWIXINBQXH7JJXFGZMGH22VJWFJFROMR6QV2S",
+        "areFeesSponsored": true
+      }
+    }
+  ]
+}
+```
+
+`/verify` and `/settle` accept `scheme: "upto"` payloads the same way they
+accept `exact` ones. Two things worth knowing if you're integrating by hand:
+the settlement hook is refused (no arbitrary post-settle callback), and
+`/verify` simulates at the ceiling, not the actual, since the actual isn't
+decided yet.
+
+### The wire shape
+
+`payload.payload.transaction` is a **base64-encoded, unsigned Soroban
+transaction envelope** that invokes the deployed contract's `settle`
+function — "unsigned" at the envelope level; what actually carries the
+buyer's authorization is the Soroban auth entries attached to that one
+operation, which **are** signed. The facilitator never relays this envelope
+as-is: it rebuilds the transaction from its own sponsor account (so the
+buyer holds no XLM and pays no fee) and swaps in the metered `actual_amount`
+before submitting.
+
+This is the actual request body `POST /verify` and `POST /settle` both take
+— matching what `examples/upto-buyer.mjs` constructs. `paymentPayload.accepted`
+is the same object as the top-level `paymentRequirements` (omitted a second
+time below for brevity):
+
+```json
+{
+  "x402Version": 2,
+  "paymentPayload": {
+    "x402Version": 2,
+    "accepted": { "...": "same object as paymentRequirements below" },
+    "payload": { "transaction": "AAAAAgAAAAC1I3O2CN...(base64, unsigned envelope)" }
+  },
+  "paymentRequirements": {
+    "scheme": "upto",
+    "network": "stellar:testnet",
+    "asset": "CBIELTK6YBZJU5UP2WWQEUCYKLPU6AUNZ2BQ4WWFEIE3USCIHMXQDAMA",
+    "amount": "1000000",
+    "payTo": "GDEST...",
+    "maxTimeoutSeconds": 120,
+    "extra": { "actualAmount": "400000" }
+  }
+}
+```
+
+**The metered actual lives in `requirements.extra.actualAmount`** (a string,
+atomic units) — set by the seller/facilitator at settlement time, not
+something the buyer ever signs. It's the one field that's easy to miss: the
+buyer's signed authorization deliberately excludes it (that's the whole
+point — the signature covers the ceiling, not the eventual charge), and if
+you omit it entirely the facilitator settles for the full ceiling rather
+than a metered amount.
+
+**The settle response's `amount` is the actual settled amount, not the
+ceiling** — distinct from `paymentRequirements.amount`, which stays the
+ceiling throughout:
+
+| Field | Meaning | Example above |
+| --- | --- | --- |
+| `paymentRequirements.amount` | The **ceiling** the buyer authorized (`max_amount`) | `"1000000"` |
+| `SettleResponse.amount` | The **actual** amount settled (`actual_amount`, ≤ ceiling, enforced on-ledger) | `"400000"` |
+
+A settle response looks like `{ "success": true, "transaction": "<hash>",
+"payer": "G...", "amount": "400000" }` — reconcile against
+`paymentRequirements.amount`, not the other way around, if you need to
+confirm how much of the ceiling was actually used.
+
+### Contract argument order
+
+For anyone building the invocation by hand, the deployed contract's `settle`
+takes exactly eight arguments, in this order — get this wrong and it fails
+before any signature is even checked:
+
+```
+(token, from, to, max_amount, expiration_ledger, nonce, actual_amount, hook)
+```
+
+**`hook` must be `None`/void.** The facilitator refuses anything else
+(`invalid_upto_stellar_hook_not_supported`) — it's a deliberate settlement
+hook, not a defended one, because nothing legitimate needs it and refusing
+is cheaper than sandboxing an arbitrary post-settle callback aimed at the
+sponsor.
+
+**Not yet in `vellar-sdk`.** `wallet.x402.fetch()` speaks `exact` only right
+now. To pay with `upto` today, build the authorization by hand — the same way
+[the smart-account buyer example](./x402.md) does for `exact`, because the
+official x402 client doesn't support this scheme either.
+
+**End-to-end client:** `examples/upto-buyer.mjs` in the facilitator repo signs
+the ceiling authorization and drives `/verify` + `/settle` directly.
+
+```sh
+cd examples
+FACILITATOR_URL=http://localhost:4100 UPTO_CONTRACT=C... \
+PAYER_SECRET=S... PAYTO=G... ASSET=C... SIM_SOURCE_ACCOUNT=G... \
+MAX=1000000 ACTUAL=400000 node upto-buyer.mjs
+```
+
+`SIM_SOURCE_ACCOUNT` must be a funded account that **is not** the payer —
+same reason as the `exact` smart-account flow: simulating from the payer
+yields source-account credentials the scheme rejects.
+
+## Deployed contract
+
+Published so it can be verified against its source without trusting this
+page — every value below is independently checkable.
+
+| | |
+| --- | --- |
+| Contract ID (testnet) | `CDHPA64M73TUTEM4MMHIWIXINBQXH7JJXFGZMGH22VJWFJFROMR6QV2S` |
+| Wasm hash (on-chain) | `c276b905981eab91704ce9b9046ebb4867b164dd7e4ba0e0ecda841527d398a9` |
+| Source | `contracts/upto-stellar/` in the [facilitator repo](https://github.com/Vellar-Wallet/vellar-facilitator) — vendored verbatim (Apache-2.0) from [rail402](https://github.com/tolgayayci/rail402)'s `contracts/upto-stellar/` at commit `ff504b85ac065369dc985759afe4164a4541d861`, reviewed line-by-line before vendoring |
+| Deployed | 2026-08-21, from the facilitator repo's own sponsor account |
+
+The on-chain wasm hash is the sha256 of the wasm, so anyone can rebuild and
+compare:
+
+```sh
+cd contracts/upto-stellar
+stellar contract build
+shasum -a 256 target/wasm32v1-none/release/x402_upto_stellar.wasm
+# → c276b905981eab91704ce9b9046ebb4867b164dd7e4ba0e0ecda841527d398a9
+```
+
+Full deployment record, including the fetch-and-compare steps against the
+live contract and the first on-chain settlement's transaction hash:
+[`docs/upto-deployment.md`](https://github.com/Vellar-Wallet/vellar-facilitator/blob/main/docs/upto-deployment.md)
+in the facilitator repo.
+
+## Watch it settle
+
+[explorer.vellar.xyz](https://explorer.vellar.xyz) is a public transaction
+explorer for this facilitator's settlements, `upto` included — the actual
+metered amount on a real settlement is easier to see there than to reconstruct
+from a signed ceiling.

--- a/website/content/docs/x402.md
+++ b/website/content/docs/x402.md
@@ -154,6 +154,11 @@ higher ceiling. A plain transfer stays well under the default.
 ceiling specifically so policy-governed agent payments settle instead of
 being rejected — plus Bazaar discovery so agents can find payable resources.
 
+That facilitator also speaks a second, experimental scheme alongside `exact`:
+[`upto`](./upto.md), for metered pricing where the buyer authorizes a ceiling
+and the facilitator settles the actual usage, enforced on-ledger. `wallet.x402`
+doesn't build `upto` payments yet — this page's flow is `exact` only.
+
 ## Errors
 
 The client throws typed errors:

--- a/website/lib/docs-registry.ts
+++ b/website/lib/docs-registry.ts
@@ -34,6 +34,8 @@ export const DOC_PAGES: DocPage[] = [
     description: "Pay HTTP-402 resources from a smart account with wallet.x402.fetch() — the give-your-agent-a-budget-not-your-keys flow." },
   { slug: "facilitator", title: "x402 Facilitator & Bazaar", nav: "Facilitator & Bazaar", section: "x402 Payments",
     description: "The hosted Stellar x402 facilitator: verify/settle endpoints, Bazaar discovery and search, trust signals, and operational limits." },
+  { slug: "upto", title: "upto — Metered Payments", nav: "Upto (metered)", section: "x402 Payments",
+    description: "The experimental upto scheme: authorize a spending ceiling with one signature, settle for the actual metered amount, enforced on-ledger by a Soroban contract." },
 
   // Agents & Provenance
   { slug: "agent-keys", title: "Agent Keys", nav: "Agent keys", section: "Agents & Provenance",


### PR DESCRIPTION
## Summary

- New page: the `upto` metered-payment scheme — the mechanism, the deployed contract ID + wasm hash (cross-checked live against the hosted facilitator's `/supported`), reproducible-build steps, the full request/response wire shape and contract argument order (verified line-for-line against `src/upto.ts` and `examples/upto-buyer.mjs`), and the PR #3134 caveat (open upstream, competing with #3098).
- Three corrections found by checking the live site directly rather than trusting the 2026-08-12 handover audit, which was itself stale (most of it had already been fixed same-day in `fdd322d`): the settle-failure section rewritten with real probe numbers (22 runs, 0 failures in 180 attempts, framed as "hasn't recurred," not "fixed"), `verified_only`'s documented behavior corrected from "empty list" to the actual `400 verified_only_unavailable`, and a dead `SIM_SOURCE_ACCOUNT` line removed from the e2e example.
- `explorer.vellar.xyz` linked from the facilitator page; `reverifyPending` documented; keep-warm window corrected to the actual `07:00-21:00 UTC` weekdays.

## Test plan
- [x] `next build` passes
- [x] Docs registry test suite passes, 36/36 pages generate including the new one
- [x] Contract ID / wasm hash cross-checked against the live hosted facilitator's `/supported`
- [x] `verified_only` behavior cross-checked by curling the live facilitator
- [x] PR #3134 / #3098 status cross-checked against x402-foundation/x402 (both open)
- [x] Settle-probe run count/outcomes cross-checked against GitHub Actions history
- [x] Wire shape (argument order, `actualFor` default, hook rejection reason) cross-checked line-for-line against `src/upto.ts`