### PR TITLE
contrib: add example scripts for wallet session, secret masking, and relative time

### DIFF
--- a/contrib/examples/build-wallet-session/README.md
+++ b/contrib/examples/build-wallet-session/README.md
@@ -1,0 +1,36 @@
+# Build WalletSession Example (#115)
+
+Constructs a minimal sample `WalletSession` object by hand, validates that the provided `accountId` matches a Soroban contract address format, and outputs the resulting object as formatted JSON.
+
+## WalletSession Shape
+
+```typescript
+interface WalletSession {
+  /** The Soroban contract address of the wallet (must start with 'C' and be 56 characters long). */
+  accountId: string;
+  /** Optional session key or signer key identifier. */
+  keyId?: string;
+  /** ISO 8601 timestamp indicating when the session was created. */
+  createdAt: string;
+}
+```
+
+## Examples
+
+| Account ID | Key ID | Valid Contract Address? | Output JSON |
+| --- | --- | --- | --- |
+| `CA7QY3Z54G5P6H7J8K9L0M1N2O3P4Q5R6S7T8U9V0W1X2Y3Z4A5B6C7D` | `undefined` | Yes | `{ "accountId": "CA7QY3...", "createdAt": "..." }` |
+| `CA7QY3Z54G5P6H7J8K9L0M1N2O3P4Q5R6S7T8U9V0W1X2Y3Z4A5B6C7D` | `key-secp256r1-001` | Yes | `{ "accountId": "CA7QY3...", "keyId": "key-secp256r1-001", "createdAt": "..." }` |
+| `GABC1234567890` | `undefined` | No | Throws Validation Error |
+
+## Run it
+
+```sh
+npx tsx contrib/examples/build-wallet-session/build-wallet-session.ts
+```
+
+## Tests
+
+```sh
+npx vitest run contrib/examples/build-wallet-session
+```

--- a/contrib/examples/build-wallet-session/build-wallet-session.test.ts
+++ b/contrib/examples/build-wallet-session/build-wallet-session.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildWalletSession,
+  isContractAddress,
+} from './build-wallet-session';
+
+describe('build-wallet-session (#115)', () => {
+  const validContractId =
+    'CA7QY3Z54G5P6H7J8K9L0M1N2O3P4Q5R6S7T8U9V0W1X2Y3Z4A5B6C7D';
+
+  it('validates contract addresses correctly', () => {
+    expect(isContractAddress(validContractId)).toBe(true);
+    expect(isContractAddress('GABC1234567890')).toBe(false);
+    expect(isContractAddress('')).toBe(false);
+  });
+
+  it('builds a WalletSession object with accountId', () => {
+    const session = buildWalletSession(validContractId);
+    expect(session.accountId).toBe(validContractId);
+    expect(session.keyId).toBeUndefined();
+    expect(typeof session.createdAt).toBe('string');
+  });
+
+  it('includes keyId when provided', () => {
+    const keyId = 'passkey-01';
+    const session = buildWalletSession(validContractId, keyId);
+    expect(session.accountId).toBe(validContractId);
+    expect(session.keyId).toBe(keyId);
+  });
+
+  it('throws an error for invalid accountId', () => {
+    expect(() => buildWalletSession('INVALID_ADDRESS')).toThrow(
+      /is not a valid contract address/,
+    );
+  });
+});

