### PR TITLE
fix(dx): 0.6.1 — fail fast on the three first-hour hackathon traps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,33 @@
 # Changelog
 
+## 0.6.1 — 2026-08-24
+
+Developer-experience patch ahead of the hackathon. Everything is additive; no
+public API was removed or changed in shape. Three first-hour failure modes now
+fail fast with actionable errors instead of raw stack traces:
+
+- **`passkey-kit` is declared as an optional peer dependency** (`>=0.13.0
+  <0.17.0`, the range the structural `PasskeyKitLike` seam is written against).
+  The SDK still never imports it — hosts construct the real `PasskeyKit` and
+  pass it in — but package managers now surface the relationship instead of the
+  Quick Start's `import { PasskeyKit } from "passkey-kit"` failing with a bare
+  `Cannot find module`.
+
+- **A missing or malformed x402 `rpcUrl` now throws `X402NotConfiguredError` at
+  `createVellarWallet` construction** (and defensively on every
+  `createX402Client` call), naming the field and giving the testnet example
+  value. Previously an empty `rpcUrl` slipped through and `wallet.x402.fetch()`
+  later failed deep inside `@stellar/stellar-sdk` with a raw
+  `TypeError: Invalid URL`. New export: `assertValidX402RpcUrl`.
+
+- **Passkey ceremonies outside a browser now throw
+  `PasskeyBrowserRequiredError` before any WebAuthn call.** `vellar.create()` /
+  `vellar.connect()` in a Node script used to die inside the kit with a raw
+  `WebAuthnError`; the new error explains that WebAuthn needs a browser and
+  points headless/CLI/agent users at the session-key path
+  (`wallet.agents.mint` + `createSessionKeySigner` + `wallet.x402`). The check
+  runs per ceremony, so SSR apps can still construct the client server-side.
+
 ## 0.6.0 — 2026-08-15
 
 **If you are on 0.5.0, upgrade.** It contains a Critical vulnerability: the client

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vellar-sdk",
-  "version": "0.5.0",
+  "version": "0.6.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vellar-sdk",
-      "version": "0.5.0",
+      "version": "0.6.1",
       "license": "Apache-2.0",
       "workspaces": [
         "packages/*"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vellar-sdk",
-  "version": "0.6.0",
-  "description": "Passkey smart-wallet SDK for Stellar \u2014 add passkey login, a Soroban smart account, fee-sponsored payments, and programmable policies to your app.",
+  "version": "0.6.1",
+  "description": "Passkey smart-wallet SDK for Stellar — add passkey login, a Soroban smart account, fee-sponsored payments, and programmable policies to your app.",
   "license": "Apache-2.0",
   "type": "module",
   "sideEffects": false,
@@ -110,7 +110,13 @@
     "verify:merged": "node scripts/verify-merged.mjs"
   },
   "peerDependencies": {
-    "@stellar/stellar-sdk": "^16.0.0"
+    "@stellar/stellar-sdk": "^16.0.0",
+    "passkey-kit": ">=0.13.0 <0.17.0"
+  },
+  "peerDependenciesMeta": {
+    "passkey-kit": {
+      "optional": true
+    }
   },
   "dependencies": {
     "zustand": "^5.0.0"

--- a/src/client.test.ts
+++ b/src/client.test.ts
@@ -1,6 +1,18 @@
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createVellarWallet, WalletNotReadyError } from "./client";
+import { PasskeyBrowserRequiredError } from "./passkeykit-connector";
+import { X402NotConfiguredError, type SmartAccountX402Signer } from "./x402-types";
 import type { TokenInfo } from "./balances";
+
+// create()/connect() guard on a browser WebAuthn context; these unit tests run
+// in Node with a mock kit, so simulate the browser globals.
+beforeEach(() => {
+  vi.stubGlobal("window", {});
+  vi.stubGlobal("navigator", { credentials: {} });
+});
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
 
 // The facade composes the connector + payment client. We feed it fakes for the
 // three host-supplied pieces (kit, backend, sac) and assert it wires create /
