### PR TITLE
docs: unbreak the hackathon onboarding path

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,5 +20,8 @@ jobs:
       # change is reported and decided, not forced through by CI.
       - run: npm audit --audit-level=high
       - run: npm run typecheck
+      # Docs snippets typecheck against the current source — a quickstart that
+      # drifts from the real API fails the PR that introduces the drift.
+      - run: npm run check:docs
       - run: npm test
       - run: npm run build

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ coverage/
 # Throwaway diagnostics. A one-off probe committed next to the source reads as
 # product to the next person — name it *-tmp.mjs and it stays local.
 *-tmp.mjs
+.doc-snippets/

--- a/README.md
+++ b/README.md
@@ -27,8 +27,12 @@ API reference, wallet methods, policies, and the security model.
 ## Install
 
 ```sh
-npm install vellar-sdk @stellar/stellar-sdk
+npm install vellar-sdk @stellar/stellar-sdk passkey-kit
 ```
+
+`@stellar/stellar-sdk` is a required peer; `passkey-kit` is the passkey engine
+you construct and pass in as `kit` (an optional peer of this package — the SDK
+never imports it itself).
 
 ## Quick start
 
@@ -58,8 +62,10 @@ const vellar = createVellarWallet({
     rpcUrl: TESTNET.rpcUrl,
     networkPassphrase: TESTNET.networkPassphrase,
   }),
-  // Point this at YOUR backend (see "Your backend" below). It holds the
-  // relayer/sponsor secrets — the SDK never sees them.
+  // Your backend (see "Your backend" below) — it holds the relayer/sponsor
+  // secrets, the SDK never sees them. For testnet prototyping you can point at
+  // the hosted gateway: https://vellar-backend.onrender.com (free instance,
+  // first request after idle takes 30-60s to wake).
   backend: createHttpWalletBackend("https://api.myapp.com"),
   isValidAddress: (a) =>
     StrKey.isValidEd25519PublicKey(a) || StrKey.isValidContract(a),

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vellar-sdk",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vellar-sdk",
-      "version": "0.5.0",
+      "version": "0.6.0",
       "license": "Apache-2.0",
       "workspaces": [
         "packages/*"
@@ -16,6 +16,7 @@
       },
       "devDependencies": {
         "@stellar/stellar-sdk": "^16.0.1",
+        "passkey-kit": "^0.16.5",
         "tsup": "^8.5.1",
         "typescript": "^5.9.2",
         "vitest": "^3.2.0"
@@ -23,6 +24,23 @@
       "peerDependencies": {
         "@stellar/stellar-sdk": "^16.0.0"
       }
+    },
+    "node_modules/@actions/exec": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@actions/exec/-/exec-1.1.1.tgz",
+      "integrity": "sha512-+sCcHHbVdk93a0XT19ECtO/gIXoxvdsgQLzb2fE2/5sIZmWQuluYyjPQtrtTHdU1YzTZ7bAPN4sITq2xi1679w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@actions/io": "^1.0.1"
+      }
+    },
+    "node_modules/@actions/io": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@actions/io/-/io-1.1.3.tgz",
+      "integrity": "sha512-wi9JjgKLYS7U/z8PPbco+PvTb/nRWjeoFlJ1Qer83k/3C5PHQi28hiVdeE2kHXmIL99mQFawx8qt/JPjZilJ8Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.27.7",
@@ -569,6 +587,35 @@
         "node": ">=18.0.0"
       }
     },