--- a/contrib/examples/build-wallet-session/build-wallet-session.ts
+++ b/contrib/examples/build-wallet-session/build-wallet-session.ts
@@ -1,0 +1,82 @@
+// Example: Build a minimal WalletSession object and validate its contract accountId.
+//
+// Run with: npx tsx contrib/examples/build-wallet-session/build-wallet-session.ts
+
+export interface WalletSession {
+  accountId: string;
+  keyId?: string;
+  createdAt: string;
+}
+
+/**
+ * Checks whether an address string matches a Soroban contract address format
+ * (starts with 'C' and is 56 characters long).
+ */
+export function isContractAddress(address: string): boolean {
+  if (!address || typeof address !== 'string') {
+    return false;
+  }
+  return /^C[A-Z0-9]{55}$/i.test(address.trim());
+}
+
+/**
+ * Validates the accountId contract address and constructs a WalletSession object.
+ * Throws an error if the accountId is not a valid contract address.
+ */
+export function buildWalletSession(
+  accountId: string,
+  keyId?: string,
+): WalletSession {
+  const trimmedAddress = accountId.trim();
+
+  if (!isContractAddress(trimmedAddress)) {
+    throw new Error(
+      `Invalid accountId: "${accountId}" is not a valid contract address (must start with "C" and be 56 characters long).`,
+    );
+  }
+
+  const session: WalletSession = {
+    accountId: trimmedAddress,
+    createdAt: new Date().toISOString(),
+  };
+
+  if (keyId && keyId.trim()) {
+    session.keyId = keyId.trim();
+  }
+
+  return session;
+}
+
+function main() {
+  console.log('=== Build WalletSession Example ===\n');
+
+  // Example 1: Valid Contract Account ID without optional keyId
+  const validContractId =
+    'CA7QY3Z54G5P6H7J8K9L0M1N2O3P4Q5R6S7T8U9V0W1X2Y3Z4A5B6C7D';
+  console.log('Building session for valid contract address:');
+  const session1 = buildWalletSession(validContractId);
+  console.log(JSON.stringify(session1, null, 2));
+
+  console.log('\n-----------------------------------\n');
+
+  // Example 2: Valid Contract Account ID with optional keyId
+  const keyId = 'key-session-secp256r1-001';
+  console.log('Building session with optional keyId:');
+  const session2 = buildWalletSession(validContractId, keyId);
+  console.log(JSON.stringify(session2, null, 2));
+
+  console.log('\n-----------------------------------\n');
+
+  // Example 3: Invalid Account ID validation
+  const invalidAddress = 'GABC1234567890';
+  console.log(`Attempting to build session with invalid address "${invalidAddress}":`);
+  try {
+    buildWalletSession(invalidAddress);
+  } catch (err: any) {
+    console.log(`Validation Error caught: ${err.message}`);
+  }
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main();
+}

--- a/contrib/examples/issue-112-relative-time/README.md
+++ b/contrib/examples/issue-112-relative-time/README.md
@@ -1,0 +1,3 @@
+# Format Relative Time Example (#112)
+
+See [`contrib/examples/relative-time/README.md`](../relative-time/README.md) for full documentation.

--- a/contrib/examples/issue-112-relative-time/relative-time.ts
+++ b/contrib/examples/issue-112-relative-time/relative-time.ts
@@ -1,0 +1,1 @@
+export * from '../relative-time/relative-time';

--- a/contrib/examples/issue-113-mask-secret/README.md
+++ b/contrib/examples/issue-113-mask-secret/README.md
@@ -1,0 +1,3 @@
+# Mask Secret Key Example (#113)
+
+See [`contrib/examples/mask-secret/README.md`](../mask-secret/README.md) for full documentation.

--- a/contrib/examples/issue-113-mask-secret/mask-secret.ts
+++ b/contrib/examples/issue-113-mask-secret/mask-secret.ts
@@ -1,0 +1,1 @@
+export * from '../mask-secret/mask-secret';

--- a/contrib/examples/issue-115-build-wallet-session/README.md
+++ b/contrib/examples/issue-115-build-wallet-session/README.md
@@ -1,0 +1,3 @@
+# Build WalletSession Example (#115)
+
+See [`contrib/examples/build-wallet-session/README.md`](../build-wallet-session/README.md) for full documentation.

--- a/contrib/examples/issue-115-build-wallet-session/build-wallet-session.ts
+++ b/contrib/examples/issue-115-build-wallet-session/build-wallet-session.ts
@@ -1,0 +1,1 @@
+export * from '../build-wallet-session/build-wallet-session';

