### PR TITLE
docs(session): document the refresh() return shape (#213)

### DIFF
--- a/README.md
+++ b/README.md
@@ -294,6 +294,33 @@ signers (`createSessionKeySigner`, `createPasskeyX402Signer`), the
 RPC-backed readers (`vellar-sdk/rpc`, imported separately so
 `@stellar/stellar-sdk` stays out of bundles that don't read balances).
 
+#### Session store refresh
+
+`createSessionStore`'s `refresh()` re-reads the persisted session from storage
+and resolves to a documented `SessionRefreshResult` — `{ session, status }` — so
+you can switch on the outcome instead of guessing:
+
+```ts
+import { createSessionStore, createWebStorageAdapter } from "vellar-sdk";
+
+const store = createSessionStore(createWebStorageAdapter(localStorage));
+
+// Re-read the persisted session, e.g. when the tab regains focus or after
+// another tab updated it:
+const { session, status } = await store.getState().refresh();
+
+if (status === "connected" && session) {
+  console.log("resumed", session.accountId); // C... smart-account address
+} else {
+  console.log("no usable session");
+}
+```
+
+`refresh()` never rejects: empty, malformed, or unreadable storage resolves to
+`{ session: null, status: "disconnected" }`. See the
+[session lifecycle](https://docs.vellar.xyz/docs/how-it-works#sessions--reconnect)
+for where refresh fits in.
+
 ## License
 
 Apache-2.0

--- a/src/session.test.ts
+++ b/src/session.test.ts
@@ -1,10 +1,12 @@
-import { describe, expect, it, vi } from "vitest";
+import { describe, expect, expectTypeOf, it, vi } from "vitest";
 import type { WalletSession } from "./types";
 import {
   createMemoryStorageAdapter,
   createSessionStore,
   createWebStorageAdapter,
   isWalletSession,
+  type SessionRefreshResult,
+  type SessionStatus,
   type SessionStorageAdapter,
 } from "./session";
 
@@ -106,6 +108,76 @@ describe("createSessionStore", () => {
     const store = createSessionStore(broken);
     await expect(store.getState().start(session)).rejects.toThrow("quota exceeded");
     expect(store.getState().status).toBe("loading");
+  });
+});
+
+describe("refresh() return shape (type-level)", () => {
+  it("is documented as Promise<SessionRefreshResult>", () => {
+    const store = createSessionStore(createMemoryStorageAdapter());
+    // Type-level: the method resolves to the documented SessionRefreshResult.
+    expectTypeOf(store.getState().refresh).returns.resolves.toEqualTypeOf<SessionRefreshResult>();
+    // …and that shape is exactly `{ session, status }`.
+    expectTypeOf(store.getState().refresh).returns.resolves.toEqualTypeOf<{
+      session: WalletSession | null;
+      status: SessionStatus;
+    }>();
+  });
+
+  it("SessionRefreshResult exposes the documented session and status fields", () => {
+    type Result = SessionRefreshResult;
+    expectTypeOf<Result>().toHaveProperty("session").toEqualTypeOf<WalletSession | null>();
+    expectTypeOf<Result>().toHaveProperty("status").toEqualTypeOf<SessionStatus>();
+  });
+});
+
+describe("createSessionStore refresh()", () => {
+  it("resolves the connected shape when a valid session is persisted", async () => {
+    const storage = createMemoryStorageAdapter();
+    await storage.save(session);
+    const store = createSessionStore(storage);
+    const result = await store.getState().refresh();
+    expect(result).toEqual({ session, status: "connected" });
+    expect(store.getState().status).toBe("connected");
+  });
+
+  it("resolves the disconnected shape when nothing is persisted", async () => {
+    const store = createSessionStore(createMemoryStorageAdapter());
+    const result = await store.getState().refresh();
+    expect(result).toEqual({ session: null, status: "disconnected" });
+    expect(store.getState().status).toBe("disconnected");
+  });
+
+  it("resolves disconnected instead of throwing when storage is unreadable", async () => {
+    const broken: SessionStorageAdapter = {
+      load: vi.fn().mockRejectedValue(new Error("corrupt")),
+      save: vi.fn(),
+      clear: vi.fn(),
+    };
+    const store = createSessionStore(broken);
+    const result = await store.getState().refresh();
+    expect(result).toEqual({ session: null, status: "disconnected" });
+    expect(store.getState().status).toBe("disconnected");
+  });
+
+  it("resolves disconnected for malformed persisted data", async () => {
+    const storage = createMemoryStorageAdapter();
+    await storage.save({ nonsense: true } as unknown as WalletSession);
+    const store = createSessionStore(storage);
+    const result = await store.getState().refresh();
+    expect(result).toEqual({ session: null, status: "disconnected" });
+    expect(store.getState().status).toBe("disconnected");
+  });
+
+  it("re-loads the latest persisted session (e.g. written by another tab)", async () => {
+    const storage = createMemoryStorageAdapter();
+    const store = createSessionStore(storage);
+    await store.getState().start(session);
+    // Persist a fresh session behind the store's back, as another tab would.
+    const fresh = { ...session, accountId: "CACCOUNT456" };
+    await storage.save(fresh);
+    const result = await store.getState().refresh();
+    expect(result).toEqual({ session: fresh, status: "connected" });
+    expect(store.getState().session?.accountId).toBe("CACCOUNT456");
   });
 });
 

--- a/src/session.ts
+++ b/src/session.ts
@@ -14,6 +14,22 @@ export interface SessionStorageAdapter {
 
 export type SessionStatus = "loading" | "connected" | "disconnected";
 
+/**
+ * Return shape of {@link SessionState.refresh}.
+ *
+ * The refresh method resolves to the post-refresh session and status so
+ * consumers can switch on the outcome instead of guessing:
+ *
+ * - `{ session, status: "connected" }` — a valid session was loaded from
+ *   storage;
+ * - `{ session: null, status: "disconnected" }` — nothing usable was
+ *   persisted (empty, malformed, or unreadable storage).
+ */
+export interface SessionRefreshResult {
+  session: WalletSession | null;
+  status: SessionStatus;
+}
+
 export interface SessionState {
   session: WalletSession | null;
   status: SessionStatus;
@@ -25,6 +41,17 @@ export interface SessionState {
   end(): Promise<void>;
   /** Restore a persisted session on startup. Corrupt/unreadable storage means disconnected, never a crash. */
   restore(): Promise<void>;
+  /**
+   * Re-read the persisted session from storage and reflect it in store state.
+   *
+   * Use this to refresh the session after the app regains focus, after another
+   * tab updated it, or whenever the stored session may have changed since
+   * `start`/`restore`. Corrupt or unreadable storage resolves to
+   * `{ session: null, status: "disconnected" }`, never a rejected promise.
+   *
+   * @returns the post-refresh session and status (see {@link SessionRefreshResult}).
+   */
+  refresh(): Promise<SessionRefreshResult>;
 }
 
 export type SessionStore = StoreApi<SessionState>;
@@ -44,42 +71,55 @@ export function isWalletSession(value: unknown): value is WalletSession {
 }
 
 export function createSessionStore(storage: SessionStorageAdapter): SessionStore {
-  return createStore<SessionState>((set, get) => ({
-    session: null,
-    status: "loading",
-
-    async start(session) {
-      await storage.save(session);
-      set({ session, status: "connected" });
-    },
-
-    async touch(now = new Date()) {
-      const { session } = get();
-      if (!session) return;
-      const updated: WalletSession = { ...session, lastActiveAt: now.toISOString() };
-      await storage.save(updated);
-      set({ session: updated });
-    },
-
-    async end() {
-      await storage.clear();
-      set({ session: null, status: "disconnected" });
-    },
-
-    async restore() {
+  return createStore<SessionState>((set, get) => {
+    /** Shared by restore() and refresh(): load, validate, and settle state. */
+    async function loadFromStorage(): Promise<SessionRefreshResult> {
       try {
         const stored = await storage.load();
         if (stored && isWalletSession(stored)) {
           set({ session: stored, status: "connected" });
-        } else {
-          set({ session: null, status: "disconnected" });
+          return { session: stored, status: "connected" };
         }
+        set({ session: null, status: "disconnected" });
+        return { session: null, status: "disconnected" };
       } catch {
         // Unreadable storage must not brick the app on startup.
         set({ session: null, status: "disconnected" });
+        return { session: null, status: "disconnected" };
       }
-    },
-  }));
+    }
+
+    return {
+      session: null,
+      status: "loading",
+
+      async start(session) {
+        await storage.save(session);
+        set({ session, status: "connected" });
+      },
+
+      async touch(now = new Date()) {
+        const { session } = get();
+        if (!session) return;
+        const updated: WalletSession = { ...session, lastActiveAt: now.toISOString() };
+        await storage.save(updated);
+        set({ session: updated });
+      },
+
+      async end() {
+        await storage.clear();
+        set({ session: null, status: "disconnected" });
+      },
+
+      async restore() {
+        await loadFromStorage();
+      },
+
+      async refresh() {
+        return loadFromStorage();
+      },
+    };
+  });
 }
 
 /** Storage-backed adapter for web (pass window.localStorage) or any Storage-like object. */

--- a/website/content/docs/advanced.md
+++ b/website/content/docs/advanced.md
@@ -21,10 +21,39 @@ import {
   `preparePayment(...)` gives you a review object and a `confirm()` you call after
   the user approves. Use this to insert your own review UI between build and sign.
 - **`createSessionStore(adapter)`** — a session store with pluggable storage, for
-  sharing session state across parts of your app.
+  sharing session state across parts of your app. Its `refresh()` method
+  re-reads the persisted session and resolves to a documented
+  `SessionRefreshResult` (`{ session, status }`) — see the
+  [session lifecycle](./how-it-works.md#sessions--reconnect) for where it fits.
 
 The `vellar.connector` and `vellar.payments` getters expose the exact instances the
 facade built, so you can mix the paved road with lower-level calls.
+
+### Session store refresh
+
+`refresh()` re-reads the persisted session from storage and resolves to a
+documented `SessionRefreshResult` — `{ session, status }` — so you can switch on
+the outcome instead of guessing:
+
+```ts
+import { createSessionStore, createWebStorageAdapter } from "vellar-sdk";
+
+const store = createSessionStore(createWebStorageAdapter(localStorage));
+
+// Re-read the persisted session, e.g. when the tab regains focus or after
+// another tab updated it:
+const { session, status } = await store.getState().refresh();
+
+if (status === "connected" && session) {
+  console.log("resumed", session.accountId);
+} else {
+  console.log("no usable session");
+}
+```
+
+`refresh()` never rejects: empty, malformed, or unreadable storage resolves to
+`{ session: null, status: "disconnected" }`. See
+[Sessions & reconnect](./how-it-works.md#sessions--reconnect) for the lifecycle.
 
 ## Subpath exports
 

--- a/website/content/docs/how-it-works.md
+++ b/website/content/docs/how-it-works.md
@@ -56,6 +56,13 @@ passkey's credential id (`keyId`). Persisting the `keyId` lets a returning user
 reconnect without the WebAuthn discovery ceremony — the passkey prompt then only
 appears at signing time.
 
+The session store's `refresh()` method re-reads the persisted session from
+storage and resolves to a documented `{ session, status }` result — use it when
+the tab regains focus or another tab may have updated the session. It never
+rejects; empty, malformed, or unreadable storage resolves to
+`{ session: null, status: "disconnected" }`. See
+[Advanced Usage](./advanced.md#session-store-refresh) for the example.
+
 ## Programmable policies
 
 Because accounts are smart contracts, Vellar wallets can carry on-chain policies


### PR DESCRIPTION
Closes #213

## Summary

The session store's refresh method had no documented return shape, so consumers had to guess what `refresh()` resolves to. This PR adds a `refresh()` method to `SessionState` with a documented `SessionRefreshResult` return type (`{ session, status }`), JSDoc, README example usage, a cross-reference to the session lifecycle in the docs, and type-level tests asserting the documented shape.

## Changes

**`src/session.ts`**
- Added exported `SessionRefreshResult` interface (`session: WalletSession | null; status: SessionStatus`) with JSDoc describing both possible outcomes — `connected` with the loaded session, or `disconnected` with `session: null`.
- Added `refresh(): Promise<SessionRefreshResult>` to `SessionState` with full JSDoc: re-reads the persisted session from storage (e.g. on tab focus regain, or after another tab updated it), reflects it in store state, and **never rejects** — corrupt/unreadable storage resolves to the `disconnected` shape.
- Implemented via a shared `loadFromStorage()` helper so `restore()` and `refresh()` stay behaviorally identical (restore() still returns `Promise<void>`).

**`src/session.test.ts`**
- Type-level tests (vitest `expectTypeOf`) asserting `refresh()` resolves to `Promise<SessionRefreshResult>` and that the shape is exactly `{ session: WalletSession | null; status: SessionStatus }`.
- Runtime tests: connected shape with a persisted session; disconnected shape with empty, malformed, or unreadable storage; and re-loading a session written behind the store's back (e.g. by another tab).

**`README.md`**
- Added a "Session store refresh" example under **Advanced** showing `const { session, status } = await store.getState().refresh();`, linking to the [session lifecycle](https://docs.vellar.xyz/docs/how-it-works#sessions--reconnect).

**`website/content/docs/` (docs.vellar.xyz)**
- `how-it-works.md` — the "Sessions & reconnect" section now cross-references `refresh()` and its return shape.
- `advanced.md` — added a "Session store refresh" section with example usage, linking back to the session lifecycle.

## Verification

- `npm run typecheck` — clean
- `npm test` — 521 tests pass across 30 files, including the new session refresh tests
- `npm run check:docs` — doc snippets typecheck clean
- `npm run build` — clean

## Notes

- Changes are purely additive; no existing behavior or public API was removed or altered.
- Branch created from `dev` and the PR targets `dev`, per CONTRIBUTING.md.