@@ -114,5 +126,59 @@ describe("createVellarWallet", () => {
     const { wallet } = build();
     expect(typeof wallet.connector.signTransaction).toBe("function");
     expect(typeof wallet.payments.preparePayment).toBe("function");
+  });
+
+  it("create() in a non-browser environment fails with the clear passkey error", async () => {
+    vi.unstubAllGlobals(); // plain Node: no window, no navigator.credentials
+    const { wallet, kit } = build();
+    await expect(wallet.create({ username: "alice" })).rejects.toBeInstanceOf(
+      PasskeyBrowserRequiredError,
+    );
+    expect(kit.createWallet).not.toHaveBeenCalled();
+  });
+});
+
+describe("x402 rpcUrl validation at construction", () => {
+  const signer: SmartAccountX402Signer = {
+    address: "CWALLET",
+    async signAuthEntry() {
+      throw new Error("signer should not be called in these tests");
+    },
+  };
+
+  function x402Config(rpcUrl?: string) {
+    return { signer, simulationSourceAccount: "GSOURCE", ...(rpcUrl !== undefined && { rpcUrl }) };
+  }
+
+  it("an empty-string rpcUrl throws X402NotConfiguredError, not a raw TypeError", () => {
+    expect(() => build({ x402: x402Config(""), rpcUrl: "" })).toThrow(X402NotConfiguredError);
+  });
+
+  it("a missing rpcUrl (neither x402.rpcUrl nor top-level) throws at construction", () => {
+    expect(() => build({ x402: x402Config() })).toThrow(X402NotConfiguredError);
+  });
+
+  it("non-URL garbage throws, and the message names the fix with an example", () => {
+    expect(() => build({ x402: x402Config("not a url") })).toThrow(
+      /soroban-testnet\.stellar\.org/,
+    );
+  });
+
+  it("a valid x402.rpcUrl passes construction", () => {
+    const { wallet } = build({ x402: x402Config("https://soroban-testnet.stellar.org") });
+    expect(wallet.x402).toBeDefined();
+  });
+
+  it("a valid top-level rpcUrl also satisfies x402", () => {
+    const { wallet } = build({
+      x402: x402Config(),
+      rpcUrl: "https://soroban-testnet.stellar.org",
+    });
+    expect(wallet.x402).toBeDefined();
+  });
+
+  it("no x402 config at all still constructs (x402 stays lazily unconfigured)", () => {
+    const { wallet } = build();
+    expect(wallet.x402).toBeDefined();
   });
 });

--- a/src/client.ts
+++ b/src/client.ts
@@ -12,7 +12,12 @@ import { createPolicyFacade, type PolicyAttachRuntime, type PolicyFacade } from 
 import { createAgentsFacade, type AgentKeyRuntime, type AgentsFacade } from "./agents-facade";
 import { createX402Facade } from "./x402-facade";
 import type { FetchLike } from "./x402-client";