--- a/contrib/examples/mask-secret/README.md
+++ b/contrib/examples/mask-secret/README.md
@@ -1,0 +1,24 @@
+# Mask Secret Key Example (#113)
+
+Provides a lightweight, safe utility `maskSecret` that masks all but the first few characters of a secret key string (such as a Stellar secret seed starting with `S`). Suitable for safe logging without exposing sensitive key material in stdout or telemetry.
+
+## Examples & Expected Outputs
+
+| Input Secret Key | Visible Chars | Masked Output for Safe Logging |
+| --- | --- | --- |
+| `SD4V5Q7Z3X8K9L0M1N2O3P4Q5R6S7T8U9V0W1X2Y3Z4A5B6C7D8E9F0G` | 4 (Default) | `SD4V****************************************************` |
+| `SBXZ9876543210FEDCBA9876543210FEDCBA9876543210FEDCBA9876` | 4 (Default) | `SBXZ****************************************************` |
+| `SBXZ9876543210` | 2 | `SB****************` |
+| `S123` | 4 | `****` (Fully masked to prevent leaks) |
+
+## Run it
+
+```sh
+npx tsx contrib/examples/mask-secret/mask-secret.ts
+```
+
+## Tests
+
+```sh
+npx vitest run contrib/examples/mask-secret
+```

--- a/contrib/examples/mask-secret/mask-secret.test.ts
+++ b/contrib/examples/mask-secret/mask-secret.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest';
+import { maskSecret } from './mask-secret';
+
+describe('mask-secret (#113)', () => {
+  it('masks secret key showing only first 4 characters by default', () => {
+    const secret =
+      'SD4V5Q7Z3X8K9L0M1N2O3P4Q5R6S7T8U9V0W1X2Y3Z4A5B6C7D8E9F0G';
+    const masked = maskSecret(secret);
+    expect(masked.startsWith('SD4V')).toBe(true);
+    expect(masked.slice(4)).toBe('*'.repeat(secret.length - 4));
+    expect(masked.length).toBe(secret.length);
+  });
+
+  it('customizes visible length and mask character', () => {
+    const secret = 'SBXZ9876543210';
+    const masked = maskSecret(secret, 2, '#');
+    expect(masked.startsWith('SB')).toBe(true);
+    expect(masked.slice(2)).toBe('#'.repeat(secret.length - 2));
+  });
+
+  it('masks short strings entirely to avoid leaking secrets', () => {
+    expect(maskSecret('S123')).toBe('****');
+    expect(maskSecret('AB')).toBe('**');
+  });
+
+  it('handles empty or null inputs gracefully', () => {
+    expect(maskSecret('')).toBe('');
+    expect(maskSecret(null as any)).toBe('');
+  });
+});

--- a/contrib/examples/mask-secret/mask-secret.ts
+++ b/contrib/examples/mask-secret/mask-secret.ts
@@ -1,0 +1,55 @@
+// Example: Mask secret keys for safe logging without exposing full unmasked secrets.
+//
+// Run with: npx tsx contrib/examples/mask-secret/mask-secret.ts
+
+/**
+ * Masks a secret key string, showing only the first `visibleChars` characters
+ * followed by `*` mask characters.
+ *
+ * Safe Logging Guarantee:
+ * - If the input is empty or invalid, returns an empty string or fixed mask.
+ * - If the secret is shorter than or equal to `visibleChars`, masks all characters.
+ * - Never returns or leaks the unmasked secret.
+ */
+export function maskSecret(
+  secret: string,
+  visibleChars = 4,
+  maskChar = '*',
+): string {
+  if (!secret || typeof secret !== 'string') {
+    return '';
+  }
+
+  const str = secret.trim();
+  if (str.length <= visibleChars) {
+    return maskChar.repeat(str.length);
+  }
+
+  const visiblePart = str.slice(0, visibleChars);
+  const maskedPart = maskChar.repeat(str.length - visibleChars);
+  return `${visiblePart}${maskedPart}`;
+}
+
+function main() {
+  console.log('=== Mask Secret Key Example ===\n');
+
+  // Example secret keys (Sample/Testnet values)
+  // IMPORTANT: The script only prints the result of maskSecret(), never unmasked secrets!
+  const sampleSecretKeys = [
+    'SD4V5Q7Z3X8K9L0M1N2O3P4Q5R6S7T8U9V0W1X2Y3Z4A5B6C7D8E9F0G',
+    'SBXZ9876543210FEDCBA9876543210FEDCBA9876543210FEDCBA9876',
+    'S123',
+    'SECRET_API_KEY_LIVE_99887766554433221100',
+  ];
+
+  console.log('Safe Masked Outputs for Logging:');
+  console.log('-----------------------------------');
+  for (const secretKey of sampleSecretKeys) {
+    const masked = maskSecret(secretKey);
+    console.log(`Masked Output : ${masked}  (Length: ${masked.length})`);
+  }
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main();
+}

