### PR TITLE
ci: retarget PRs from main to dev instead of closing them

### DIFF
--- a/.github/workflows/close-prs-outside-contrib.yml
+++ b/.github/workflows/close-prs-outside-contrib.yml
@@ -3,7 +3,7 @@ name: Close PRs touching files outside contrib/
 on:
   pull_request_target:
     types: [opened, reopened, ready_for_review, edited, synchronize]
-    branches: [drips]
+    branches: [dev]
 
 permissions:
   pull-requests: write
@@ -52,7 +52,7 @@ jobs:
                 "",
                 list + more,
                 "",
-                `Please open a new PR with your changes scoped to \`contrib/\` only. See [CONTRIBUTING.md](${repoUrl}/blob/main/CONTRIBUTING.md) and [contrib/README.md](${repoUrl}/blob/main/contrib/README.md). If your assigned issue genuinely needs changes elsewhere, say so on the issue first — don't open a PR outside \`contrib/\`.`,
+                `Please open a new PR with your changes scoped to \`contrib/\` only, targeting \`dev\`. See [CONTRIBUTING.md](${repoUrl}/blob/main/CONTRIBUTING.md) and [contrib/README.md](${repoUrl}/blob/main/contrib/README.md). If your assigned issue genuinely needs changes elsewhere, say so on the issue first — don't open a PR outside \`contrib/\`.`,
                 "",
                 "Questions? Ask in the [Telegram group](https://t.me/+RWPCKXXJTj45Njk0).",
               ].join("\n"),

--- a/.github/workflows/close-prs-to-main.yml
+++ b/.github/workflows/close-prs-to-main.yml
@@ -1,4 +1,9 @@
-name: Close PRs targeting main
+name: Redirect PRs from main to dev
+
+# Contributions are not accepted on `main`. Any PR opened against `main` by
+# someone other than the maintainer (davedumto) is automatically retargeted to
+# the `dev` branch and a comment (tagging the author) explains what happened.
+# The contributor does NOT have to reopen anything — their PR is preserved.
 
 on:
   pull_request_target:
@@ -9,7 +14,7 @@ permissions:
   pull-requests: write
 
 jobs:
-  close:
+  redirect-to-dev:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/github-script@v7
@@ -17,24 +22,37 @@ jobs:
           script: |
             const pr = context.payload.pull_request;
             if (pr.state === "closed") return;
+
+            // The maintainer is allowed to open PRs directly to main.
+            const MAINTAINER = "davedumto";
+            if (pr.user.login === MAINTAINER) return;
+
             // Maintainers (owner, org members, collaborators) may PR to main.
             if (["OWNER", "MEMBER", "COLLABORATOR"].includes(pr.author_association)) return;
-            const repoUrl = `https://github.com/${context.repo.owner}/${context.repo.repo}`;
+
+            // Safety: only act while the base is still main (avoid loops).
+            if (pr.base.ref !== "main") return;
+
+            const author = pr.user.login;
+
+            // Retarget the PR from main -> dev. The contributor's work is kept.
+            await github.rest.pulls.update({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: pr.number,
+              base: "dev",
+            });
+
+            // Explain what happened.
             await github.rest.issues.createComment({
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: pr.number,
               body: [
-                "Thanks for the contribution — but pull requests to `main` are reserved for maintainers.",
+                `Hi @${author} — thanks for the contribution!`,
                 "",
-                "All contributions must target the **`drips`** branch. Please open your PR again with `drips` as the base branch (or use the *Edit* button next to the PR title to change the base).",
+                "We do **not** accept pull requests to the `main` branch. All contributions go to the **`dev`** branch, so I've automatically **retargeted this PR from `main` to `dev`** for you.",
                 "",
-                `See [CONTRIBUTING.md](${repoUrl}/blob/main/CONTRIBUTING.md) for the contribution rules. Questions? Ask in the [Telegram group](https://t.me/+RWPCKXXJTj45Njk0).`,
+                "You don't need to reopen anything — your work is preserved and this PR now targets `dev`. Going forward, please set the base branch to `dev` when you open a PR. 🙏",
               ].join("\n"),
-            });
-            await github.rest.pulls.update({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              pull_number: pr.number,
-              state: "closed",
             });

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,20 +12,22 @@ start — pull requests that don't follow them will be closed.
    ```sh
    gh repo fork Vellar-Wallet/vellar-sdk --clone
    cd vellar-sdk
-   git checkout drips
+   git checkout dev
    git checkout -b my-change
    # ...work, commit...
    git push -u origin my-change
    ```
 
-2. **All pull requests must target the `drips` branch — never `main`.**
-   When you open a PR, set the base branch to `drips`. PRs opened against
-   `main` are closed automatically by a bot. `main` is the release branch and
-   is managed by maintainers only.
+2. **All pull requests must target the `dev` branch — never `main`.**
+   When you open a PR, set the base branch to `dev`. PRs opened against
+   `main` are automatically retargeted to `dev` by a bot (your work is kept,
+   you don't need to reopen anything — just set the base to `dev` yourself
+   next time). `main` is the release branch and is managed by maintainers
+   only.
 
 3. **Contributor changes must stay inside `contrib/`.** External PRs that
    touch any file outside `contrib/` are closed automatically by a bot, even
-   if they also target `drips` correctly. See [contrib/README.md](contrib/README.md)
+   if they also target `dev` correctly. See [contrib/README.md](contrib/README.md)
    for what belongs there. If your assigned issue genuinely requires changes
    elsewhere in the codebase, say so on the issue before starting — a
    maintainer will make that change or explicitly widen your scope.


### PR DESCRIPTION
## Summary
Brings vellar-sdk's main-branch PR guard in line with the mechanism already
shipped on vellar-dapp: a PR opened against `main` by a non-maintainer is now
automatically retargeted to `dev` (base flipped, contributor's work kept)
instead of being closed and requiring the contributor to reopen against
`drips`.

## Changes
- `.github/workflows/close-prs-to-main.yml` — retarget-to-`dev` logic
  (mirrors vellar-dapp), plus a `pr.base.ref !== "main"` loop guard the old
  version didn't have.
- `.github/workflows/close-prs-outside-contrib.yml` — trigger fixed from
  `branches: [drips]` to `branches: [dev]`. It was silently dead against the
  new target branch before this fix.
- `CONTRIBUTING.md` — contribution target updated from `drips` to `dev`.

## Not in scope
`contrib/README.md` and `ci.yml` still mention `drips` — left untouched, out
of scope for this change. `drips` itself is left in place, not deleted.

## Test plan
- [ ] Open a throwaway PR from a non-maintainer account targeting `main` and
      confirm it gets retargeted to `dev` with the explanatory comment.
- [ ] Open a PR targeting `dev` that touches a file outside `contrib/` and
      confirm `close-prs-outside-contrib.yml` now fires and closes it.