+    "node_modules/@noble/curves": {
+      "version": "1.9.7",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.9.7.tgz",
+      "integrity": "sha512-gbKGcRUYIjA3/zCCNaWDciTMFI0dCkvou3TL8Zmy5Nc7sJ47a0jtOeZoTaMxkuqRo9cRhjOdZJXegxYE5FN/xw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "1.8.0"
+      },
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@noble/curves/node_modules/@noble/hashes": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/@noble/ed25519": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/@noble/ed25519/-/ed25519-3.1.0.tgz",
@@ -588,6 +635,85 @@
       },
       "funding": {
         "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@openzeppelin/relayer-plugin-channels": {
+      "version": "0.20.0",
+      "resolved": "https://registry.npmjs.org/@openzeppelin/relayer-plugin-channels/-/relayer-plugin-channels-0.20.0.tgz",
+      "integrity": "sha512-buZ0Xcir1mPcevMBU3vzbq4v77YUsikWX+E1k31YxdE6p97GEn40RnxNzow/eLNVnS3WNwYZ1SuEZgsQE7KHAg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@actions/exec": "^1.1.1",
+        "@openzeppelin/relayer-sdk": "^1.10.0",
+        "@stellar/stellar-sdk": "^14.6.0",
+        "axios": "^1.13.5"
+      },
+      "engines": {
+        "node": ">=22.18.0",
+        "npm": "use pnpm",
+        "pnpm": ">=9",
+        "yarn": "use pnpm"
+      }
+    },
+    "node_modules/@openzeppelin/relayer-plugin-channels/node_modules/@stellar/stellar-sdk": {
+      "version": "14.6.1",
+      "resolved": "https://registry.npmjs.org/@stellar/stellar-sdk/-/stellar-sdk-14.6.1.tgz",
+      "integrity": "sha512-A1rQWDLdUasXkMXnYSuhgep+3ZZzyuXJKdt5/KAIc0gkmSp906HTvUpbT4pu+bVr41tu0+J4Ugz9J4BQAGGytg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@stellar/stellar-base": "^14.1.0",
+        "axios": "^1.13.3",
+        "bignumber.js": "^9.3.1",
+        "commander": "^14.0.2",
+        "eventsource": "^2.0.2",
+        "feaxios": "^0.0.23",
+        "randombytes": "^2.1.0",
+        "toml": "^3.0.0",
+        "urijs": "^1.19.1"
+      },
+      "bin": {
+        "stellar-js": "bin/stellar-js"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@openzeppelin/relayer-plugin-channels/node_modules/bignumber.js": {
+      "version": "9.3.1",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.3.1.tgz",
+      "integrity": "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/@openzeppelin/relayer-plugin-channels/node_modules/eventsource": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-2.0.2.tgz",
+      "integrity": "sha512-IzUmBGPR3+oUG9dUeXynyNmf91/3zUSJg1lCktzKw47OXuhco54U3r9B7O4XX+Rb1Itm9OZ2b0RkTs10bICOxA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/@openzeppelin/relayer-sdk": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@openzeppelin/relayer-sdk/-/relayer-sdk-1.10.0.tgz",
+      "integrity": "sha512-C7v4C63VnFR4keISicpcDf4Ix646sa1OdokzddFeSPEGlJIY2b/XJ9sIWiXOBVJVGzbB+RdX3/fbkygAPhcVNw==",
+      "dev": true,
+      "license": "AGPL-3.0-or-later",
+      "dependencies": {
+        "axios": "^1.7.7"
+      },
+      "engines": {
+        "node": ">=22.14.0",
+        "npm": "use pnpm",
+        "pnpm": ">=9",
+        "yarn": "use pnpm"
       }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
@@ -979,6 +1105,13 @@
         "win32"
       ]
     },
+    "node_modules/@simplewebauthn/browser": {
+      "version": "13.3.0",
+      "resolved": "https://registry.npmjs.org/@simplewebauthn/browser/-/browser-13.3.0.tgz",
+      "integrity": "sha512-BE/UWv6FOToAdVk0EokzkqQQDOWtNydYlY6+OrmiZ5SCNmb41VehttboTetUM3T/fr6EAFYVXjz4My2wg230rQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@stellar/js-xdr": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@stellar/js-xdr/-/js-xdr-4.0.0.tgz",
@@ -987,6 +1120,42 @@
       "engines": {
         "node": ">=20.0.0",
         "pnpm": ">=9.0.0"
+      }
+    },
+    "node_modules/@stellar/stellar-base": {
+      "version": "14.1.0",
+      "resolved": "https://registry.npmjs.org/@stellar/stellar-base/-/stellar-base-14.1.0.tgz",
+      "integrity": "sha512-A8kFli6QGy22SRF45IjgPAJfUNGjnI+R7g4DF5NZYVsD1kGf7B4ITyc4OPclLV9tqNI4/lXxafGEw0JEUbHixw==",
+      "deprecated": "This package is now rolled into @stellar/stellar-sdk. Please use @stellar/stellar-sdk to continue receiving updates and support.",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@noble/curves": "^1.9.6",
+        "@stellar/js-xdr": "^3.1.2",
+        "base32.js": "^0.1.0",
+        "bignumber.js": "^9.3.1",
+        "buffer": "^6.0.3",
+        "sha.js": "^2.4.12"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@stellar/stellar-base/node_modules/@stellar/js-xdr": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@stellar/js-xdr/-/js-xdr-3.1.2.tgz",
+      "integrity": "sha512-VVolPL5goVEIsvuGqDc5uiKxV03lzfWdvYg1KikvwheDmTBO68CKDji3bAZ/kppZrx5iTA8z3Ld5yuytcvhvOQ==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/@stellar/stellar-base/node_modules/bignumber.js": {
+      "version": "9.3.1",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.3.1.tgz",
+      "integrity": "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/@stellar/stellar-sdk": {
@@ -1310,6 +1479,22 @@
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
       "license": "MIT"
     },
+    "node_modules/available-typed-arrays": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
+      "integrity": "sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "possible-typed-array-names": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/axios": {
       "version": "1.18.0",
       "resolved": "https://registry.npmjs.org/axios/-/axios-1.18.0.tgz",
@@ -1350,6 +1535,16 @@
         }
       ],
       "license": "MIT"
+    },
+    "node_modules/base64url": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/base64url/-/base64url-3.0.1.tgz",
+      "integrity": "sha512-ir1UPr3dkwexU7FdV8qBBbNDRUhMmIekYMFZfi+C/sLNnRESKPl23nB9b2pltqfOQNnGzsDdId90AEtG5tCx4A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
     },
     "node_modules/bignumber.js": {
       "version": "11.1.5",
@@ -1451,6 +1646,25 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/call-bind": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.9.tgz",
+      "integrity": "sha512-a/hy+pNsFUTR+Iz8TCJvXudKVLAnz/DyeSUo10I5yvFDQJBFU2s9uqQpoSrJlroHUKoKqzg+epxyP9lqFdzfBQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "get-intrinsic": "^1.3.0",
+        "set-function-length": "^1.2.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/call-bind-apply-helpers": {
@@ -1659,6 +1873,24 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/define-data-property": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
+      "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-define-property": "^1.0.0",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/delayed-stream": {
@@ -2047,6 +2279,22 @@
         }
       }
     },