--- a/contrib/examples/relative-time/README.md
+++ b/contrib/examples/relative-time/README.md
@@ -1,0 +1,29 @@
+# Format Relative Time Example (#112)
+
+Converts ISO timestamps into human-readable relative time strings (such as `"5 minutes ago"`, `"2 hours ago"`). Crucially handles timestamps in the future by clearly indicating that with `"in X ..."` phrasing (e.g. `"in 10 minutes"`) rather than showing negative values.
+
+## Examples & Expected Outputs
+
+Assume current reference time is `2026-08-27T12:00:00.000Z`:
+
+| Input Timestamp | Direction | Expected Relative Output |
+| --- | --- | --- |
+| `2026-08-27T11:59:58.000Z` | Past (<5s) | `just now` |
+| `2026-08-27T11:55:00.000Z` | Past | `5 minutes ago` |
+| `2026-08-27T10:00:00.000Z` | Past | `2 hours ago` |
+| `2026-08-24T12:00:00.000Z` | Past | `3 days ago` |
+| `2026-08-27T12:10:00.000Z` | **Future** | `in 10 minutes` |
+| `2026-08-29T12:00:00.000Z` | **Future** | `in 2 days` |
+| `invalid-date-string` | Invalid | `invalid date` |
+
+## Run it
+
+```sh
+npx tsx contrib/examples/relative-time/relative-time.ts
+```
+
+## Tests
+
+```sh
+npx vitest run contrib/examples/relative-time
+```

--- a/contrib/examples/relative-time/relative-time.test.ts
+++ b/contrib/examples/relative-time/relative-time.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest';
+import { formatRelativeTime } from './relative-time';
+
+describe('relative-time (#112)', () => {
+  const baseNow = new Date('2026-08-27T12:00:00.000Z');
+
+  it('formats past timestamps correctly', () => {
+    expect(formatRelativeTime('2026-08-27T11:59:58.000Z', baseNow)).toBe(
+      'just now',
+    );
+    expect(formatRelativeTime('2026-08-27T11:55:00.000Z', baseNow)).toBe(
+      '5 minutes ago',
+    );
+    expect(formatRelativeTime('2026-08-27T10:00:00.000Z', baseNow)).toBe(
+      '2 hours ago',
+    );
+    expect(formatRelativeTime('2026-08-24T12:00:00.000Z', baseNow)).toBe(
+      '3 days ago',
+    );
+  });
+
+  it('handles future timestamps with "in X" phrasing instead of negative values', () => {
+    expect(formatRelativeTime('2026-08-27T12:10:00.000Z', baseNow)).toBe(
+      'in 10 minutes',
+    );
+    expect(formatRelativeTime('2026-08-29T12:00:00.000Z', baseNow)).toBe(
+      'in 2 days',
+    );
+  });
+
+  it('handles invalid timestamps gracefully', () => {
+    expect(formatRelativeTime('invalid-date-string', baseNow)).toBe(
+      'invalid date',
+    );
+  });
+});

