### PR TITLE
docs: honest cold-start numbers + the localhost-seller guard

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ const vellar = createVellarWallet({
   // Your backend (see "Your backend" below) — it holds the relayer/sponsor
   // secrets, the SDK never sees them. For testnet prototyping you can point at
   // the hosted gateway: https://vellar-backend.onrender.com (free instance,
-  // first request after idle takes 30-60s to wake).
+  // first request after idle takes 30-90s, occasionally ~2min, to wake).
   backend: createHttpWalletBackend("https://api.myapp.com"),
   isValidAddress: (a) =>
     StrKey.isValidEd25519PublicKey(a) || StrKey.isValidContract(a),

--- a/website/content/docs/facilitator.md
+++ b/website/content/docs/facilitator.md
@@ -177,7 +177,12 @@ discoverable," using this page alone:
 # 1. Provision an asset + funded accounts (~40s–3min)
 node provision-testnet.mjs
 
-# 2. Start a seller advertising it, with the PAYTO/ASSET it just printed
+# 2. Start a seller advertising it, with the PAYTO/ASSET it just printed.
+#    Heads up: with a localhost URL and the SHARED facilitator, seller.mjs
+#    REFUSES to start (a localhost resource would enter the public Bazaar
+#    permanently, unverifiable). For local testing add
+#    ALLOW_UNVERIFIABLE_ON_SHARED=1, or run your own facilitator and set
+#    FACILITATOR_URL — the refusal message walks through both.
 PAYTO=G... ASSET=C... PRICE_ATOMIC=1000000 node seller.mjs
 
 # 3. Pay it — classic keypair, no extra dependencies. No second funded

--- a/website/content/docs/facilitator.md
+++ b/website/content/docs/facilitator.md
@@ -42,11 +42,73 @@ smart-account wallet for the buyer side — see [Agent keys](./agent-keys.md)
 for generating that keypair without the secret ever touching a command line
 or a file.
 
-**The demo seller's `X402TST` (`CDYCX4PE…`) cannot be acquired by anyone.**
-Its issuer keypair was generated in-process by a throwaway script, and the
-secret no longer exists — nobody can mint more of it, including us. If you
-find that contract id in `/discovery/resources`, don't spend time trying to
-get a balance of it; point your own buyer at your own seller instead.
+**One old Bazaar entry, `X402TST` (`CDYCX4PE…`), cannot be acquired by
+anyone.** Its issuer keypair was generated in-process by a throwaway script,
+and the secret no longer exists — nobody can mint more of it, including us.
+If you find that contract id in `/discovery/resources`, don't spend time
+trying to get a balance of it. This warning is about **that entry only** —
+the deployed demo seller itself now charges real testnet USDC and is payable
+by anyone; see the next section.
+
+## Paying the deployed demo seller
+
+Want to test against a live seller without running your own?
+`https://vellar-seller-demo.onrender.com/quote` charges **0.1 real testnet
+USDC** (`USDC:GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5`,
+Circle's official testnet issuer) with sponsored fees. Testnet USDC is
+freely obtainable with no faucet form: Friendbot an account, then buy USDC
+on the testnet DEX with the Friendbot XLM — the same two steps the
+[playground](https://playground.vellar.xyz) performs when it funds a
+session wallet:
+
+```ts
+import {
+  Asset,
+  Horizon,
+  Keypair,
+  Networks,
+  Operation,
+  TransactionBuilder,
+} from "@stellar/stellar-sdk";
+
+const USDC = new Asset("USDC", "GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5");
+const horizon = new Horizon.Server("https://horizon-testnet.stellar.org");
+
+const payer = Keypair.random();
+await fetch(`https://friendbot.stellar.org?addr=${payer.publicKey()}`);
+
+const account = await horizon.loadAccount(payer.publicKey());
+const tx = new TransactionBuilder(account, { fee: "1000", networkPassphrase: Networks.TESTNET })
+  .addOperation(Operation.changeTrust({ asset: USDC }))
+  .addOperation(
+    Operation.pathPaymentStrictReceive({
+      sendAsset: Asset.native(),
+      sendMax: "1000", // XLM you are willing to spend
+      destination: payer.publicKey(),
+      destAsset: USDC,
+      destAmount: "0.5", // USDC you receive
+    }),
+  )
+  .setTimeout(60)
+  .build();
+tx.sign(payer);
+await horizon.submitTransaction(tx);
+console.log("payer:", payer.publicKey(), "secret:", payer.secret());
+```
+
+Then pay the seller with that keypair (classic flow, from `examples/`):
+
+```sh
+RESOURCE_URL="https://vellar-seller-demo.onrender.com/quote?topic=perseverance" \
+PAYER_SECRET=S...   # the secret the script printed
+node buyer-classic.mjs
+```
+
+Both steps are verified working end to end. Note the demo seller is a free
+Render instance — from deep sleep the first request can take a minute or
+more to answer. For the **smart-account/agent** flow you still provision
+your own seller (below): a fresh smart account holds no USDC, and the
+budget-policy story needs an asset your policies are scoped to.
 
 ## Why it exists
 

--- a/website/content/docs/hackathon.md
+++ b/website/content/docs/hackathon.md
@@ -98,7 +98,9 @@ signer, a Friendbot-funded `G...` account as `simulationSourceAccount`, and
 `rpcUrl: "https://soroban-testnet.stellar.org"` — copy it from
 [Enabling x402](./x402.md#enabling-x402). Mint the session key per
 [Agent Keys](./agent-keys.md), and discover payable resources through the
-[facilitator's Bazaar](./facilitator.md).
+[facilitator's Bazaar](./facilitator.md). Want to test against a live seller
+without running your own? The demo seller accepts testnet USDC — see
+[Paying the deployed demo seller](./facilitator.md#paying-the-deployed-demo-seller).
 
 > **Scope note:** this track is specifically about **agent (session-key)
 > payments**, the proven, working path. Human passkey-signed x402 payments
@@ -341,6 +343,47 @@ npm run dev
 - [ ] Submission **Issue** opened with the correct title and template filled in
 - [ ] Submitted **before the deadline**
 
+
+## FAQ
+
+The canonical answers for the pinned channel FAQ — if these ever disagree
+with a pinned message, this page wins.
+
+**The first request is hanging / everything seems down.** The hosted backend
+and facilitator sleep when idle (free instances). The first request after a
+quiet spell can take 30–90 seconds, occasionally ~2 minutes, while they
+wake. Retry — after that everything is fast. Not a bug in your code.
+
+**How do I get a funded testnet account?** Friendbot, free:
+`curl "https://friendbot.stellar.org?addr=G...YOURKEY"`. You only need it
+for x402's `simulationSourceAccount` (never charged) — wallet creation and
+payments are fee-sponsored. See the [Quickstart](./quickstart.md#0-install).
+
+**`vellar.create()` crashes in my Node script.** Passkeys are WebAuthn,
+browser-only. For Node, CLIs, and agents use the session-key path: mint an
+agent key (browser session, or `provision-testnet.mjs`), then
+`createSessionKeySigner` + `wallet.x402`. The `PasskeyBrowserRequiredError`
+you'll see says exactly this. See [Agent Keys](./agent-keys.md).
+
+**Can I build on passkey-signed x402?** No — it does not settle on any
+deployed facilitator. Build on the session-key (agent) path. See
+[x402](./x402.md).
+
+**I got `X402NotConfiguredError`.** Your x402 config is missing a valid
+`rpcUrl`. Add `rpcUrl: "https://soroban-testnet.stellar.org"` to the `x402`
+block of `createVellarWallet`. Seeing a raw `TypeError: Invalid URL`
+instead? Upgrade to `vellar-sdk` 0.6.1.
+
+**Can I pay the demo seller from the Bazaar?** Yes — it charges real
+testnet USDC. Easiest: the [playground](https://playground.vellar.xyz)
+funds a session wallet with USDC automatically and pays with one click.
+Headless: Friendbot an account, then buy USDC on the testnet DEX — the
+exact recipe is in
+[Paying the deployed demo seller](./facilitator.md#paying-the-deployed-demo-seller).
+For the smart-account/agent flow, run your own seller via
+`provision-testnet.mjs` instead. One asset in the Bazaar genuinely can't be
+obtained (`X402TST` — its issuer key was destroyed); that warning is about
+that entry only, not the demo seller.
 
 ## Getting Started
 

--- a/website/content/docs/installation.md
+++ b/website/content/docs/installation.md
@@ -48,7 +48,7 @@ for why submission is server-side.
 > `createHttpWalletBackend` at it and skip the server work entirely (this is
 > what [hackathon](./hackathon.md#getting-started) projects should do). It
 > also serves the policy API for `apiUrl`. Free instance: the first request
-> after idle can take 30–60 seconds to wake. Run your own backend when you
+> after idle can take 30–90 seconds (occasionally up to ~2 minutes) to wake. Run your own backend when you
 > ship to production.
 
 ## Requirements

--- a/website/content/docs/policies.md
+++ b/website/content/docs/policies.md
@@ -36,7 +36,7 @@ const vellar = createVellarWallet({
   isValidAddress,
   // The hosted testnet policy gateway (same host as the wallet backend).
   // Production: your own gateway. Free instance — the first request after a
-  // quiet spell can take 30-60s while it wakes.
+  // quiet spell can take 30-90s (occasionally ~2min) while it wakes.
   apiUrl: "https://vellar-backend.onrender.com",
   policyAttach: {
     // build kit.addPolicy(contractId) → passkey-sign → submit via your backend

--- a/website/content/docs/quickstart.md
+++ b/website/content/docs/quickstart.md
@@ -63,7 +63,8 @@ hash, and native-token id — no more digging for magic values. And
 > hosted testnet gateway (the same one the [hackathon](./hackathon.md#getting-started)
 > uses) — fine for the hackathon and prototyping. It runs on a free Render
 > instance that sleeps when idle, so the **first request after a quiet spell can
-> take 30–60 seconds** while it wakes; retry once rather than assuming a bug.
+> take 30–90 seconds — occasionally up to ~2 minutes** while it wakes; retry
+> rather than assuming a bug.
 > For production you run your own backend — it's three routes holding your
 > relayer/sponsor secrets; see [Installation](./installation.md#what-you-supply)
 > and [How It Works](./how-it-works.md).

--- a/website/content/docs/x402.md
+++ b/website/content/docs/x402.md
@@ -73,6 +73,11 @@ Friendbot funds any keypair for free:
 `curl "https://friendbot.stellar.org?addr=G..."` — see the
 [Quickstart](./quickstart.md#0-install).
 
+> **Want to test against a live seller without running your own?** The
+> deployed demo seller accepts real testnet USDC, which you can obtain
+> headlessly in two steps — see
+> [Paying the deployed demo seller](./facilitator.md#paying-the-deployed-demo-seller).
+
 `simulationSourceAccount` must be a **different** funded account from the
 payer — never the wallet's own address. The facilitator rebuilds the
 transaction with itself as the source before submitting, so yours is only


### PR DESCRIPTION
Small follow-up from the pre-hackathon verification dry-runs (Phases 3–5).

1. **Cold-start honesty.** The callouts said 30–60s; measured wake-from-sleep was **~89s** (backend), **~32s** (facilitator), and **several minutes** (demo seller). All four callouts — quickstart, installation, policies, README — now say *30–90 seconds, occasionally ~2 minutes*. (PR #201 proposes the keepalive that makes this moot during the event.)

2. **The localhost-seller refusal.** During the Track 3 dry-run, `seller.mjs` (correctly) refused to start with a localhost URL against the shared facilitator — a guard the facilitator.md walkthrough never mentions, so a participant following it hits a wall mid-tutorial. The walkthrough now warns about the refusal upfront and names both documented outs (`ALLOW_UNVERIFIABLE_ON_SHARED=1`, or a local facilitator via `FACILITATOR_URL`).

check:docs green.