+    "node_modules/for-each": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz",
+      "integrity": "sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-callable": "^1.2.7"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/form-data": {
       "version": "4.0.6",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
@@ -2149,6 +2397,19 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-property-descriptors": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
+      "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-define-property": "^1.0.0"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -2295,6 +2556,19 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/is-callable": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
+      "integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-promise": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
@@ -2312,6 +2586,29 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/is-typed-array": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.15.tgz",
+      "integrity": "sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "which-typed-array": "^1.1.16"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/isarray": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
+      "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/isexe": {
       "version": "2.0.0",
@@ -2569,6 +2866,43 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/passkey-kit": {
+      "version": "0.16.5",
+      "resolved": "https://registry.npmjs.org/passkey-kit/-/passkey-kit-0.16.5.tgz",
+      "integrity": "sha512-g5VjQ3yfGQJQMjkr4mTlFBxe6PLR1p2SrOUhqImuPAYGkt84NLM+irP085WgsNU4Cp7sGAHENNotBQwWOSkH6A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@openzeppelin/relayer-plugin-channels": "^0.20.0",
+        "@simplewebauthn/browser": "^13.3.0",
+        "@stellar/stellar-sdk": ">=16.0.0",
+        "base64url": "^3.0.1",
+        "buffer": "^6.0.3",
+        "passkey-kit-sdk": "0.8.2",
+        "sac-sdk": "0.4.4"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      },
+      "peerDependencies": {
+        "@stellar/stellar-sdk": ">=16.0.0"
+      }
+    },
+    "node_modules/passkey-kit-sdk": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/passkey-kit-sdk/-/passkey-kit-sdk-0.8.2.tgz",
+      "integrity": "sha512-il75yM7pfYkgV60I0Q19sqlqQ+/9KuT1aX/kgL/VDO+m5jXBcWegdq3gFodOugjYls6Rzje2k8r++vJ/8nVANg==",
+      "dev": true,
+      "dependencies": {
+        "buffer": "^6.0.3"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      },
+      "peerDependencies": {
+        "@stellar/stellar-sdk": ">=16.0.0"
+      }
+    },
     "node_modules/path-key": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
@@ -2654,6 +2988,16 @@
         "confbox": "^0.1.8",
         "mlly": "^1.7.4",
         "pathe": "^2.0.1"
+      }
+    },
+    "node_modules/possible-typed-array-names": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
+      "integrity": "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/postcss": {
@@ -2764,6 +3108,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/randombytes": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
+      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "^5.1.0"
       }
     },
     "node_modules/range-parser": {
@@ -2888,6 +3242,42 @@
         "node": ">= 18"
       }
     },