--- a/contrib/examples/relative-time/relative-time.ts
+++ b/contrib/examples/relative-time/relative-time.ts
@@ -1,0 +1,80 @@
+// Example: Convert an ISO timestamp into a relative time string (e.g., "5 minutes ago", "in 10 minutes").
+//
+// Run with: npx tsx contrib/examples/relative-time/relative-time.ts
+
+/**
+ * Formats an ISO timestamp string or Date object into a human-readable relative time string.
+ * Correctly handles future timestamps by returning "in X ..." instead of negative durations.
+ */
+export function formatRelativeTime(
+  timestamp: string | Date,
+  now: Date = new Date(),
+): string {
+  const targetDate = typeof timestamp === 'string' ? new Date(timestamp) : timestamp;
+  const targetMs = targetDate.getTime();
+  const nowMs = now.getTime();
+
+  if (isNaN(targetMs)) {
+    return 'invalid date';
+  }
+
+  const diffMs = targetMs - nowMs;
+  const isFuture = diffMs > 0;
+  const absSeconds = Math.floor(Math.abs(diffMs) / 1000);
+
+  if (absSeconds < 5) {
+    return 'just now';
+  }
+
+  const minutes = Math.floor(absSeconds / 60);
+  const hours = Math.floor(minutes / 60);
+  const days = Math.floor(hours / 24);
+  const months = Math.floor(days / 30);
+  const years = Math.floor(days / 365);
+
+  let timeUnitString = '';
+  if (years >= 1) {
+    timeUnitString = `${years} ${years === 1 ? 'year' : 'years'}`;
+  } else if (months >= 1) {
+    timeUnitString = `${months} ${months === 1 ? 'month' : 'months'}`;
+  } else if (days >= 1) {
+    timeUnitString = `${days} ${days === 1 ? 'day' : 'days'}`;
+  } else if (hours >= 1) {
+    timeUnitString = `${hours} ${hours === 1 ? 'hour' : 'hours'}`;
+  } else if (minutes >= 1) {
+    timeUnitString = `${minutes} ${minutes === 1 ? 'minute' : 'minutes'}`;
+  } else {
+    timeUnitString = `${absSeconds} ${absSeconds === 1 ? 'second' : 'seconds'}`;
+  }
+
+  return isFuture ? `in ${timeUnitString}` : `${timeUnitString} ago`;
+}
+
+function main() {
+  console.log('=== Format Relative Time Example ===\n');
+
+  const now = new Date('2026-08-27T12:00:00.000Z');
+
+  const exampleTimestamps = [
+    { label: 'Just now', iso: '2026-08-27T11:59:58.000Z' },
+    { label: '5 minutes ago', iso: '2026-08-27T11:55:00.000Z' },
+    { label: '2 hours ago', iso: '2026-08-27T10:00:00.000Z' },
+    { label: '3 days ago', iso: '2026-08-24T12:00:00.000Z' },
+    { label: 'Future: in 10 minutes', iso: '2026-08-27T12:10:00.000Z' },
+    { label: 'Future: in 2 days', iso: '2026-08-29T12:00:00.000Z' },
+    { label: 'Invalid ISO format', iso: 'not-a-timestamp' },
+  ];
+
+  console.log(`Base reference time (NOW): ${now.toISOString()}\n`);
+  console.log('Timestamp                              -> Formatted Relative Time');
+  console.log('------------------------------------------------------------------');
+
+  for (const item of exampleTimestamps) {
+    const formatted = formatRelativeTime(item.iso, now);
+    console.log(`${item.iso.padEnd(38)} -> ${formatted}`);
+  }
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main();
+}


### PR DESCRIPTION
relative time (#115, #113, #112)

- Add contrib/examples/build-wallet-session script with Soroban contract address validation (#115)
- Add contrib/examples/mask-secret script for safe logging of secret keys (#113)
- Add contrib/examples/relative-time script supporting past and future ISO timestamps (#112)
- Add README documentation and Vitest test suites for all examples

Closes #115
Closes #113
Closes #112