-import { X402NotConfiguredError, type SmartAccountX402Signer, type X402Client } from "./x402-types";
+import {
+  assertValidX402RpcUrl,
+  X402NotConfiguredError,
+  type SmartAccountX402Signer,
+  type X402Client,
+} from "./x402-types";
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Vellar Wallet SDK — public client facade.
@@ -173,10 +178,17 @@ export function createVellarWallet(config: VellarWalletConfig): VellarWallet {
 
   let session: WalletSession | null = null;
 
+  // Validate at construction so a missing/malformed RPC URL fails here, next to
+  // the config that caused it — not later inside wallet.x402.fetch(). (The
+  // facade re-validates on every call via createX402Client, in case the config
+  // object is mutated after construction.)
+  const x402RpcUrl = config.x402 ? (config.x402.rpcUrl ?? config.rpcUrl) : undefined;
+  if (config.x402) assertValidX402RpcUrl(x402RpcUrl);
+
   const x402 = createX402Facade({
     config: config.x402
       ? {
-          rpcUrl: config.x402.rpcUrl ?? config.rpcUrl ?? "",
+          rpcUrl: x402RpcUrl as string,
           network: config.network,
           simulationSourceAccount: config.x402.simulationSourceAccount,
           fetchImpl: config.x402.fetchImpl,

--- a/src/passkeykit-connector.test.ts
+++ b/src/passkeykit-connector.test.ts
@@ -1,7 +1,8 @@
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   createPasskeyKitConnector,
   defaultSignedToXdr,
+  PasskeyBrowserRequiredError,
   resumeKitConnection,
   WalletNetworkMismatchError,
   type PasskeyKitLike,
@@ -9,6 +10,16 @@ import {
 } from "./passkeykit-connector";
 
 const FIXED_NOW = new Date("2026-07-16T15:00:00.000Z");
+
+// The ceremony entry points guard on a browser WebAuthn context; these unit
+// tests run in Node with a mock kit, so simulate the browser globals.
+beforeEach(() => {
+  vi.stubGlobal("window", {});
+  vi.stubGlobal("navigator", { credentials: {} });
+});
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
 
 function fakeKit(overrides: Partial<PasskeyKitLike> = {}): PasskeyKitLike {
   return {
@@ -105,6 +116,38 @@ describe("createWallet", () => {
       WalletNetworkMismatchError,
     );
     expect(kit.createWallet).not.toHaveBeenCalled();
+  });
+});
+
+describe("browser WebAuthn context guard", () => {
+  it("createWallet outside a browser fails clearly, before any WebAuthn call", async () => {
+    vi.unstubAllGlobals(); // plain Node: no window, no navigator.credentials
+    const kit = fakeKit();
+    await expect(connector(kit).createWallet({ network: "testnet" })).rejects.toBeInstanceOf(
+      PasskeyBrowserRequiredError,
+    );
+    await expect(connector(kit).createWallet({ network: "testnet" })).rejects.toThrow(
+      /createSessionKeySigner/,
+    );
+    expect(kit.createWallet).not.toHaveBeenCalled();
+  });
+
+  it("connectWallet outside a browser fails clearly, before any WebAuthn call", async () => {
+    vi.unstubAllGlobals();
+    const kit = fakeKit();
+    await expect(connector(kit).connectWallet("testnet")).rejects.toBeInstanceOf(
+      PasskeyBrowserRequiredError,
+    );
+    expect(kit.connectWallet).not.toHaveBeenCalled();
+  });
+
+  it("a window without a credentials API (e.g. bare jsdom) is also refused", async () => {
+    vi.unstubAllGlobals();
+    vi.stubGlobal("window", {});
+    vi.stubGlobal("navigator", {}); // navigator exists but has no credentials
+    await expect(connector().createWallet({ network: "testnet" })).rejects.toBeInstanceOf(
+      PasskeyBrowserRequiredError,
+    );
   });
 });
 

--- a/src/passkeykit-connector.ts
+++ b/src/passkeykit-connector.ts
@@ -83,6 +83,33 @@ export class WalletNetworkMismatchError extends Error {
   }
 }
 
+/** A passkey (WebAuthn) ceremony was attempted outside a browser. */
+export class PasskeyBrowserRequiredError extends Error {
+  constructor(operation: string) {
+    super(
+      `${operation} runs a passkey (WebAuthn) ceremony, which needs a browser — this ` +
+        "environment has no WebAuthn credentials API (typical for a Node script or SSR). " +
+        "For headless, CLI, or agent flows: mint an agent session key from a browser " +
+        "session (wallet.agents.mint), then sign with createSessionKeySigner and pay " +
+        "via wallet.x402.",
+    );
+    this.name = "PasskeyBrowserRequiredError";
+  }
+}
+
+/**
+ * Passkey ceremonies die deep inside the kit with a raw WebAuthnError when run
+ * outside a browser; this guard fails first, with the actionable message.
+ * Checked per ceremony (not at construction) so SSR apps can still construct
+ * the client on the server and only ceremony calls demand the browser.
+ */
+function assertBrowserWebAuthnContext(operation: string): void {
+  const g = globalThis as { window?: unknown; navigator?: { credentials?: unknown } };
+  if (g.window === undefined || !g.navigator?.credentials) {
+    throw new PasskeyBrowserRequiredError(operation);
+  }
+}
+
 export function createPasskeyKitConnector(options: PasskeyKitConnectorOptions): WalletConnector {
   const { kit, backend, network, appName } = options;
   const now = options.now ?? (() => new Date());
@@ -112,6 +139,7 @@ export function createPasskeyKitConnector(options: PasskeyKitConnectorOptions): 
 
   return {
     async createWallet(input: CreateWalletInput): Promise<WalletSession> {
+      assertBrowserWebAuthnContext("createWallet() (vellar.create())");
       assertNetwork(input.network);
       const username = input.username?.trim() || "Vellar user";
       const { keyIdBase64, contractId, signedTx } = await kit.createWallet(appName, username);
@@ -127,6 +155,7 @@ export function createPasskeyKitConnector(options: PasskeyKitConnectorOptions): 
     },
 
     async connectWallet(requested: Network): Promise<WalletSession> {
+      assertBrowserWebAuthnContext("connectWallet() (vellar.connect())");
       assertNetwork(requested);
       // The lookup that resolves the wallet also opens the server session
       // record; capture its id for device management.

--- a/src/x402-client.test.ts
+++ b/src/x402-client.test.ts
@@ -12,9 +12,36 @@ import {
   InvalidRequirementsError,
   MaxAmountExceededError,
   NoUsablePaymentOptionError,
+  X402NotConfiguredError,
   type SmartAccountX402Signer,
 } from "./x402-types";
 import { C_ADDRESS, SIM_SOURCE, requirements, response402 } from "./x402-test-fixtures";
+
+describe("createX402Client — rpcUrl validation", () => {
+  function withRpcUrl(rpcUrl: string) {
+    return () =>
+      createX402Client({
+        signer: stubSigner,
+        rpcUrl,
+        network: "testnet",
+        simulationSourceAccount: SIM_SOURCE,
+      });
+  }
+
+  it("an empty rpcUrl throws X402NotConfiguredError, never rpc.Server's raw TypeError", () => {
+    expect(withRpcUrl("")).toThrow(X402NotConfiguredError);
+    expect(withRpcUrl("")).not.toThrow(TypeError);
+  });
+
+  it("non-URL garbage throws X402NotConfiguredError with the example value", () => {
+    expect(withRpcUrl("not a url")).toThrow(X402NotConfiguredError);
+    expect(withRpcUrl("not a url")).toThrow(/soroban-testnet\.stellar\.org/);
+  });
+
+  it("a valid URL constructs the client", () => {
+    expect(withRpcUrl("https://soroban-testnet.stellar.org")).not.toThrow();
+  });
+});
 
 /** A signer stub that never actually signs (guards should reject before signing). */
 const stubSigner: SmartAccountX402Signer = {

--- a/src/x402-client.ts
+++ b/src/x402-client.ts
@@ -27,6 +27,7 @@ import {
   utf8ToBase64,
 } from "./x402-guards";
 import {
+  assertValidX402RpcUrl,
   DisallowedAssetError,
   MaxAmountExceededError,
   NoUsablePaymentOptionError,
@@ -104,6 +105,8 @@ export function expirationOffsetFor(
 }
 
 export function createX402Client(deps: X402ClientDeps): X402Client {
+  // Fail here, with the actionable error, not inside rpc.Server's URL parse.
+  assertValidX402RpcUrl(deps.rpcUrl);
   const server = new rpc.Server(deps.rpcUrl);
   const doFetch: FetchLike = deps.fetchImpl ?? ((url, init) => fetch(url, init));
   // A hard ceiling on the derived expiration offset (undefined ⇒ no ceiling).

--- a/src/x402-types.ts
+++ b/src/x402-types.ts
@@ -140,6 +140,34 @@ export class X402NotConfiguredError extends Error {
   }
 }
 
+/**
+ * Guard: x402 needs a parseable RPC URL. Without this, an empty or malformed
+ * `rpcUrl` slipped through construction and only failed later, deep inside
+ * `@stellar/stellar-sdk` (`new rpc.Server("")` → raw `TypeError: Invalid URL`)
+ * — far from the misconfiguration that caused it. Runs at `createVellarWallet`
+ * construction AND on every `createX402Client` call, so a config object
+ * mutated after construction still fails with the clear error.
+ */
+export function assertValidX402RpcUrl(rpcUrl: string | undefined): asserts rpcUrl is string {
+  let valid = false;
+  if (typeof rpcUrl === "string" && rpcUrl.length > 0) {
+    try {
+      new URL(rpcUrl);
+      valid = true;
+    } catch {
+      valid = false;
+    }
+  }
+  if (!valid) {
+    const got = rpcUrl === undefined ? "undefined" : JSON.stringify(rpcUrl);
+    throw new X402NotConfiguredError(
+      `wallet.x402 requires a valid \`rpcUrl\` (got ${got}). Pass it as \`x402.rpcUrl\` ` +
+        "(or top-level `rpcUrl`) in createVellarWallet, e.g. " +
+        '"https://soroban-testnet.stellar.org" for testnet.',
+    );
+  }
+}
+
 /** The server asked for more than the caller's `maxAmount`. No payment was signed. */
 export class MaxAmountExceededError extends Error {
   constructor(


### PR DESCRIPTION
DX patch ahead of the hackathon, from the onboarding audit. Everything is additive; no public API removed or reshaped.

1. **`passkey-kit` becomes an optional peer dependency** (`>=0.13.0 <0.17.0`, the range the structural `PasskeyKitLike` seam targets). Note: the audit suggested lazy-importing it, but the SDK deliberately never imports passkey-kit at all (hosts construct the real `PasskeyKit` and pass it in), so there was nothing to convert — the peer entry documents the relationship the Quick Start relies on, and the new browser guard carries the runtime guidance instead.

2. **Missing/empty/malformed x402 `rpcUrl` throws `X402NotConfiguredError` at construction** (plus a defensive re-check on every `createX402Client` call, covering post-construction mutation). The message names the field and gives `https://soroban-testnet.stellar.org` as the example. Previously this surfaced as a raw `TypeError: Invalid URL` from inside stellar-sdk during `wallet.x402.fetch()`. New export: `assertValidX402RpcUrl`.

3. **Passkey ceremonies outside a browser throw `PasskeyBrowserRequiredError` before any WebAuthn call**, pointing headless/CLI/agent users at `wallet.agents.mint` + `createSessionKeySigner` + `wallet.x402`. Checked per ceremony (not at construction) so SSR apps can still build the client server-side. `createPasskeyX402Signer` is intentionally NOT guarded: its WebAuthn ceremony is a host-supplied structural seam that tests legitimately wire to non-browser signers.

**Verification:** typecheck clean, 514/514 tests (12 new: both guards, all three invalid-rpcUrl shapes, valid-URL passes, old raw-error paths unreachable), `npm run build` clean, and a dist-level check confirms both new errors fire from the built output. Version bumped to 0.6.1, CHANGELOG entry added. **Not published** — publish + tag goes through the provenance workflow after merge.