+    "node_modules/sac-sdk": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/sac-sdk/-/sac-sdk-0.4.4.tgz",
+      "integrity": "sha512-GNT7tR1zwxb3W6N+xNdp2Bjs4AmwrFFvd+A3K3wHtWdIDwKQvMhatOV4lzqIy63GRJ3GIbKtr3+yvh1LYOhIjQ==",
+      "dev": true,
+      "dependencies": {
+        "buffer": "^6.0.3"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      },
+      "peerDependencies": {
+        "@stellar/stellar-sdk": ">=16.0.0"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
@@ -2964,11 +3354,50 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/set-function-length": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
+      "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-data-property": "^1.1.4",
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2",
+        "get-intrinsic": "^1.2.4",
+        "gopd": "^1.0.1",
+        "has-property-descriptors": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/setprototypeof": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
       "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
       "license": "ISC"
+    },
+    "node_modules/sha.js": {
+      "version": "2.4.12",
+      "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.12.tgz",
+      "integrity": "sha512-8LzC5+bvI45BjpfXU8V5fdU2mfeKiQe1D1gIMn7XUlF3OTUrpdJpPPH4EMAnF0DsHHdSZqCdSss5qCmJKuiO3w==",
+      "dev": true,
+      "license": "(MIT AND BSD-3-Clause)",
+      "dependencies": {
+        "inherits": "^2.0.4",
+        "safe-buffer": "^5.2.1",
+        "to-buffer": "^1.2.0"
+      },
+      "bin": {
+        "sha.js": "bin.js"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",
@@ -3255,6 +3684,21 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/to-buffer": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/to-buffer/-/to-buffer-1.2.2.tgz",
+      "integrity": "sha512-db0E3UJjcFhpDhAF4tLo03oli3pwl3dbnzXOUIlRKrp+ldk/VUxzpWYZENsw2SZiuBjHAk7DfB0VU7NKdpb6sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "isarray": "^2.0.5",
+        "safe-buffer": "^5.2.1",
+        "typed-array-buffer": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/toidentifier": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
@@ -3263,6 +3707,13 @@
       "engines": {
         "node": ">=0.6"
       }
+    },
+    "node_modules/toml": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/toml/-/toml-3.0.0.tgz",
+      "integrity": "sha512-y/mWCZinnvxjTKYhJ+pYxwD0mRLVvOtdS2Awbgxln6iEnt4rk0yBxeSBHkGJcPucRiG0e55mwWp+g/05rsrd6w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/tree-kill": {
       "version": "1.2.2",
@@ -3390,6 +3841,21 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/typed-array-buffer": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/typed-array-buffer/-/typed-array-buffer-1.0.3.tgz",
+      "integrity": "sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "es-errors": "^1.3.0",
+        "is-typed-array": "^1.1.14"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/typescript": {
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
@@ -3438,6 +3904,13 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/urijs": {
+      "version": "1.19.11",
+      "resolved": "https://registry.npmjs.org/urijs/-/urijs-1.19.11.tgz",
+      "integrity": "sha512-HXgFDgDommxn5/bIv0cnQZsPhHDA90NPHD6+c/v21U5+Sx5hoP8+dP9IZXBU1gIfvdRfhG8cel9QNPeionfcCQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/vary": {
       "version": "1.1.2",
@@ -3636,6 +4109,28 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/which-typed-array": {
+      "version": "1.1.22",
+      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.22.tgz",
+      "integrity": "sha512-fvO4ExWMFsqyhG3AiPAObMuY1lxaqgYcxbc49CNdWDDECOJNgQyvsOWVwbZc+qf3rzRtxojBK+CMEv0Ld5CYpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "available-typed-arrays": "^1.0.7",
+        "call-bind": "^1.0.9",
+        "call-bound": "^1.0.4",
+        "for-each": "^0.3.5",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/why-is-node-running": {

--- a/package.json
+++ b/package.json
@@ -104,6 +104,7 @@
   "scripts": {
     "build": "tsup",
     "typecheck": "tsc --noEmit && tsc --noEmit -p packages/mcp-x402-payer/tsconfig.json",
+    "check:docs": "node scripts/check-doc-snippets.mjs",
     "test": "vitest run",
     "test:integration": "npm run test:integration --workspace @vellar/mcp-x402-payer",
     "prepublishOnly": "npm run typecheck && npm test && npm run build",
@@ -117,6 +118,7 @@
   },
   "devDependencies": {
     "@stellar/stellar-sdk": "^16.0.1",
+    "passkey-kit": "^0.16.5",
     "tsup": "^8.5.1",
     "typescript": "^5.9.2",
     "vitest": "^3.2.0"

--- a/scripts/check-doc-snippets.mjs
+++ b/scripts/check-doc-snippets.mjs
@@ -1,0 +1,104 @@
+#!/usr/bin/env node
+// Typecheck the docs' code snippets against the CURRENT SDK source, so a
+// quickstart that drifts from the real API fails CI instead of failing the
+// first participant who copy-pastes it (the way `TESTNET.nativeTokenId` did).
+//
+// How: extract every ```ts fence from each listed page, hoist import lines to
+// the top (deduped), keep the FIRST block's body at top level (it declares the
+// shared setup later blocks reference), wrap each later block in its own async
+// function (so `await` works and repeated `const session = ...` declarations
+// don't collide), then run `tsc --noEmit` over the result with `vellar-sdk`
+// path-mapped to ./src. passkey-kit and @stellar/stellar-sdk resolve from
+// node_modules like any import.
+//
+// Only pages whose snippets are self-contained-in-order belong in PAGES —
+// most other pages' snippets reference free variables (`kit`, `sac`, ...) by
+// design and cannot typecheck standalone.
+
+import { execFileSync } from "node:child_process";
+import { mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const PAGES = ["website/content/docs/quickstart.md"];
+
+const outDir = path.join(root, ".doc-snippets");
+rmSync(outDir, { recursive: true, force: true });
+mkdirSync(outDir, { recursive: true });
+
+let extracted = 0;
+for (const page of PAGES) {
+  const md = readFileSync(path.join(root, page), "utf8");
+  const blocks = [...md.matchAll(/```ts\n([\s\S]*?)```/g)].map((m) => m[1]);
+  if (blocks.length === 0) continue;
+
+  const imports = new Set();
+  const bodies = [];
+  for (const block of blocks) {
+    const lines = block.split("\n");
+    const body = [];
+    let inImport = false;
+    for (const line of lines) {
+      if (inImport || /^import[\s{]/.test(line)) {
+        imports.add(line);
+        inImport = !/from\s+["'][^"']+["'];?\s*$/.test(line);
+      } else {
+        body.push(line);
+      }
+    }
+    bodies.push(body.join("\n").trim());
+  }
+
+  const [first, ...rest] = bodies;
+  const wrapped = rest
+    .filter((b) => b.length > 0)
+    .map((b, i) => `async function __snippet_${i + 2}() {\n${b}\n}\nvoid __snippet_${i + 2};`);
+  const file = [
+    `// GENERATED from ${page} by scripts/check-doc-snippets.mjs — do not edit.`,
+    [...imports].join("\n"),
+    first,
+    ...wrapped,
+    "export {};",
+  ].join("\n\n");
+
+  const name = path.basename(page, ".md") + ".snippets.ts";
+  writeFileSync(path.join(outDir, name), file);
+  extracted += blocks.length;
+  console.log(`extracted ${blocks.length} ts block(s) from ${page} -> .doc-snippets/${name}`);
+}
+
+if (extracted === 0) {
+  console.error("no ts snippets extracted — PAGES out of date?");
+  process.exit(1);
+}
+
+writeFileSync(
+  path.join(outDir, "tsconfig.json"),
+  JSON.stringify(
+    {
+      compilerOptions: {
+        noEmit: true,
+        strict: true,
+        target: "ES2022",
+        module: "ESNext",
+        moduleResolution: "bundler",
+        lib: ["ES2022", "DOM"],
+        skipLibCheck: true,
+        baseUrl: ".",
+        paths: { "vellar-sdk": ["../src/index.ts"], "vellar-sdk/*": ["../src/*"] },
+      },
+      include: ["*.ts"],
+    },
+    null,
+    2,
+  ),
+);
+
+try {
+  execFileSync("npx", ["tsc", "--noEmit", "-p", outDir], { cwd: root, stdio: "inherit" });
+} catch {
+  console.error("\ndoc snippets failed to typecheck against the current SDK — fix the docs (or the API drift) before merging.");
+  process.exit(1);
+}
+console.log("doc snippets typecheck clean");

--- a/website/content/docs/api-reference.md
+++ b/website/content/docs/api-reference.md
@@ -20,6 +20,17 @@ interface VellarWalletConfig {
   backend: Backend;
   isValidAddress: (address: string) => boolean;
   signedToXdr?: (signed: unknown) => string;
+  apiUrl?: string;
+  policyAttach?: PolicyAttachRuntime;
+  agentKeys?: AgentKeyRuntime;
+  x402?: {
+    signer: SmartAccountX402Signer;
+    simulationSourceAccount: string;
+    rpcUrl?: string;
+    fetchImpl?: FetchLike;
+    expirationLedgerOffset?: number;
+  };
+  rpcUrl?: string;
 }
 ```
 
@@ -32,6 +43,21 @@ interface VellarWalletConfig {
 | `backend` | `Backend` | Your server endpoints for submission and lookup (holds relayer/sponsor secrets — never the SDK). |
 | `isValidAddress` | `(address) => boolean` | Validates a recipient before a payment is ever signed. |
 | `signedToXdr?` | `(signed) => string` | Advanced/test hook: convert the kit's signed output to XDR. Defaults to handling strings and objects with `toXDR()`. |
+| `apiUrl?` | `string` | Policy API gateway base URL. Required to use `wallet.policies` — see [Policies](./policies.md#enabling-policies). |
+| `policyAttach?` | `PolicyAttachRuntime` | Passkey-attach runtime for `wallet.policies.deploy()`; without it read/generate/simulate work but deploy throws. See [Policies](./policies.md#enabling-policies). |
+| `agentKeys?` | `AgentKeyRuntime` | Passkey-signed wallet-admin runtime for `wallet.agents` (mint/revoke agent session keys). See [Agent Keys](./agent-keys.md). |
+| `x402?` | `{ signer, simulationSourceAccount, rpcUrl?, fetchImpl?, expirationLedgerOffset? }` | Enables `wallet.x402` agentic payments. A valid RPC URL is required (here or top-level `rpcUrl`) — from 0.6.1, construction throws `X402NotConfiguredError` otherwise. See [x402](./x402.md#enabling-x402). |
+| `rpcUrl?` | `string` | RPC URL for x402 simulation when `x402.rpcUrl` isn't given, e.g. `https://soroban-testnet.stellar.org`. |
+
+<!-- TODO(docs): this page documents createVellarWallet's config only. Real,
+     public exports still undocumented anywhere on the site — needs its own
+     effort: waitForTransaction / TxStatusReader (tx-status), createSessionStore
+     + storage adapters (session), the vellar-sdk/x402-guards subpath
+     (decodePaymentRequired, selectRequirements, classifySettlement — the
+     don't-double-pay retry classifier), assertAuthEntryInvocation
+     (x402-auth-entry), the vellar-sdk/x402-untrusted prompt-injection
+     sanitizers, and vellar-sdk/rpc (isValidStellarAddress,
+     createRpcBalanceReader, createRpcTxStatusReader). -->
 
 ## The `backend` contract
 

--- a/website/content/docs/hackathon.md
+++ b/website/content/docs/hackathon.md
@@ -54,6 +54,10 @@ us.
 **Key SDK surface:** `createVellarWallet`, `.create()`, `.connect()`, `.pay()`.
 See [Quickstart](./quickstart.md).
 
+**Config you need:** point `backend` at the hosted testnet gateway,
+`createHttpWalletBackend("https://vellar-backend.onrender.com")` — the
+[Quickstart](./quickstart.md#1-create-the-client) shows the full client setup.
+
 ### Track 2, Policy Builder
 
 Programmable on-chain spending controls, built on `wallet.policies`. Vellar
@@ -69,6 +73,11 @@ surprise us.
 **Key SDK surface:** `wallet.policies` (templates, generate, simulate, deploy).
 See [Policies](./policies.md).
 
+**Config you need:** `apiUrl: "https://vellar-backend.onrender.com"` in
+`createVellarWallet` (the same host as the wallet backend) — see
+[Enabling policies](./policies.md#enabling-policies), which includes a
+zero-context smoke test you can paste before writing any wallet code.
+
 ### Track 3, x402 Agent Payments
 
 **"Give your agent a budget, not your keys."** An autonomous agent holds a
@@ -83,6 +92,13 @@ starting points, not the ceiling, the strongest submissions will surprise us.
 
 **Key SDK surface:** `wallet.x402.fetch()`, `createSessionKeySigner`. See
 [x402 Agentic Payments](./x402.md).
+
+**Config you need:** the `x402` block in `createVellarWallet` — a session-key
+signer, a Friendbot-funded `G...` account as `simulationSourceAccount`, and
+`rpcUrl: "https://soroban-testnet.stellar.org"` — copy it from
+[Enabling x402](./x402.md#enabling-x402). Mint the session key per
+[Agent Keys](./agent-keys.md), and discover payable resources through the
+[facilitator's Bazaar](./facilitator.md).
 
 > **Scope note:** this track is specifically about **agent (session-key)
 > payments**, the proven, working path. Human passkey-signed x402 payments

--- a/website/content/docs/installation.md
+++ b/website/content/docs/installation.md
@@ -43,6 +43,14 @@ These forward to your server, which holds the OpenZeppelin Relayer / sponsor
 credentials and submits to the network. See [How It Works](./how-it-works.md)
 for why submission is server-side.
 
+> **You don't have to build this backend to get started.** A hosted testnet
+> gateway runs at `https://vellar-backend.onrender.com` — point
+> `createHttpWalletBackend` at it and skip the server work entirely (this is
+> what [hackathon](./hackathon.md#getting-started) projects should do). It
+> also serves the policy API for `apiUrl`. Free instance: the first request
+> after idle can take 30–60 seconds to wake. Run your own backend when you
+> ship to production.
+
 ## Requirements
 
 - **A secure context** — WebAuthn (passkeys) only works over HTTPS or

--- a/website/content/docs/policies.md
+++ b/website/content/docs/policies.md
@@ -34,7 +34,10 @@ const vellar = createVellarWallet({
   sac,
   backend,
   isValidAddress,
-  apiUrl: "https://api.myapp.com", // your policy API gateway
+  // The hosted testnet policy gateway (same host as the wallet backend).
+  // Production: your own gateway. Free instance — the first request after a
+  // quiet spell can take 30-60s while it wakes.
+  apiUrl: "https://vellar-backend.onrender.com",
   policyAttach: {
     // build kit.addPolicy(contractId) → passkey-sign → submit via your backend
     async attachPolicy(policyContractId) {
@@ -52,6 +55,28 @@ const vellar = createVellarWallet({
 
 Without `apiUrl`, `wallet.policies` throws. Without `policyAttach`, read /
 generate / simulate still work but `deploy()` throws a clear error.
+
+### Zero-context smoke test
+
+Nothing here needs a wallet or a passkey — paste this anywhere (browser console,
+a Node script) to confirm the gateway is live and see the real templates,
+including their honest enforcement labels:
+
+```ts
+import { createPolicyClient } from "vellar-sdk";
+
+const policyClient = createPolicyClient({
+  apiUrl: "https://vellar-backend.onrender.com",
+  network: "testnet",
+});
+
+const templates = await policyClient.listTemplates();
+console.log(templates.map((t) => `${t.type} — ${t.title} (${t.enforcement.kind})`));
+// e.g. "spending_limit — Spending limit (policy-contract)"
+```
+
+If that prints templates, your config is right — everything after this is the
+same client with a wallet session attached (`wallet.policies`).
 
 ## The flow
 

--- a/website/content/docs/quickstart.md
+++ b/website/content/docs/quickstart.md
@@ -5,6 +5,26 @@ minutes. Once you have a wallet, add [x402 payments](./x402.md) to pay for
 HTTP-402 resources, and [agent keys](./agent-keys.md) to let an agent pay on its
 own under on-chain limits.
 
+## 0. Install
+
+All three packages — the SDK, its Stellar peer, and the passkey engine you pass
+in as `kit`:
+
+```sh
+npm install vellar-sdk @stellar/stellar-sdk passkey-kit
+```
+
+> **Need a funded testnet account?** Some flows (like
+> [x402's](./x402.md) `simulationSourceAccount`) need a funded classic `G...`
+> account. Friendbot funds any testnet account for free:
+>
+> ```sh
+> curl "https://friendbot.stellar.org?addr=GYOUR_ACCOUNT_ID_HERE"
+> ```
+>
+> Wallet creation and payments in THIS quickstart don't need one — deployment
+> and fees are sponsored by the backend.
+
 ## 1. Create the client
 
 ```ts
@@ -28,8 +48,8 @@ const vellar = createVellarWallet({
     rpcUrl: TESTNET.rpcUrl,
     networkPassphrase: TESTNET.networkPassphrase,
   }),
-  // Point at YOUR backend — it holds the relayer/sponsor secrets.
-  backend: createHttpWalletBackend("https://api.myapp.com"),
+  // The hosted testnet backend — it holds the relayer/sponsor secrets.
+  backend: createHttpWalletBackend("https://vellar-backend.onrender.com"),
   isValidAddress: (a) =>
     StrKey.isValidEd25519PublicKey(a) || StrKey.isValidContract(a),
 });
@@ -37,7 +57,16 @@ const vellar = createVellarWallet({
 
 `TESTNET` (shipped by the SDK) provides the RPC URL, passphrase, wallet wasm
 hash, and native-token id — no more digging for magic values. And
-`createHttpWalletBackend` is the ready-made client for your gateway.
+`createHttpWalletBackend` is the ready-made client for the gateway.
+
+> **About that backend URL.** `https://vellar-backend.onrender.com` is the
+> hosted testnet gateway (the same one the [hackathon](./hackathon.md#getting-started)
+> uses) — fine for the hackathon and prototyping. It runs on a free Render
+> instance that sleeps when idle, so the **first request after a quiet spell can
+> take 30–60 seconds** while it wakes; retry once rather than assuming a bug.
+> For production you run your own backend — it's three routes holding your
+> relayer/sponsor secrets; see [Installation](./installation.md#what-you-supply)
+> and [How It Works](./how-it-works.md).
 
 ## 2. Create a wallet
 
@@ -69,7 +98,7 @@ const { hash } = await vellar.pay({
   to: "CDEST...",
   amount: 5_0000000n, // 5 XLM, in stroops (bigint)
   token: {
-    contractId: TESTNET.nativeTokenId, // XLM's Stellar Asset Contract — no faucet needed, it's shipped by TESTNET
+    contractId: TESTNET.nativeTokenContractId, // XLM's Stellar Asset Contract — shipped by TESTNET
     symbol: "XLM",
     decimals: 7,
   },

--- a/website/content/docs/x402.md
+++ b/website/content/docs/x402.md
@@ -62,9 +62,16 @@ const vellar = createVellarWallet({
       secretKey: sessionKeySecret, // the session key attached to it
     }),
     simulationSourceAccount: aFundedGAccount,
+    // Soroban RPC used for x402 simulation — required.
+    rpcUrl: "https://soroban-testnet.stellar.org",
   },
 });
 ```
+
+Need a funded `G...` account for `simulationSourceAccount`? On testnet,
+Friendbot funds any keypair for free:
+`curl "https://friendbot.stellar.org?addr=G..."` — see the
+[Quickstart](./quickstart.md#0-install).
 
 `simulationSourceAccount` must be a **different** funded account from the
 payer — never the wallet's own address. The facilitator rebuilds the
@@ -75,6 +82,13 @@ rejects outright (`invalid_exact_stellar_payload_unsupported_credential_type`).
 Any funded `G...` keypair works here — it never signs and is never charged.
 
 Without `x402` config, calls on `wallet.x402` throw `X402NotConfiguredError`.
+
+> **Troubleshooting `X402NotConfiguredError`.** From `vellar-sdk` 0.6.1 this is
+> also thrown at `createVellarWallet` construction when `rpcUrl` is missing,
+> empty, or not a parseable URL (pass it as `x402.rpcUrl` or top-level
+> `rpcUrl`). On earlier versions the same mistake surfaced later, as a raw
+> `TypeError: Invalid URL` from inside `@stellar/stellar-sdk` during
+> `wallet.x402.fetch()` — if you see that, this config is the cause.
 
 ## Paying a resource
 
@@ -111,6 +125,15 @@ signer-agnostic:
 | ------ | ---- | ------ |
 | `createSessionKeySigner({ address, secretKey })` | **Agent** — a scoped ed25519 session key signs headlessly. Bounded on-chain by the spending-limit policy attached to it. | None — an agent runs unattended. |
 | `createPasskeyX402Signer({ address, webAuthn })` | **Human** — a person pays from the web app. `webAuthn` is a seam you wire to your passkey ceremony. | One passkey prompt per payment. |
+
+> ⚠️ **The passkey signer does not settle today.** `createPasskeyX402Signer`
+> produces a correct signature shape, but **no deployed facilitator currently
+> accepts human passkey-signed x402 payments** — a payment built with it will
+> not settle. Build on the **session-key path** (`createSessionKeySigner`),
+> which settles end to end against the
+> [hosted facilitator](./facilitator.md). This applies to
+> [hackathon](./hackathon.md) projects especially: don't build around the
+> passkey signer.
 
 Both produce **V1 (`sorobanCredentialsAddress`) credentials** in the smart-wallet
 signature format the account's `__check_auth` expects. (The SDK builds this


### PR DESCRIPTION
Companion to #199 (SDK 0.6.1). Fixes every docs finding from the DX audit so a participant can go from `npm install` to a settled payment without leaving the paved road.

**Quickstart (B1)**
- New install step includes `passkey-kit` — the first snippet imports it, but it was absent from the install line (and from the SDK's dependency metadata; #199 adds the optional peer).
- `TESTNET.nativeTokenId` → `nativeTokenContractId` (the field that exists). This was step 4 of the flagship example failing on copy-paste.
- The `https://api.myapp.com` placeholder is now the real hosted gateway `https://vellar-backend.onrender.com`, with a callout: free Render instance, first request after idle takes 30–60s; production = run your own (linked). README updated the same way.
- Friendbot callout (`curl "https://friendbot.stellar.org?addr=G..."`) — previously never mentioned anywhere; x402.md links to it.

**Track 2 / policies.md (B2)** — the placeholder `apiUrl` replaced with the hosted gateway, **verified live** (`GET /policies/templates` returns the six real templates). Added a zero-context smoke test using `createPolicyClient` that runs with no wallet, passkey, or session.

**Track 3 / x402.md (B3)** — config example gains the required `rpcUrl`; a prominent warning marks `createPasskeyX402Signer` as not settling on any deployed facilitator (the page no longer contradicts hackathon.md); troubleshooting note for `X402NotConfiguredError` covering 0.6.1's construction-time validation.

**Cross-linking (B4)** — each hackathon track section now states the exact config it needs with a link to the page that shows it; installation.md points at the hosted gateway so nobody builds relayer infrastructure they don't need.

**api-reference.md triage (B5)** — the five missing config fields (`apiUrl`, `policyAttach`, `agentKeys`, `x402`, `rpcUrl`) documented with links; a TODO comment inventories the still-undocumented exports (waitForTransaction, classifySettlement, sanitizers, …) for the separate full-reference effort.

**Docs CI (B6)** — `scripts/check-doc-snippets.mjs` extracts the quickstart's ```ts fences, wraps successive blocks so they share the first block's setup, and runs `tsc --noEmit` with `vellar-sdk` path-mapped to `./src`. `passkey-kit` joins devDependencies so the `new PasskeyKit({...})` call typechecks against the real package. Wired into ci.yml between typecheck and test. **Verified it fails on the original `nativeTokenId` bug and passes after the fix.** Pages whose snippets intentionally use free variables stay out of scope (documented in the script).

**Verification:** typecheck clean, 501/501 tests, `npm audit --audit-level=high` exit 0 (one low, below the gate), docs site production build clean, zero remaining `nativeTokenId` / placeholder-URL occurrences in the fixed pages.