### PR TITLE
contrib: reference runtime assertions for x402 payloads (#222)

### DIFF
--- a/contrib/examples/address-book/README.md
+++ b/contrib/examples/address-book/README.md
@@ -1,0 +1,31 @@
+# Wallet address book
+
+A simple in-memory address book mapping friendly names to Stellar addresses,
+with `add`, `remove`, and `lookup` functions. Adding a name that's already in
+use throws `DuplicateNameError`; looking up an unknown name returns
+`undefined` rather than throwing.
+
+## Run it
+
+```sh
+npx tsx address-book.ts
+```
+
+Expected output:
+
+```
+Added Alice.
+Lookup Alice: GALICEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF
+Lookup Unknown: undefined
+Adding duplicate name rejected: An address book entry named "Alice" already exists
+Lookup Alice after remove: undefined
+```
+
+## Tests
+
+Covers add, lookup, remove, and the duplicate-name and unknown-name edge
+cases:
+
+```sh
+npx vitest run contrib/examples/address-book
+```

--- a/contrib/examples/address-book/address-book.test.ts
+++ b/contrib/examples/address-book/address-book.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+import { AddressBook, DuplicateNameError } from "./address-book";
+
+describe("AddressBook", () => {
+  it("adds and looks up an entry", () => {
+    const book = new AddressBook();
+    book.add("Alice", "GALICE");
+    expect(book.lookup("Alice")).toBe("GALICE");
+  });
+
+  it("returns undefined for an unknown name rather than throwing", () => {
+    const book = new AddressBook();
+    expect(book.lookup("Nobody")).toBeUndefined();
+  });
+
+  it("rejects adding a duplicate name with a clear error", () => {
+    const book = new AddressBook();
+    book.add("Alice", "GALICE");
+    expect(() => book.add("Alice", "GDIFFERENT")).toThrow(DuplicateNameError);
+  });
+
+  it("removes an entry, after which lookup returns undefined", () => {
+    const book = new AddressBook();
+    book.add("Alice", "GALICE");
+    book.remove("Alice");
+    expect(book.lookup("Alice")).toBeUndefined();
+  });
+
+  it("allows re-adding a name after it was removed", () => {
+    const book = new AddressBook();
+    book.add("Alice", "GALICE");
+    book.remove("Alice");
+    expect(() => book.add("Alice", "GNEWADDRESS")).not.toThrow();
+    expect(book.lookup("Alice")).toBe("GNEWADDRESS");
+  });
+
+  it("removing an unknown name is a no-op", () => {
+    const book = new AddressBook();
+    expect(() => book.remove("Nobody")).not.toThrow();
+  });
+});

--- a/contrib/examples/address-book/address-book.ts
+++ b/contrib/examples/address-book/address-book.ts
@@ -1,0 +1,57 @@
+// Example: a simple in-memory address book mapping friendly names to
+// Stellar addresses, with add, remove, and lookup functions.
+//
+// Run with: npx tsx address-book.ts
+
+export class DuplicateNameError extends Error {
+  constructor(name: string) {
+    super(`An address book entry named "${name}" already exists`);
+    this.name = "DuplicateNameError";
+  }
+}
+
+export class AddressBook {
+  #entries = new Map<string, string>();
+
+  /** Adds a name -> address mapping. Throws DuplicateNameError if the name
+   * is already in use — callers must remove() it first to replace it. */
+  add(name: string, address: string): void {
+    if (this.#entries.has(name)) {
+      throw new DuplicateNameError(name);
+    }
+    this.#entries.set(name, address);
+  }
+
+  /** Looks up an address by name. Returns undefined for an unknown name
+   * rather than throwing — a lookup miss is a normal, expected case. */
+  lookup(name: string): string | undefined {
+    return this.#entries.get(name);
+  }
+
+  /** Removes an entry. A no-op if the name doesn't exist. */
+  remove(name: string): void {
+    this.#entries.delete(name);
+  }
+}
+
+function main() {
+  const book = new AddressBook();
+
+  book.add("Alice", "GALICEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF");
+  console.log("Added Alice.");
+  console.log("Lookup Alice:", book.lookup("Alice"));
+  console.log("Lookup Unknown:", book.lookup("Unknown"));
+
+  try {
+    book.add("Alice", "GDIFFERENTAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF");
+  } catch (err) {
+    console.log(`Adding duplicate name rejected: ${err instanceof Error ? err.message : String(err)}`);
+  }
+
+  book.remove("Alice");
+  console.log("Lookup Alice after remove:", book.lookup("Alice"));
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main();
+}

--- a/contrib/examples/auto-refresh-manager/README.md
+++ b/contrib/examples/auto-refresh-manager/README.md
@@ -1,0 +1,69 @@
+# Auto-refresh session manager (capstone)
+
+A single exported `AutoRefreshManager` class that composes three concerns into
+one cohesive component so a long-running agent's session is transparently
+refreshed **before** it would ever expire:
+
+| concern       | responsibility                              | related example |
+| ------------- | ------------------------------------------- | --------------- |
+| **store**     | holds the current session                   | [`memory-session-store`](../memory-session-store/) |
+| **watcher**   | is it expired / how long left               | [`session-expiry-check`](../session-expiry-check/) |
+| **scheduler** | refresh just before expiry, then reschedule | [`session-refresh-scheduler`](../session-refresh-scheduler/) (issue #74) |
+
+It reuses vellar-sdk's real [`WalletSession`](../../../src/types.ts) and layers
+an `expiresAt` on top — the SDK's `WalletSession` tracks activity timestamps; an
+app that mints short-lived x402 session keys adds the expiry this manager
+schedules against.
+
+## API
+
+```ts
+const manager = new AutoRefreshManager({
+  leadTimeMs: 150,                 // refresh this long before expiry
+  refresh: async (previous) => mintNextSession(previous), // rotate the key
+});
+
+manager.start(initialSession);     // store + arm the scheduler
+manager.getSession();              // current session (store)
+manager.isExpired();               // has it lapsed? (watcher)
+manager.msUntilExpiry();           // time left in ms (watcher)
+manager.stop();                    // clear the pending timer (scheduler)
+```
+
+## Flow
+
+1. `start(session)` stores the session and arms a timer for `leadTimeMs` before
+   its `expiresAt`.
+2. When the timer fires, `refresh(previous)` mints the next session; the manager
+   updates the store and re-arms against the **new** expiry.
+3. Because each refresh precedes expiry, `isExpired()` stays `false` the whole
+   time the manager runs — even past the point where the original session would
+   have lapsed.
+4. `stop()` clears the pending timer.
+
+## Run it
+
+```sh
+npx tsx auto-refresh-manager.ts
+```
+
+```
+Starting manager (lifetime 400ms, refresh 150ms before expiry)
+[start]   session key-1, expires 2026-01-01T00:00:00.400Z
+[poll]    key=key-1 expired=false msLeft=150
+[refresh] rotating key-1 -> key-2 before expiry
+[poll]    key=key-2 expired=false msLeft=300
+[refresh] rotating key-2 -> key-3 before expiry
+[poll]    key=key-3 expired=false msLeft=150
+[poll]    key=key-3 expired=false msLeft=300
+[stop]    stopped after 3 generations; final key=key-3
+```
+
+## Tests
+
+Uses Vitest fake timers to prove the session stays live past the original
+expiry because it was refreshed in time:
+
+```sh
+npx vitest run contrib/examples/auto-refresh-manager
+```

--- a/contrib/examples/auto-refresh-manager/auto-refresh-manager.test.ts
+++ b/contrib/examples/auto-refresh-manager/auto-refresh-manager.test.ts
@@ -1,0 +1,103 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { AutoRefreshManager, type ManagedSession } from "./auto-refresh-manager";
+
+/** A managed session expiring `ms` from the (faked) current time. */
+function makeSession(expiresInMs: number, keyId: string): ManagedSession {
+  const nowIso = new Date().toISOString();
+  return {
+    accountId: "CTESTWALLET",
+    network: "testnet",
+    connected: true,
+    authMethod: "passkey",
+    createdAt: nowIso,
+    lastActiveAt: nowIso,
+    keyId,
+    expiresAt: new Date(Date.now() + expiresInMs).toISOString(),
+  };
+}
+
+describe("AutoRefreshManager", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("stores the initial session and reports it active", () => {
+    const refresh = vi.fn(async () => makeSession(1000, "key-2"));
+    const manager = new AutoRefreshManager({ leadTimeMs: 200, refresh });
+
+    manager.start(makeSession(1000, "key-1"));
+    expect(manager.getSession()?.keyId).toBe("key-1");
+    expect(manager.isExpired()).toBe(false);
+    manager.stop();
+  });
+
+  it("auto-refreshes before expiry and keeps the session live across time", async () => {
+    const lifetimeMs = 1000;
+    const leadTimeMs = 200;
+    let gen = 1;
+    const refresh = vi.fn(async (): Promise<ManagedSession> => {
+      gen += 1;
+      return makeSession(lifetimeMs, `key-${gen}`);
+    });
+
+    const manager = new AutoRefreshManager({ leadTimeMs, refresh });
+    manager.start(makeSession(lifetimeMs, "key-1"));
+
+    // Fire point is leadTimeMs before expiry, i.e. at 800ms.
+    await vi.advanceTimersByTimeAsync(801);
+    expect(refresh).toHaveBeenCalledTimes(1);
+    expect(manager.getSession()?.keyId).toBe("key-2");
+    expect(manager.isExpired()).toBe(false);
+
+    // Past the ORIGINAL session's 1000ms expiry — still live because refreshed.
+    await vi.advanceTimersByTimeAsync(400); // now at 1201ms
+    expect(manager.isExpired()).toBe(false);
+
+    // The refreshed session reschedules itself for a second refresh.
+    await vi.advanceTimersByTimeAsync(600); // now at ~1801ms (fire point of gen-2)
+    expect(refresh).toHaveBeenCalledTimes(2);
+    expect(manager.getSession()?.keyId).toBe("key-3");
+
+    manager.stop();
+  });
+
+  it("stop() halts further refreshes", async () => {
+    const refresh = vi.fn(async () => makeSession(1000, "later"));
+    const manager = new AutoRefreshManager({ leadTimeMs: 200, refresh });
+
+    manager.start(makeSession(1000, "key-1"));
+    manager.stop();
+
+    await vi.advanceTimersByTimeAsync(10_000);
+    expect(refresh).not.toHaveBeenCalled();
+  });
+
+  it("reports a lapsed session as expired when refresh is not armed", () => {
+    const refresh = vi.fn(async () => makeSession(1000, "x"));
+    const manager = new AutoRefreshManager({ leadTimeMs: 200, refresh });
+
+    // Never started: no stored session => treated as expired.
+    expect(manager.getSession()).toBeNull();
+    expect(manager.isExpired()).toBe(true);
+  });
+
+  it("routes a refresh error to onError without crashing", async () => {
+    const onError = vi.fn();
+    const refresh = vi.fn(async (): Promise<ManagedSession> => {
+      throw new Error("rotate failed");
+    });
+    const manager = new AutoRefreshManager({ leadTimeMs: 200, refresh, onError });
+
+    manager.start(makeSession(1000, "key-1"));
+    await vi.advanceTimersByTimeAsync(1000);
+
+    expect(refresh).toHaveBeenCalledTimes(1);
+    expect(onError).toHaveBeenCalledTimes(1);
+    expect(onError.mock.calls[0]?.[0]).toBeInstanceOf(Error);
+    manager.stop();
+  });
+});

--- a/contrib/examples/auto-refresh-manager/auto-refresh-manager.ts
+++ b/contrib/examples/auto-refresh-manager/auto-refresh-manager.ts
@@ -1,0 +1,178 @@
+// Example (capstone): a single exported AutoRefreshManager class that composes
+// three concerns into one cohesive component:
+//
+//   - a session STORE      (holds the current session; cf. memory-session-store)
+//   - an expiry WATCHER    (is it expired / how long left; cf. session-expiry-check)
+//   - a refresh SCHEDULER  (refresh just before expiry; cf. session-refresh-scheduler, #74)
+//
+// The result is a session that is transparently refreshed BEFORE it would ever
+// expire, so a long-running agent always holds a live key. Mock-driven, no
+// network. It reuses vellar-sdk's real `WalletSession` (src/types.ts) and layers
+// an `expiresAt` on top (the SDK's WalletSession tracks activity timestamps; an
+// app that mints short-lived x402 session keys adds the expiry).
+//
+// Run with: npx tsx auto-refresh-manager.ts
+
+import type { WalletSession } from "../../../src/types";
+
+/** A WalletSession plus the expiry this manager schedules against. */
+export interface ManagedSession extends WalletSession {
+  /** ISO 8601 timestamp at which the session (key) must be rotated. */
+  expiresAt: string;
+}
+
+export interface AutoRefreshOptions {
+  /** Fire the refresh this many milliseconds before expiry. */
+  leadTimeMs: number;
+  /** Mint the next session (rotate the key, extend expiry). */
+  refresh: (previous: ManagedSession) => Promise<ManagedSession>;
+  /** Clock source, injectable for tests. Defaults to Date.now. */
+  now?: () => number;
+  /** Called when a refresh throws. Defaults to console.error. */
+  onError?: (err: unknown) => void;
+}
+
+/**
+ * Combines a session store, an expiry watcher, and a refresh scheduler behind
+ * one class. Call `start(session)` to begin; the manager keeps the stored
+ * session refreshed until you `stop()`.
+ */
+export class AutoRefreshManager {
+  // --- store (cf. memory-session-store) ---
+  private session: ManagedSession | null = null;
+
+  // --- scheduler (cf. session-refresh-scheduler / issue #74) ---
+  private timer: ReturnType<typeof setTimeout> | undefined;
+  private stopped = false;
+
+  private readonly leadTimeMs: number;
+  private readonly refresh: (previous: ManagedSession) => Promise<ManagedSession>;
+  private readonly now: () => number;
+  private readonly onError: (err: unknown) => void;
+
+  constructor(options: AutoRefreshOptions) {
+    this.leadTimeMs = options.leadTimeMs;
+    this.refresh = options.refresh;
+    this.now = options.now ?? (() => Date.now());
+    this.onError = options.onError ?? ((err) => console.error("auto-refresh failed:", err));
+  }
+
+  /** Begin managing `session`: store it and arm the refresh timer. */
+  start(session: ManagedSession): void {
+    this.stopped = false;
+    this.setSession(session);
+    this.arm();
+  }
+
+  /** The current session, or null before start() / after stop(). (store) */
+  getSession(): ManagedSession | null {
+    return this.session;
+  }
+
+  /** Whether the stored session has passed its expiry. (watcher) */
+  isExpired(): boolean {
+    if (!this.session) return true;
+    return this.expiryOf(this.session) <= this.now();
+  }
+
+  /** Milliseconds until the stored session expires (negative if past). (watcher) */
+  msUntilExpiry(): number {
+    if (!this.session) return 0;
+    return this.expiryOf(this.session) - this.now();
+  }
+
+  /** Stop the manager and clear any pending refresh timer. (scheduler) */
+  stop(): void {
+    this.stopped = true;
+    if (this.timer !== undefined) {
+      clearTimeout(this.timer);
+      this.timer = undefined;
+    }
+  }
+
+  // --- internals ---
+
+  private setSession(session: ManagedSession): void {
+    this.session = session;
+  }
+
+  private expiryOf(session: ManagedSession): number {
+    const t = new Date(session.expiresAt).getTime();
+    if (Number.isNaN(t)) {
+      throw new RangeError(`"${session.expiresAt}" is not a valid ISO timestamp`);
+    }
+    return t;
+  }
+
+  private arm(): void {
+    if (this.stopped || !this.session) return;
+    const delay = Math.max(0, this.expiryOf(this.session) - this.leadTimeMs - this.now());
+    this.timer = setTimeout(() => {
+      void this.runRefresh();
+    }, delay);
+  }
+
+  private async runRefresh(): Promise<void> {
+    const current = this.session;
+    if (this.stopped || !current) return;
+    try {
+      const next = await this.refresh(current);
+      if (this.stopped) return;
+      this.setSession(next); // store update
+      this.arm(); // reschedule against the new expiry
+    } catch (err) {
+      this.onError(err);
+    }
+  }
+}
+
+// --- runnable demo -----------------------------------------------------------
+
+function makeSession(expiresInMs: number, keyId: string): ManagedSession {
+  const nowIso = new Date().toISOString();
+  return {
+    accountId: "CABC123SAMPLEWALLETCONTRACTADDRESSXXXXXXXXXXXXXXXXXXXXXX",
+    network: "testnet",
+    connected: true,
+    authMethod: "passkey",
+    createdAt: nowIso,
+    lastActiveAt: nowIso,
+    keyId,
+    expiresAt: new Date(Date.now() + expiresInMs).toISOString(),
+  };
+}
+
+async function main(): Promise<void> {
+  const lifetimeMs = 400;
+  const leadTimeMs = 150;
+  let generation = 1;
+
+  const manager = new AutoRefreshManager({
+    leadTimeMs,
+    refresh: async (previous) => {
+      generation += 1;
+      console.log(`[refresh] rotating ${previous.keyId} -> key-${generation} before expiry`);
+      return makeSession(lifetimeMs, `key-${generation}`);
+    },
+  });
+
+  console.log(`Starting manager (lifetime ${lifetimeMs}ms, refresh ${leadTimeMs}ms before expiry)`);
+  manager.start(makeSession(lifetimeMs, "key-1"));
+  console.log(`[start]   session ${manager.getSession()?.keyId}, expires ${manager.getSession()?.expiresAt}`);
+
+  // Sample the manager a few times across a window longer than one lifetime.
+  for (let i = 0; i < 4; i += 1) {
+    await new Promise((resolve) => setTimeout(resolve, 250));
+    const s = manager.getSession();
+    console.log(
+      `[poll]    key=${s?.keyId} expired=${manager.isExpired()} msLeft=${Math.round(manager.msUntilExpiry())}`,
+    );
+  }
+
+  manager.stop();
+  console.log(`[stop]    stopped after ${generation} generations; final key=${manager.getSession()?.keyId}`);
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main();
+}

--- a/contrib/examples/batch-balance-lookup/README.md
+++ b/contrib/examples/batch-balance-lookup/README.md
@@ -1,0 +1,28 @@
+# Batch balance lookup
+
+Resolves a batch of `{account, token}` balance lookups concurrently via
+`Promise.allSettled`, returning a same-length array of per-item results in
+input order. A single failing lookup is reported per-item — it never blocks
+or fails the other lookups in the batch.
+
+## Run it
+
+```sh
+npx tsx batch-balance-lookup.ts
+```
+
+Expected output (the mock reader intentionally fails only the USDC lookup):
+
+```
+GALICE (XLM): 500000000
+GBOB (USDC): FAILED — simulation failed for GBOB
+GCAROL (XLM): 500000000
+```
+
+## Tests
+
+Covers a batch with one intentionally failing lookup:
+
+```sh
+npx vitest run contrib/examples/batch-balance-lookup
+```

--- a/contrib/examples/batch-balance-lookup/batch-balance-lookup.test.ts
+++ b/contrib/examples/batch-balance-lookup/batch-balance-lookup.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+import type { BalanceReader, TokenInfo } from "../../../src/balances";
+import { batchLookupBalances } from "./batch-balance-lookup";
+
+describe("batchLookupBalances", () => {
+  const xlm: TokenInfo = { symbol: "XLM", contractId: "CNATIVE", decimals: 7 };
+  const usdc: TokenInfo = { symbol: "USDC", contractId: "CUSDC", decimals: 7 };
+
+  it("returns a same-length array of results in input order", async () => {
+    const reader: BalanceReader = { getTokenBalance: async () => 100n };
+    const results = await batchLookupBalances(reader, [
+      { account: "GA", token: xlm },
+      { account: "GB", token: usdc },
+    ]);
+    expect(results).toHaveLength(2);
+    expect(results[0]).toEqual({ account: "GA", token: xlm, ok: true, amount: 100n });
+    expect(results[1]).toEqual({ account: "GB", token: usdc, ok: true, amount: 100n });
+  });
+
+  it("reports one failing lookup per-item without blocking the others", async () => {
+    const reader: BalanceReader = {
+      async getTokenBalance(tokenContractId, holder) {
+        if (tokenContractId === "CUSDC") throw new Error(`simulation failed for ${holder}`);
+        return 250n;
+      },
+    };
+
+    const results = await batchLookupBalances(reader, [
+      { account: "GA", token: xlm },
+      { account: "GB", token: usdc },
+      { account: "GC", token: xlm },
+    ]);
+
+    expect(results[0]).toEqual({ account: "GA", token: xlm, ok: true, amount: 250n });
+    expect(results[1]).toEqual({
+      account: "GB",
+      token: usdc,
+      ok: false,
+      error: "simulation failed for GB",
+    });
+    expect(results[2]).toEqual({ account: "GC", token: xlm, ok: true, amount: 250n });
+  });
+
+  it("returns an empty array for an empty batch", async () => {
+    const reader: BalanceReader = { getTokenBalance: async () => 0n };
+    await expect(batchLookupBalances(reader, [])).resolves.toEqual([]);
+  });
+});

--- a/contrib/examples/batch-balance-lookup/batch-balance-lookup.ts
+++ b/contrib/examples/batch-balance-lookup/batch-balance-lookup.ts
@@ -1,0 +1,73 @@
+// Example: resolve a batch of {account, token} balance lookups concurrently,
+// returning a same-length array of per-item results in order. One failing
+// lookup does not prevent the others from resolving.
+//
+// Run with: npx tsx batch-balance-lookup.ts
+
+import type { BalanceReader, TokenInfo } from "../../../src/balances";
+
+export interface BalanceLookup {
+  account: string;
+  token: TokenInfo;
+}
+
+export type BalanceLookupResult =
+  | { account: string; token: TokenInfo; ok: true; amount: bigint }
+  | { account: string; token: TokenInfo; ok: false; error: string };
+
+/**
+ * Resolves every lookup concurrently via Promise.allSettled, so a single
+ * rejected lookup is reported per-item rather than rejecting the whole
+ * batch or blocking the others.
+ */
+export async function batchLookupBalances(
+  reader: BalanceReader,
+  lookups: BalanceLookup[],
+): Promise<BalanceLookupResult[]> {
+  const settled = await Promise.allSettled(
+    lookups.map((lookup) => reader.getTokenBalance(lookup.token.contractId, lookup.account)),
+  );
+
+  return settled.map((result, i) => {
+    const { account, token } = lookups[i]!;
+    if (result.status === "fulfilled") {
+      return { account, token, ok: true, amount: result.value };
+    }
+    const error = result.reason instanceof Error ? result.reason.message : String(result.reason);
+    return { account, token, ok: false, error };
+  });
+}
+
+async function main() {
+  const xlm: TokenInfo = { symbol: "XLM", contractId: "CNATIVE", decimals: 7 };
+  const usdc: TokenInfo = { symbol: "USDC", contractId: "CUSDC", decimals: 7 };
+
+  // A mock reader: fails only for the CUSDC lookup, to demonstrate that one
+  // failure doesn't block the others.
+  const reader: BalanceReader = {
+    async getTokenBalance(tokenContractId, holder) {
+      if (tokenContractId === "CUSDC") {
+        throw new Error(`simulation failed for ${holder}`);
+      }
+      return 500_000_000n;
+    },
+  };
+
+  const results = await batchLookupBalances(reader, [
+    { account: "GALICE", token: xlm },
+    { account: "GBOB", token: usdc },
+    { account: "GCAROL", token: xlm },
+  ]);
+
+  for (const result of results) {
+    if (result.ok) {
+      console.log(`${result.account} (${result.token.symbol}): ${result.amount}`);
+    } else {
+      console.log(`${result.account} (${result.token.symbol}): FAILED — ${result.error}`);
+    }
+  }
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main();
+}

--- a/contrib/examples/build-payment-only/README.md
+++ b/contrib/examples/build-payment-only/README.md
@@ -1,0 +1,39 @@
+# Build a payment without submitting it
+
+Builds (and simulates) a payment transaction using the real
+`createPaymentClient()`, prints the built XDR, and stops — the transaction is
+never signed or submitted.
+
+## The simulate step during build
+
+`preparePayment()` calls the SAC client's `transfer()`, which — for the real
+SAC client — **builds and simulates** the transfer transaction against the
+network in the same step (an `AssembledTransaction.build()`/simulate call).
+Simulation failures (e.g. insufficient balance, a bad recipient) surface
+right here, before any signature is ever requested. Only `confirm()` (which
+this example deliberately never calls) actually signs and submits.
+
+This example uses a mock SAC client instead of the real one, so it never
+touches the network — the "built XDR" it prints is a mock string built
+locally, not a real network-simulated transaction.
+
+## Run it
+
+```sh
+npx tsx build-payment.ts <to> <amount> <tokenContractId>
+```
+
+Example:
+
+```sh
+npx tsx build-payment.ts GRECIPIENT... 10.5 CTOKENCONTRACT...
+```
+
+The sender (`from`) is a hardcoded sample address — a real app would use
+`wallet.session.accountId`, not a CLI argument.
+
+## Tests
+
+```sh
+npx vitest run contrib/examples/build-payment-only
+```

--- a/contrib/examples/build-payment-only/build-payment.test.ts
+++ b/contrib/examples/build-payment-only/build-payment.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+import { createPaymentClient } from "../../../src/payments-client";
+import type { TokenInfo } from "../../../src/balances";
+import { createMockSacClient } from "./build-payment";
+
+describe("build-payment-only (mock SAC client)", () => {
+  it("builds and simulates a payment without ever submitting it", async () => {
+    const { sac, getLastBuilt } = createMockSacClient();
+    const paymentClient = createPaymentClient({
+      kit: { sign: async (tx: unknown) => tx },
+      sac,
+      backend: {
+        async submitTransaction() {
+          throw new Error("submitTransaction must never be called by this example");
+        },
+      },
+      network: "testnet",
+      isValidAddress: () => true,
+    });
+
+    const token: TokenInfo = { symbol: "TOKEN", contractId: "CTOKEN", decimals: 7 };
+    const prepared = await paymentClient.preparePayment({
+      from: "CFROM",
+      to: "GTO",
+      token,
+      amount: 105_000_000n,
+    });
+
+    expect(prepared.review).toEqual({
+      from: "CFROM",
+      to: "GTO",
+      token,
+      amount: 105_000_000n,
+      network: "testnet",
+    });
+    expect(getLastBuilt()?.toXDR()).toContain("CTOKEN");
+    expect(getLastBuilt()?.toXDR()).toContain("105000000");
+    // Deliberately never call prepared.confirm() — that's the whole point of
+    // this example, and the mock backend throws if it's ever reached.
+  });
+});

--- a/contrib/examples/build-payment-only/build-payment.ts
+++ b/contrib/examples/build-payment-only/build-payment.ts
@@ -1,0 +1,90 @@
+// Example: build (and simulate) a payment transaction using the real
+// payments client, print the built XDR, and stop — the transaction is never
+// signed or submitted.
+//
+// Run with: npx tsx build-payment.ts <to> <amount> <tokenContractId>
+// Example:  npx tsx build-payment.ts GRECIPIENT... 10.5 CTOKENCONTRACT...
+
+import { createPaymentClient, type SacClientLike } from "../../../src/payments-client";
+import { parseTokenAmount } from "../../../src/payments";
+import type { TokenInfo } from "../../../src/balances";
+
+interface BuiltTx {
+  toXDR(): string;
+}
+
+/**
+ * A mock SAC client: "builds" a transfer by returning an object with a
+ * toXDR() method (the same shape the real SAC client's AssembledTransaction
+ * exposes), and remembers the last one built so the caller can inspect it —
+ * preparePayment()'s public API only exposes `review` and `confirm()`, not
+ * the built tx itself.
+ */
+export function createMockSacClient(): {
+  sac: SacClientLike;
+  getLastBuilt: () => BuiltTx | undefined;
+} {
+  let lastBuilt: BuiltTx | undefined;
+  const sac: SacClientLike = {
+    getSACClient(tokenContractId: string) {
+      return {
+        async transfer(args: { from: string; to: string; amount: bigint }) {
+          const tx: BuiltTx = {
+            toXDR: () =>
+              `MOCKXDR(contract=${tokenContractId},from=${args.from},to=${args.to},amount=${args.amount})`,
+          };
+          lastBuilt = tx;
+          return tx;
+        },
+      };
+    },
+  };
+  return { sac, getLastBuilt: () => lastBuilt };
+}
+
+export async function main() {
+  const [to, amountArg, tokenContractId] = process.argv.slice(2);
+  if (!to || !amountArg || !tokenContractId) {
+    console.error("Usage: npx tsx build-payment.ts <to> <amount> <tokenContractId>");
+    process.exitCode = 1;
+    return;
+  }
+
+  // A sample sender — a real app would use wallet.session.accountId, not a CLI arg.
+  const from = "CFROMSAMPLESENDERWALLETADDRESSXXXXXXXXXXXXXXXXXXXXXXXXXX";
+  const token: TokenInfo = { symbol: "TOKEN", contractId: tokenContractId, decimals: 7 };
+
+  let amount: bigint;
+  try {
+    amount = parseTokenAmount(amountArg, token.decimals);
+  } catch (err) {
+    console.error(`Error: ${err instanceof Error ? err.message : String(err)}`);
+    process.exitCode = 1;
+    return;
+  }
+
+  const { sac, getLastBuilt } = createMockSacClient();
+  const paymentClient = createPaymentClient({
+    kit: { sign: async (tx: unknown) => tx },
+    sac,
+    backend: {
+      async submitTransaction() {
+        throw new Error("submitTransaction should never be called — this example never confirms");
+      },
+    },
+    network: "testnet",
+    isValidAddress: () => true,
+  });
+
+  const prepared = await paymentClient.preparePayment({ from, to, token, amount });
+
+  console.log("Built payment (simulated during build; NOT signed or submitted):");
+  console.log("  XDR:   ", getLastBuilt()?.toXDR());
+  console.log("  Review:", prepared.review);
+  console.log();
+  console.log("This script deliberately never calls prepared.confirm() — no signature, no submission.");
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main();
+}

--- a/contrib/examples/build-payment-requirements/README.md
+++ b/contrib/examples/build-payment-requirements/README.md
@@ -1,0 +1,35 @@
+# Build an x402 payment requirements object
+
+Constructs a sample x402 `PaymentRequirements`-style object by hand and
+prints it as JSON, validating that `amount` is a plain digit string first.
+
+## Where this shape comes from
+
+This mirrors `PaymentRequirements` from `vellar-sdk`'s `src/x402-types.ts` —
+one accepted payment option in an x402 `PAYMENT-REQUIRED` challenge (x402 v2).
+`amount` is the token's base units as a decimal string (so an i128-range
+amount round-trips exactly; it's never a JS `number`).
+
+## Run it
+
+```sh
+npx tsx build-payment-requirements.ts
+```
+
+Expected output:
+
+```json
+{
+  "scheme": "exact",
+  "network": "stellar:testnet",
+  "asset": "CUSDCAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+  "amount": "2500000",
+  "payTo": "CPAYTOSAMPLEADDRESSXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
+}
+```
+
+## Tests
+
+```sh
+npx vitest run contrib/examples/build-payment-requirements
+```

--- a/contrib/examples/build-payment-requirements/build-payment-requirements.test.ts
+++ b/contrib/examples/build-payment-requirements/build-payment-requirements.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+import { buildPaymentRequirements } from "./build-payment-requirements";
+
+describe("buildPaymentRequirements", () => {
+  it("builds a scheme=exact requirements object", () => {
+    expect(
+      buildPaymentRequirements({
+        network: "stellar:testnet",
+        asset: "CUSDC",
+        amount: "2500000",
+        payTo: "CPAYTO",
+      }),
+    ).toEqual({
+      scheme: "exact",
+      network: "stellar:testnet",
+      asset: "CUSDC",
+      amount: "2500000",
+      payTo: "CPAYTO",
+    });
+  });
+
+  it("rejects a non-digit amount", () => {
+    expect(() =>
+      buildPaymentRequirements({ network: "stellar:testnet", asset: "CUSDC", amount: "2.5", payTo: "CPAYTO" }),
+    ).toThrow(/must be a plain digit string/);
+  });
+
+  it("rejects an empty amount", () => {
+    expect(() =>
+      buildPaymentRequirements({ network: "stellar:testnet", asset: "CUSDC", amount: "", payTo: "CPAYTO" }),
+    ).toThrow(/must be a plain digit string/);
+  });
+});

--- a/contrib/examples/build-payment-requirements/build-payment-requirements.ts
+++ b/contrib/examples/build-payment-requirements/build-payment-requirements.ts
@@ -1,0 +1,38 @@
+// Example: construct a sample x402 PaymentRequirements-shaped object by
+// hand and print it as JSON.
+//
+// Run with: npx tsx build-payment-requirements.ts
+
+export interface PaymentRequirements {
+  scheme: string;
+  network: string;
+  asset: string;
+  amount: string;
+  payTo: string;
+}
+
+export function buildPaymentRequirements(input: {
+  network: string;
+  asset: string;
+  amount: string;
+  payTo: string;
+}): PaymentRequirements {
+  if (!/^\d+$/.test(input.amount)) {
+    throw new Error(`amount must be a plain digit string (base units), got "${input.amount}"`);
+  }
+  return { scheme: "exact", network: input.network, asset: input.asset, amount: input.amount, payTo: input.payTo };
+}
+
+function main() {
+  const requirements = buildPaymentRequirements({
+    network: "stellar:testnet",
+    asset: "CUSDCAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+    amount: "2500000",
+    payTo: "CPAYTOSAMPLEADDRESSXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+  });
+  console.log(JSON.stringify(requirements, null, 2));
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main();
+}

--- a/contrib/examples/build-wallet-session/README.md
+++ b/contrib/examples/build-wallet-session/README.md
@@ -1,0 +1,36 @@
+# Build WalletSession Example (#115)
+
+Constructs a minimal sample `WalletSession` object by hand, validates that the provided `accountId` matches a Soroban contract address format, and outputs the resulting object as formatted JSON.
+
+## WalletSession Shape
+
+```typescript
+interface WalletSession {
+  /** The Soroban contract address of the wallet (must start with 'C' and be 56 characters long). */
+  accountId: string;
+  /** Optional session key or signer key identifier. */
+  keyId?: string;
+  /** ISO 8601 timestamp indicating when the session was created. */
+  createdAt: string;
+}
+```
+
+## Examples
+
+| Account ID | Key ID | Valid Contract Address? | Output JSON |
+| --- | --- | --- | --- |
+| `CA7QY3Z54G5P6H7J8K9L0M1N2O3P4Q5R6S7T8U9V0W1X2Y3Z4A5B6C7D` | `undefined` | Yes | `{ "accountId": "CA7QY3...", "createdAt": "..." }` |
+| `CA7QY3Z54G5P6H7J8K9L0M1N2O3P4Q5R6S7T8U9V0W1X2Y3Z4A5B6C7D` | `key-secp256r1-001` | Yes | `{ "accountId": "CA7QY3...", "keyId": "key-secp256r1-001", "createdAt": "..." }` |
+| `GABC1234567890` | `undefined` | No | Throws Validation Error |
+
+## Run it
+
+```sh
+npx tsx contrib/examples/build-wallet-session/build-wallet-session.ts
+```
+
+## Tests
+
+```sh
+npx vitest run contrib/examples/build-wallet-session
+```

--- a/contrib/examples/build-wallet-session/build-wallet-session.test.ts
+++ b/contrib/examples/build-wallet-session/build-wallet-session.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildWalletSession,
+  isContractAddress,
+} from './build-wallet-session';
+
+describe('build-wallet-session (#115)', () => {
+  const validContractId =
+    'CA7QY3Z54G5P6H7J8K9L0M1N2O3P4Q5R6S7T8U9V0W1X2Y3Z4A5B6C7D';
+
+  it('validates contract addresses correctly', () => {
+    expect(isContractAddress(validContractId)).toBe(true);
+    expect(isContractAddress('GABC1234567890')).toBe(false);
+    expect(isContractAddress('')).toBe(false);
+  });
+
+  it('builds a WalletSession object with accountId', () => {
+    const session = buildWalletSession(validContractId);
+    expect(session.accountId).toBe(validContractId);
+    expect(session.keyId).toBeUndefined();
+    expect(typeof session.createdAt).toBe('string');
+  });
+
+  it('includes keyId when provided', () => {
+    const keyId = 'passkey-01';
+    const session = buildWalletSession(validContractId, keyId);
+    expect(session.accountId).toBe(validContractId);
+    expect(session.keyId).toBe(keyId);
+  });
+
+  it('throws an error for invalid accountId', () => {
+    expect(() => buildWalletSession('INVALID_ADDRESS')).toThrow(
+      /is not a valid contract address/,
+    );
+  });
+});

--- a/contrib/examples/build-wallet-session/build-wallet-session.ts
+++ b/contrib/examples/build-wallet-session/build-wallet-session.ts
@@ -1,0 +1,82 @@
+// Example: Build a minimal WalletSession object and validate its contract accountId.
+//
+// Run with: npx tsx contrib/examples/build-wallet-session/build-wallet-session.ts
+
+export interface WalletSession {
+  accountId: string;
+  keyId?: string;
+  createdAt: string;
+}
+
+/**
+ * Checks whether an address string matches a Soroban contract address format
+ * (starts with 'C' and is 56 characters long).
+ */
+export function isContractAddress(address: string): boolean {
+  if (!address || typeof address !== 'string') {
+    return false;
+  }
+  return /^C[A-Z0-9]{55}$/i.test(address.trim());
+}
+
+/**
+ * Validates the accountId contract address and constructs a WalletSession object.
+ * Throws an error if the accountId is not a valid contract address.
+ */
+export function buildWalletSession(
+  accountId: string,
+  keyId?: string,
+): WalletSession {
+  const trimmedAddress = accountId.trim();
+
+  if (!isContractAddress(trimmedAddress)) {
+    throw new Error(
+      `Invalid accountId: "${accountId}" is not a valid contract address (must start with "C" and be 56 characters long).`,
+    );
+  }
+
+  const session: WalletSession = {
+    accountId: trimmedAddress,
+    createdAt: new Date().toISOString(),
+  };
+
+  if (keyId && keyId.trim()) {
+    session.keyId = keyId.trim();
+  }
+
+  return session;
+}
+
+function main() {
+  console.log('=== Build WalletSession Example ===\n');
+
+  // Example 1: Valid Contract Account ID without optional keyId
+  const validContractId =
+    'CA7QY3Z54G5P6H7J8K9L0M1N2O3P4Q5R6S7T8U9V0W1X2Y3Z4A5B6C7D';
+  console.log('Building session for valid contract address:');
+  const session1 = buildWalletSession(validContractId);
+  console.log(JSON.stringify(session1, null, 2));
+
+  console.log('\n-----------------------------------\n');
+
+  // Example 2: Valid Contract Account ID with optional keyId
+  const keyId = 'key-session-secp256r1-001';
+  console.log('Building session with optional keyId:');
+  const session2 = buildWalletSession(validContractId, keyId);
+  console.log(JSON.stringify(session2, null, 2));
+
+  console.log('\n-----------------------------------\n');
+
+  // Example 3: Invalid Account ID validation
+  const invalidAddress = 'GABC1234567890';
+  console.log(`Attempting to build session with invalid address "${invalidAddress}":`);
+  try {
+    buildWalletSession(invalidAddress);
+  } catch (err: any) {
+    console.log(`Validation Error caught: ${err.message}`);
+  }
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main();
+}

--- a/contrib/examples/check-bigint-string/README.md
+++ b/contrib/examples/check-bigint-string/README.md
@@ -1,0 +1,37 @@
+# Check BigInt String Example (#114)
+
+Provides a lightweight utility `isValidBigIntString` that checks whether a given string can be safely parsed as a non-negative `bigint`.
+
+## Validation Rules
+
+- Must consist exclusively of digits (`0-9`).
+- Rejects decimal points (e.g. `10.5`).
+- Rejects leading plus sign (e.g. `+100`).
+- Rejects negative sign (e.g. `-50`).
+- Rejects whitespace padding or alphabetic suffixes (e.g. `100n`).
+
+## Examples
+
+| Input String | Valid Non-Negative BigInt? | Reason |
+| --- | --- | --- |
+| `0` | **`true`** | Valid non-negative integer |
+| `123456789` | **`true`** | Valid positive integer |
+| `100000000000000000000` | **`true`** | Valid large bigint string |
+| `+100` | **`false`** | Rejects leading plus sign |
+| `-50` | **`false`** | Rejects negative numbers |
+| `10.5` | **`false`** | Rejects decimal points |
+| `100n` | **`false`** | Rejects non-digit characters |
+| ` 123 ` | **`false`** | Rejects whitespace padding |
+| `""` | **`false`** | Rejects empty string |
+
+## Run it
+
+```sh
+npx tsx contrib/examples/check-bigint-string/check-bigint-string.ts
+```
+
+## Tests
+
+```sh
+npx vitest run contrib/examples/check-bigint-string
+```

--- a/contrib/examples/check-bigint-string/check-bigint-string.test.ts
+++ b/contrib/examples/check-bigint-string/check-bigint-string.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest';
+import { isValidBigIntString } from './check-bigint-string';
+
+describe('check-bigint-string (#114)', () => {
+  it('accepts valid non-negative integer strings', () => {
+    expect(isValidBigIntString('0')).toBe(true);
+    expect(isValidBigIntString('123')).toBe(true);
+    expect(isValidBigIntString('100000000000000000000')).toBe(true);
+  });
+
+  it('rejects leading plus sign', () => {
+    expect(isValidBigIntString('+100')).toBe(false);
+    expect(isValidBigIntString('+0')).toBe(false);
+  });
+
+  it('rejects negative numbers', () => {
+    expect(isValidBigIntString('-50')).toBe(false);
+    expect(isValidBigIntString('-1')).toBe(false);
+  });
+
+  it('rejects decimal points', () => {
+    expect(isValidBigIntString('10.5')).toBe(false);
+    expect(isValidBigIntString('0.0')).toBe(false);
+  });
+
+  it('rejects non-numeric characters and whitespace', () => {
+    expect(isValidBigIntString('100n')).toBe(false);
+    expect(isValidBigIntString(' 123 ')).toBe(false);
+    expect(isValidBigIntString('abc')).toBe(false);
+    expect(isValidBigIntString('')).toBe(false);
+  });
+});

--- a/contrib/examples/check-bigint-string/check-bigint-string.ts
+++ b/contrib/examples/check-bigint-string/check-bigint-string.ts
@@ -1,0 +1,52 @@
+// Example: Check whether a given string can be safely parsed as a non-negative bigint.
+//
+// Run with: npx tsx contrib/examples/check-bigint-string/check-bigint-string.ts
+
+/**
+ * Checks whether a given string is a valid non-negative bigint string.
+ *
+ * Rules:
+ * - Must contain only digits (0-9).
+ * - Rejects decimal points (e.g. "10.5").
+ * - Rejects leading plus sign (e.g. "+100").
+ * - Rejects negative sign (e.g. "-50").
+ * - Rejects empty strings, whitespace, or non-numeric characters.
+ */
+export function isValidBigIntString(val: string): boolean {
+  if (typeof val !== 'string' || val.length === 0) {
+    return false;
+  }
+  // Must consist entirely of 1 or more digits (0-9)
+  return /^\d+$/.test(val);
+}
+
+function main() {
+  console.log('=== Check Valid BigInt String Example ===\n');
+
+  const testCases = [
+    { input: '0', description: 'Zero (Valid)' },
+    { input: '123456789', description: 'Positive integer (Valid)' },
+    { input: '100000000000000000000', description: 'Large bigint string (Valid)' },
+    { input: '+100', description: 'Leading plus sign (Invalid)' },
+    { input: '-50', description: 'Negative sign (Invalid)' },
+    { input: '10.5', description: 'Decimal point (Invalid)' },
+    { input: '100n', description: 'BigInt literal suffix (Invalid)' },
+    { input: ' 123 ', description: 'Whitespace padding (Invalid)' },
+    { input: 'abc', description: 'Alphabetic string (Invalid)' },
+    { input: '', description: 'Empty string (Invalid)' },
+  ];
+
+  console.log('Input String               -> Valid Non-Negative BigInt?  (Notes)');
+  console.log('-------------------------------------------------------------------------');
+
+  for (const tc of testCases) {
+    const isValid = isValidBigIntString(tc.input);
+    console.log(
+      `"${tc.input}".padEnd(25) -> ${isValid ? 'TRUE ' : 'FALSE'}                          (${tc.description})`,
+    );
+  }
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main();
+}

--- a/contrib/examples/check-contract-id/README.md
+++ b/contrib/examples/check-contract-id/README.md
@@ -1,0 +1,43 @@
+# Check a contract id looks well-formed
+
+Checks whether a given string looks like a valid Stellar contract id: starts
+with `C`, is 56 characters, and passes `@stellar/stellar-sdk`'s `StrKey`
+checksum/encoding validation.
+
+## Example contract ids
+
+Valid:
+
+```
+CDFDULU2JWKGMIJW6FJWJJKNB3JIDQK54YTBDQUNPZTBYXCXCSO3MVZG
+```
+
+Invalid — wrong prefix (a classic `G...` account address, not a contract):
+
+```
+GDFDULU2JWKGMIJW6FJWJJKNB3JIDQK54YTBDQUNPZTBYXCXCSO3MVZG
+```
+
+Invalid — wrong length:
+
+```
+CTOOSHORT
+```
+
+Invalid — right shape, bad checksum (last character flipped):
+
+```
+CDFDULU2JWKGMIJW6FJWJJKNB3JIDQK54YTBDQUNPZTBYXCXCSO3MVZA
+```
+
+## Run it
+
+```sh
+npx tsx check-contract-id.ts <contractId>
+```
+
+## Tests
+
+```sh
+npx vitest run contrib/examples/check-contract-id
+```

--- a/contrib/examples/check-contract-id/check-contract-id.test.ts
+++ b/contrib/examples/check-contract-id/check-contract-id.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+import { checkContractId } from "./check-contract-id";
+
+const VALID_CONTRACT_ID = "CDFDULU2JWKGMIJW6FJWJJKNB3JIDQK54YTBDQUNPZTBYXCXCSO3MVZG";
+const BAD_CHECKSUM_CONTRACT_ID = "CDFDULU2JWKGMIJW6FJWJJKNB3JIDQK54YTBDQUNPZTBYXCXCSO3MVZA";
+
+describe("checkContractId", () => {
+  it("accepts a well-formed contract id", () => {
+    expect(checkContractId(VALID_CONTRACT_ID)).toEqual({ valid: true });
+  });
+
+  it("rejects a string not starting with C", () => {
+    const result = checkContractId("GDFDULU2JWKGMIJW6FJWJJKNB3JIDQK54YTBDQUNPZTBYXCXCSO3MVZG");
+    expect(result.valid).toBe(false);
+    expect(result.reason).toMatch(/must start with "C"/);
+  });
+
+  it("rejects a string of the wrong length", () => {
+    const result = checkContractId("CTOOSHORT");
+    expect(result.valid).toBe(false);
+    expect(result.reason).toMatch(/must be 56 characters/);
+  });
+
+  it("rejects a well-formed-looking string with a bad checksum", () => {
+    const result = checkContractId(BAD_CHECKSUM_CONTRACT_ID);
+    expect(result.valid).toBe(false);
+    expect(result.reason).toMatch(/checksum/);
+  });
+});

--- a/contrib/examples/check-contract-id/check-contract-id.ts
+++ b/contrib/examples/check-contract-id/check-contract-id.ts
@@ -1,0 +1,46 @@
+// Example: check whether a given string looks like a valid Stellar contract
+// id — starts with "C", the expected length, and passes StrKey's checksum
+// validation.
+//
+// Run with: npx tsx check-contract-id.ts <contractId>
+
+import { StrKey } from "@stellar/stellar-sdk";
+
+export interface ContractIdCheck {
+  valid: boolean;
+  reason?: string;
+}
+
+export function checkContractId(contractId: string): ContractIdCheck {
+  if (!contractId.startsWith("C")) {
+    return { valid: false, reason: `must start with "C", got "${contractId[0] ?? ""}"` };
+  }
+  if (contractId.length !== 56) {
+    return { valid: false, reason: `must be 56 characters, got ${contractId.length}` };
+  }
+  if (!StrKey.isValidContract(contractId)) {
+    return { valid: false, reason: "failed strkey checksum/encoding validation" };
+  }
+  return { valid: true };
+}
+
+function main() {
+  const contractId = process.argv[2];
+  if (!contractId) {
+    console.error("Usage: npx tsx check-contract-id.ts <contractId>");
+    process.exitCode = 1;
+    return;
+  }
+
+  const result = checkContractId(contractId);
+  if (result.valid) {
+    console.log(`VALID: ${contractId}`);
+  } else {
+    console.log(`INVALID: ${contractId} (${result.reason})`);
+    process.exitCode = 1;
+  }
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main();
+}

--- a/contrib/examples/check-trailing-zeros/README.md
+++ b/contrib/examples/check-trailing-zeros/README.md
@@ -1,0 +1,33 @@
+# Check Trailing Zeros Example (#110)
+
+Provides a lightweight utility `hasTrailingZeros` that determines whether a decimal token amount string contains unnecessary trailing zeros after the decimal point (e.g. `"10.50"` vs `"10.5"`).
+
+## Behavior & Rules
+
+- **Decimal Strings**: Returns `true` if there is a decimal point and the fractional part ends with `'0'` (e.g. `10.50`, `1.000`).
+- **Integer Strings**: Handles integer strings without decimal points (e.g. `100`, `0`) safely without throwing and returns `false`.
+
+## Examples & Expected Outputs
+
+| Amount String | Has Trailing Zeros? | Notes |
+| --- | --- | --- |
+| `10.50` | **`true`** | Unnecessary zero after `.5` |
+| `1.000` | **`true`** | Multiple trailing zeros after decimal |
+| `10.0` | **`true`** | Single trailing zero after decimal |
+| `0.050` | **`true`** | Trailing zero after non-zero fraction |
+| `10.5` | **`false`** | Clean normalized decimal |
+| `0.05` | **`false`** | Clean fraction |
+| `100` | **`false`** | Integer without decimal point (handled safely) |
+| `0` | **`false`** | Single digit integer |
+
+## Run it
+
+```sh
+npx tsx contrib/examples/check-trailing-zeros/check-trailing-zeros.ts
+```
+
+## Tests
+
+```sh
+npx vitest run contrib/examples/check-trailing-zeros
+```

--- a/contrib/examples/check-trailing-zeros/check-trailing-zeros.test.ts
+++ b/contrib/examples/check-trailing-zeros/check-trailing-zeros.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest';
+import { hasTrailingZeros } from './check-trailing-zeros';
+
+describe('check-trailing-zeros (#110)', () => {
+  it('detects trailing zeros after decimal point', () => {
+    expect(hasTrailingZeros('10.50')).toBe(true);
+    expect(hasTrailingZeros('1.000')).toBe(true);
+    expect(hasTrailingZeros('10.0')).toBe(true);
+    expect(hasTrailingZeros('0.050')).toBe(true);
+  });
+
+  it('returns false for normalized decimal strings without trailing zeros', () => {
+    expect(hasTrailingZeros('10.5')).toBe(false);
+    expect(hasTrailingZeros('0.05')).toBe(false);
+    expect(hasTrailingZeros('3.14159')).toBe(false);
+  });
+
+  it('handles integer amounts without decimal points safely without throwing', () => {
+    expect(hasTrailingZeros('100')).toBe(false);
+    expect(hasTrailingZeros('0')).toBe(false);
+    expect(hasTrailingZeros('1000')).toBe(false);
+  });
+
+  it('handles empty or non-string inputs safely', () => {
+    expect(hasTrailingZeros('')).toBe(false);
+    expect(hasTrailingZeros(null as any)).toBe(false);
+  });
+});

--- a/contrib/examples/check-trailing-zeros/check-trailing-zeros.ts
+++ b/contrib/examples/check-trailing-zeros/check-trailing-zeros.ts
@@ -1,0 +1,60 @@
+// Example: Check whether a decimal amount string contains unnecessary trailing zeros after the decimal point.
+//
+// Run with: npx tsx contrib/examples/check-trailing-zeros/check-trailing-zeros.ts
+
+/**
+ * Determines whether a decimal amount string has unnecessary trailing zeros after the decimal point.
+ *
+ * Rules:
+ * - Integer strings without a decimal point (e.g., "100", "0") return false (no throwing).
+ * - Decimal strings ending in zero after the decimal point (e.g., "10.50", "1.000", "10.0") return true.
+ * - Normalized decimal strings without trailing zeros (e.g., "10.5", "0.05") return false.
+ */
+export function hasTrailingZeros(amount: string): boolean {
+  if (typeof amount !== 'string' || !amount.trim()) {
+    return false;
+  }
+
+  const str = amount.trim();
+  const decimalIndex = str.indexOf('.');
+
+  // If there is no decimal point, it's an integer amount with no fractional trailing zeros
+  if (decimalIndex === -1) {
+    return false;
+  }
+
+  const fractionalPart = str.slice(decimalIndex + 1);
+
+  // Return true if the fractional part has at least one character and ends with '0'
+  return fractionalPart.length > 0 && fractionalPart.endsWith('0');
+}
+
+function main() {
+  console.log('=== Check Trailing Zeros Example ===\n');
+
+  const testCases = [
+    { amount: '10.50', expected: true, note: 'Trailing zero after decimal' },
+    { amount: '1.000', expected: true, note: 'Multiple trailing zeros' },
+    { amount: '10.0', expected: true, note: 'Single trailing zero' },
+    { amount: '0.050', expected: true, note: 'Trailing zero after non-zero fraction' },
+    { amount: '10.5', expected: false, note: 'Clean normalized decimal' },
+    { amount: '0.05', expected: false, note: 'Clean fraction' },
+    { amount: '100', expected: false, note: 'Integer without decimal point' },
+    { amount: '0', expected: false, note: 'Zero integer' },
+    { amount: '1000', expected: false, note: 'Integer with trailing zeros in whole number' },
+  ];
+
+  console.log('Amount String | Has Trailing Zeros? | Notes');
+  console.log('--------------|---------------------|-----------------------------------');
+
+  for (const tc of testCases) {
+    const result = hasTrailingZeros(tc.amount);
+    console.log(
+      `${tc.amount.padEnd(13)} | ${result ? 'TRUE ' : 'FALSE'}              | ${tc.note}`,
+    );
+  }
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main();
+}

--- a/contrib/examples/cleanup-plan-viewer/README.md
+++ b/contrib/examples/cleanup-plan-viewer/README.md
@@ -1,0 +1,52 @@
+# Cleanup plan viewer
+
+`renderCleanupPlan(plan)` takes a mock cleanup plan object and renders a
+readable, numbered, step-by-step view of its blockers. Each blocker is
+clearly marked `[RESOLVED]` or `[OUTSTANDING]`. A plan with **zero**
+blockers prints a clear all-clear message instead of an empty list.
+
+## Input shape
+
+```ts
+interface CleanupBlocker {
+  id: string;
+  description: string;
+  resolved: boolean;
+}
+
+interface CleanupPlan {
+  title: string;
+  blockers: CleanupBlocker[];
+}
+```
+
+Each rendered step follows the plan's `blockers` order:
+`<n>. [RESOLVED|OUTSTANDING] <description> (<id>)`.
+
+## Run it
+
+```sh
+npx tsx cleanup-plan-viewer.ts
+```
+
+Expected output (a plan with a mix of resolved and outstanding blockers,
+followed by a plan with zero blockers):
+
+```
+Testnet contract cleanup
+
+1. [RESOLVED] Revoke unused deployer signer key (blocker-1)
+2. [OUTSTANDING] Migrate policy-contract owners off the legacy multisig (blocker-2)
+3. [RESOLVED] Remove stale allowlist entries from spending-limit policy (blocker-3)
+4. [OUTSTANDING] Confirm no active sessions reference the retired signer (blocker-4)
+
+Mainnet migration cleanup
+
+All clear — no blockers remaining.
+```
+
+## Tests
+
+```sh
+npx vitest run contrib/examples/cleanup-plan-viewer
+```

--- a/contrib/examples/cleanup-plan-viewer/cleanup-plan-viewer.test.ts
+++ b/contrib/examples/cleanup-plan-viewer/cleanup-plan-viewer.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+import { renderCleanupPlan, type CleanupPlan } from "./cleanup-plan-viewer";
+
+describe("renderCleanupPlan", () => {
+  it("marks each blocker as resolved or outstanding", () => {
+    const plan: CleanupPlan = {
+      title: "Sample plan",
+      blockers: [
+        { id: "b1", description: "First step", resolved: true },
+        { id: "b2", description: "Second step", resolved: false },
+      ],
+    };
+
+    const output = renderCleanupPlan(plan);
+    expect(output).toContain("1. [RESOLVED] First step (b1)");
+    expect(output).toContain("2. [OUTSTANDING] Second step (b2)");
+  });
+
+  it("numbers steps in the given order starting at 1", () => {
+    const plan: CleanupPlan = {
+      title: "Sample plan",
+      blockers: [
+        { id: "b1", description: "A", resolved: true },
+        { id: "b2", description: "B", resolved: true },
+        { id: "b3", description: "C", resolved: false },
+      ],
+    };
+
+    const lines = renderCleanupPlan(plan).split("\n");
+    expect(lines).toContain("1. [RESOLVED] A (b1)");
+    expect(lines).toContain("2. [RESOLVED] B (b2)");
+    expect(lines).toContain("3. [OUTSTANDING] C (b3)");
+  });
+
+  it("prints a clear all-clear message for a plan with zero blockers", () => {
+    const output = renderCleanupPlan({ title: "Empty plan", blockers: [] });
+    expect(output).toBe("Empty plan\n\nAll clear — no blockers remaining.");
+    expect(output).not.toContain("RESOLVED");
+    expect(output).not.toContain("OUTSTANDING");
+  });
+
+  it("includes the plan title as a heading", () => {
+    const output = renderCleanupPlan({
+      title: "My cleanup plan",
+      blockers: [{ id: "b1", description: "Step", resolved: false }],
+    });
+    expect(output.startsWith("My cleanup plan")).toBe(true);
+  });
+});

--- a/contrib/examples/cleanup-plan-viewer/cleanup-plan-viewer.ts
+++ b/contrib/examples/cleanup-plan-viewer/cleanup-plan-viewer.ts
@@ -1,0 +1,55 @@
+// Example: take a mock cleanup plan object and render a readable step by
+// step view of its blockers, each clearly marked as resolved or
+// outstanding.
+//
+// Run with: npx tsx cleanup-plan-viewer.ts
+
+export interface CleanupBlocker {
+  id: string;
+  description: string;
+  resolved: boolean;
+}
+
+export interface CleanupPlan {
+  title: string;
+  blockers: CleanupBlocker[];
+}
+
+/**
+ * Renders `plan` as a numbered, step-by-step list of its blockers, each
+ * marked `[RESOLVED]` or `[OUTSTANDING]`. A plan with zero blockers prints a
+ * clear all-clear message instead of an empty list.
+ */
+export function renderCleanupPlan(plan: CleanupPlan): string {
+  if (plan.blockers.length === 0) {
+    return `${plan.title}\n\nAll clear — no blockers remaining.`;
+  }
+
+  const lines = [plan.title, ""];
+  plan.blockers.forEach((blocker, index) => {
+    const status = blocker.resolved ? "RESOLVED" : "OUTSTANDING";
+    lines.push(`${index + 1}. [${status}] ${blocker.description} (${blocker.id})`);
+  });
+  return lines.join("\n");
+}
+
+function main() {
+  const plan: CleanupPlan = {
+    title: "Testnet contract cleanup",
+    blockers: [
+      { id: "blocker-1", description: "Revoke unused deployer signer key", resolved: true },
+      { id: "blocker-2", description: "Migrate policy-contract owners off the legacy multisig", resolved: false },
+      { id: "blocker-3", description: "Remove stale allowlist entries from spending-limit policy", resolved: true },
+      { id: "blocker-4", description: "Confirm no active sessions reference the retired signer", resolved: false },
+    ],
+  };
+
+  console.log(renderCleanupPlan(plan));
+
+  console.log();
+  console.log(renderCleanupPlan({ title: "Mainnet migration cleanup", blockers: [] }));
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main();
+}

--- a/contrib/examples/cli-arg-parser/README.md
+++ b/contrib/examples/cli-arg-parser/README.md
@@ -1,0 +1,47 @@
+# Minimal CLI argument parser
+
+Reads named flags and positional arguments from a `process.argv`-style
+array, returning a plain object with parsed flags and an array of
+positionals.
+
+## Supported syntax
+
+- `--key=value` — a flag with a string value.
+- `--key` (no `=`) — a boolean flag (`true`).
+- anything else — a positional argument.
+
+**Deliberately not supported: `--key value` (space-separated).** Without a
+predefined schema of which flags take a value, that form is ambiguous —
+`--dry-run positional1` can't be told apart from `--amount 100` without
+knowing in advance whether `--dry-run` is boolean-only. Requiring `=` for
+any flag that takes a value sidesteps the ambiguity entirely.
+
+## Run it
+
+```sh
+npx tsx cli-arg-parser.ts
+```
+
+Expected output:
+
+```
+Input:  [
+  '--network=testnet',
+  '--dry-run',
+  'positional1',
+  '--amount=100',
+  'positional2'
+]
+Parsed: {
+  flags: { network: 'testnet', 'dry-run': true, amount: '100' },
+  positionals: [ 'positional1', 'positional2' ]
+}
+```
+
+## Tests
+
+Covers a mix of flags and positionals in one call:
+
+```sh
+npx vitest run contrib/examples/cli-arg-parser
+```

--- a/contrib/examples/cli-arg-parser/cli-arg-parser.test.ts
+++ b/contrib/examples/cli-arg-parser/cli-arg-parser.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+import { parseArgs } from "./cli-arg-parser";
+
+describe("parseArgs", () => {
+  it("parses a --key=value flag", () => {
+    expect(parseArgs(["--network=testnet"])).toEqual({
+      flags: { network: "testnet" },
+      positionals: [],
+    });
+  });
+
+  it("parses a bare flag as boolean true", () => {
+    expect(parseArgs(["--dry-run"])).toEqual({ flags: { "dry-run": true }, positionals: [] });
+  });
+
+  it("collects non-flag tokens as positionals", () => {
+    expect(parseArgs(["one", "two"])).toEqual({ flags: {}, positionals: ["one", "two"] });
+  });
+
+  it("parses a mix of flags and positionals in one call", () => {
+    const result = parseArgs(["--network=testnet", "--dry-run", "positional1", "--amount=100", "positional2"]);
+    expect(result).toEqual({
+      flags: { network: "testnet", "dry-run": true, amount: "100" },
+      positionals: ["positional1", "positional2"],
+    });
+  });
+
+  it("returns empty flags and positionals for an empty input", () => {
+    expect(parseArgs([])).toEqual({ flags: {}, positionals: [] });
+  });
+});

--- a/contrib/examples/cli-arg-parser/cli-arg-parser.ts
+++ b/contrib/examples/cli-arg-parser/cli-arg-parser.ts
@@ -1,0 +1,52 @@
+// Example: a minimal CLI argument parser reading named flags and
+// positional arguments from a process.argv-style array.
+//
+// Supported flag styles: --key=value, and a bare --key (boolean true).
+// Everything else (including anything not starting with --) is a
+// positional.
+//
+// Deliberately NOT supporting "--key value" (space-separated): without a
+// predefined schema of which flags take a value, that form is ambiguous —
+// `--dry-run positional1` can't be told apart from `--amount 100` without
+// knowing in advance whether --dry-run is boolean-only. Requiring `=` for
+// any flag that takes a value sidesteps the ambiguity entirely.
+//
+// Run with: npx tsx cli-arg-parser.ts --network=testnet --dry-run positional1 --amount=100 positional2
+
+export interface ParsedArgs {
+  flags: Record<string, string | boolean>;
+  positionals: string[];
+}
+
+export function parseArgs(argv: string[]): ParsedArgs {
+  const flags: Record<string, string | boolean> = {};
+  const positionals: string[] = [];
+
+  for (const token of argv) {
+    if (token.startsWith("--")) {
+      const body = token.slice(2);
+      const eqIndex = body.indexOf("=");
+
+      if (eqIndex !== -1) {
+        flags[body.slice(0, eqIndex)] = body.slice(eqIndex + 1);
+      } else {
+        flags[body] = true;
+      }
+      continue;
+    }
+
+    positionals.push(token);
+  }
+
+  return { flags, positionals };
+}
+
+function main() {
+  const sampleArgv = ["--network=testnet", "--dry-run", "positional1", "--amount=100", "positional2"];
+  console.log("Input: ", sampleArgv);
+  console.log("Parsed:", parseArgs(sampleArgv));
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main();
+}

--- a/contrib/examples/cli-balance-printer/README.md
+++ b/contrib/examples/cli-balance-printer/README.md
@@ -1,0 +1,91 @@
+# CLI: print a table of token balances
+
+A small command-line tool that prints an aligned table of balances for one
+account across one or more token contracts. It reads through the SDK's own
+`createBalanceService`, but wired to an in-memory mock `BalanceReader`, so it
+runs end to end with no live network call — no RPC, no Horizon, no keys.
+
+## Usage
+
+```sh
+npx tsx cli-balance-printer.ts <accountId> <tokenContractId...>
+```
+
+- `<accountId>` — the account whose balances are read. Any string works
+  against the mock; an account with no seeded balance simply reads as `0`.
+- `<tokenContractId...>` — one or more token contract ids. Rows appear in the
+  order given, and a repeated id is collapsed so no token is printed twice.
+
+## Running it with node
+
+Node cannot execute a `.ts` file on its own, so the tool runs through `tsx`,
+which is a TypeScript loader for node — `npx tsx <file>` starts node with that
+loader attached. If `tsx` is installed in the workspace you can spell the same
+thing out explicitly:
+
+```sh
+node --import tsx cli-balance-printer.ts <accountId> <tokenContractId...>
+```
+
+Everything else the tool needs is in node's standard library plus the SDK
+source, so there is nothing to configure and no network access involved.
+
+## Sample run
+
+```sh
+$ npx tsx cli-balance-printer.ts \
+    CMOCKACCOUNTXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX \
+    CXLMMOCKCONTRACTXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX \
+    CUSDCMOCKCONTRACTXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX \
+    CEURCMOCKCONTRACTXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+Account: CMOCKACCOUNTXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+
+TOKEN  CONTRACT                                                 BALANCE
+-----------------------------------------------------------------------
+XLM    CXLMMOCKCONTRACTXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX       42
+USDC   CUSDCMOCKCONTRACTXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX   1250.5
+EURC   CEURCMOCKCONTRACTXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX    18.75
+```
+
+Amounts are rendered by the SDK's `formatTokenAmount`, so each token uses its
+own `decimals` (EURC above has 6, the others 7) and the column is right
+aligned. Bad input exits non-zero with a one-line message:
+
+```sh
+$ npx tsx cli-balance-printer.ts CMOCKACCOUNTXXXX
+Error: At least one <tokenContractId> is required
+```
+
+## Known token contracts
+
+The mock ledger recognizes three fake contract ids. Reading an id outside this
+list fails before any balance is fetched, and the error lists the known ids.
+
+| Symbol | Contract id                                               | Decimals |
+| ------ | --------------------------------------------------------- | -------- |
+| USDC   | `CUSDCMOCKCONTRACTXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX`  | 7        |
+| XLM    | `CXLMMOCKCONTRACTXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX`  | 7        |
+| EURC   | `CEURCMOCKCONTRACTXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX`  | 6        |
+
+## How the mock is wired
+
+`createMockBalanceReader` returns a `BalanceReader` — the single-method seam
+`createBalanceService` reads through — backed by a plain object of raw amounts.
+An unknown token contract is rejected (a real token read against a non-token
+address fails too), while an unknown holder reads as `0n`, which is what a real
+token contract returns for an address that has never held the asset.
+
+Because the reader is just a parameter, `printBalances` accepts one: pass the
+RPC-backed reader from `src/balances-rpc.ts` instead and the same tool prints
+live balances.
+
+## Tests
+
+```sh
+npx vitest run contrib/examples/cli-balance-printer
+```
+
+Covers argument parsing (including the duplicate-token and missing-argument
+cases), contract id resolution, the mock reader's zero/unknown behavior, the
+table alignment and per-token decimals, and `printBalances` failing on an
+unknown contract before issuing any read.

--- a/contrib/examples/cli-balance-printer/cli-balance-printer.test.ts
+++ b/contrib/examples/cli-balance-printer/cli-balance-printer.test.ts
@@ -1,0 +1,144 @@
+import { describe, expect, it } from "vitest";
+import {
+  createMockBalanceReader,
+  formatBalanceTable,
+  parseArgs,
+  printBalances,
+  resolveTokens,
+} from "./cli-balance-printer";
+import type { BalanceReader } from "../../../src/balances";
+
+const ACCOUNT = "CMOCKACCOUNTXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX";
+const USDC = "CUSDCMOCKCONTRACTXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX";
+const XLM = "CXLMMOCKCONTRACTXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX";
+const EURC = "CEURCMOCKCONTRACTXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX";
+
+describe("parseArgs", () => {
+  it("takes the account id first and every remaining argument as a token", () => {
+    expect(parseArgs([ACCOUNT, USDC, XLM])).toEqual({
+      accountId: ACCOUNT,
+      tokenContractIds: [USDC, XLM],
+    });
+  });
+
+  it("accepts a single token", () => {
+    expect(parseArgs([ACCOUNT, USDC].map(String)).tokenContractIds).toEqual([USDC]);
+  });
+
+  it("collapses a repeated token contract id", () => {
+    expect(parseArgs([ACCOUNT, USDC, XLM, USDC]).tokenContractIds).toEqual([USDC, XLM]);
+  });
+
+  it("throws when no arguments are given at all", () => {
+    expect(() => parseArgs([])).toThrow(/Missing <accountId>/);
+  });
+
+  it("throws when the account id is given but no token is", () => {
+    expect(() => parseArgs([ACCOUNT])).toThrow(/At least one <tokenContractId>/);
+  });
+});
+
+describe("resolveTokens", () => {
+  it("resolves known contract ids to their token info", () => {
+    expect(resolveTokens([USDC, EURC])).toEqual([
+      { symbol: "USDC", contractId: USDC, decimals: 7 },
+      { symbol: "EURC", contractId: EURC, decimals: 6 },
+    ]);
+  });
+
+  it("rejects an unknown contract id and lists the known ones", () => {
+    expect(() => resolveTokens([USDC, "CNOTATOKEN"])).toThrow(/Unknown token contract "CNOTATOKEN"/);
+    expect(() => resolveTokens(["CNOTATOKEN"])).toThrow(new RegExp(USDC));
+  });
+});
+
+describe("createMockBalanceReader", () => {
+  it("returns the seeded balance for a known holder", async () => {
+    await expect(createMockBalanceReader().getTokenBalance(USDC, ACCOUNT)).resolves.toBe(
+      1_250_5000000n,
+    );
+  });
+
+  it("reads zero for a holder that has never held the token", async () => {
+    await expect(createMockBalanceReader().getTokenBalance(USDC, "CSOMEONEELSE")).resolves.toBe(0n);
+  });
+
+  it("rejects a read against an unknown token contract", async () => {
+    await expect(createMockBalanceReader().getTokenBalance("CNOTATOKEN", ACCOUNT)).rejects.toThrow(
+      /Unknown token contract/,
+    );
+  });
+});
+
+describe("formatBalanceTable", () => {
+  it("aligns columns and right-aligns the amounts", () => {
+    const table = formatBalanceTable(ACCOUNT, [
+      { symbol: "USDC", contractId: USDC, decimals: 7, amount: 1_250_5000000n },
+      { symbol: "XLM", contractId: XLM, decimals: 7, amount: 42_0000000n },
+    ]);
+    const [account, blank, header, rule, usdcRow, xlmRow] = table.split("\n");
+
+    expect(account).toBe(`Account: ${ACCOUNT}`);
+    expect(blank).toBe("");
+    expect(header).toMatch(/^TOKEN\s+CONTRACT\s+BALANCE$/);
+    expect(rule).toBe("-".repeat(header!.length));
+    expect(usdcRow).toContain("1250.5");
+    expect(xlmRow).toContain("42");
+    // Every row is padded to the same width, so the amount column lines up.
+    expect(new Set([header!.length, usdcRow!.length, xlmRow!.length]).size).toBe(1);
+  });
+
+  it("formats each token with its own decimals", () => {
+    const table = formatBalanceTable(ACCOUNT, [
+      { symbol: "EURC", contractId: EURC, decimals: 6, amount: 18_750000n },
+    ]);
+    expect(table).toContain("18.75");
+  });
+});
+
+describe("printBalances", () => {
+  it("prints a row per requested token, in the order given", async () => {
+    const table = await printBalances({ accountId: ACCOUNT, tokenContractIds: [XLM, USDC] });
+    const rows = table.split("\n").slice(4);
+
+    expect(rows).toHaveLength(2);
+    expect(rows[0]).toMatch(/^XLM\s/);
+    expect(rows[1]).toMatch(/^USDC\s/);
+    expect(rows[0]).toContain("42");
+    expect(rows[1]).toContain("1250.5");
+  });
+
+  it("shows a zero balance rather than omitting the token", async () => {
+    const table = await printBalances({ accountId: "CSTRANGER", tokenContractIds: [USDC] });
+    expect(table).toMatch(/USDC\s+\S+\s+0$/);
+  });
+
+  it("fails before any read when a token contract is unknown", async () => {
+    let reads = 0;
+    const counting: BalanceReader = {
+      async getTokenBalance() {
+        reads++;
+        return 0n;
+      },
+    };
+
+    await expect(
+      printBalances({ accountId: ACCOUNT, tokenContractIds: [USDC, "CNOTATOKEN"] }, counting),
+    ).rejects.toThrow(/Unknown token contract/);
+    expect(reads).toBe(0);
+  });
+
+  it("reads through an injected reader, so a caller can supply a live one", async () => {
+    const constant: BalanceReader = {
+      async getTokenBalance() {
+        return 7_0000000n;
+      },
+    };
+
+    const table = await printBalances(
+      { accountId: ACCOUNT, tokenContractIds: [USDC, XLM] },
+      constant,
+    );
+    expect(table.match(/\b7\b/g)).toHaveLength(2);
+  });
+});

--- a/contrib/examples/cli-balance-printer/cli-balance-printer.ts
+++ b/contrib/examples/cli-balance-printer/cli-balance-printer.ts
@@ -1,0 +1,158 @@
+// Example: a command-line tool that prints an aligned table of balances for
+// one account across one or more token contracts. It reads through the SDK's
+// own createBalanceService, but wired to an in-memory mock BalanceReader, so
+// it runs end to end with no live network call.
+//
+// Run with:
+//   node --experimental-strip-types cli-balance-printer.ts <accountId> <tokenContractId...>
+
+import { pathToFileURL } from "node:url";
+import {
+  createBalanceService,
+  formatTokenAmount,
+  type BalanceReader,
+  type TokenBalance,
+  type TokenInfo,
+} from "../../../src/balances";
+
+/** The token contracts the mock ledger knows about. Contract ids are obviously
+ * fake — this tool never touches a real network. */
+const MOCK_TOKENS: Record<string, TokenInfo> = {
+  CUSDCMOCKCONTRACTXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX: {
+    symbol: "USDC",
+    contractId: "CUSDCMOCKCONTRACTXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+    decimals: 7,
+  },
+  CXLMMOCKCONTRACTXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX: {
+    symbol: "XLM",
+    contractId: "CXLMMOCKCONTRACTXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+    decimals: 7,
+  },
+  CEURCMOCKCONTRACTXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX: {
+    symbol: "EURC",
+    contractId: "CEURCMOCKCONTRACTXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+    decimals: 6,
+  },
+};
+
+/** Raw balances the mock reader serves, keyed by `${contractId}:${holder}`.
+ * A holder with no entry reads as zero, which is what a real token contract
+ * returns for an address that has never held the asset. */
+const MOCK_LEDGER: Record<string, bigint> = {
+  "CUSDCMOCKCONTRACTXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX:CMOCKACCOUNTXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX":
+    1_250_5000000n,
+  "CXLMMOCKCONTRACTXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX:CMOCKACCOUNTXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX":
+    42_0000000n,
+  "CEURCMOCKCONTRACTXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX:CMOCKACCOUNTXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX":
+    18_750000n,
+};
+
+export interface CliArgs {
+  accountId: string;
+  tokenContractIds: string[];
+}
+
+/**
+ * Parses `<accountId> <tokenContractId...>`. Repeated contract ids are
+ * collapsed (first occurrence wins) so the table never shows the same token
+ * twice, and both the account id and at least one token are required.
+ */
+export function parseArgs(argv: string[]): CliArgs {
+  const positional = argv.filter((arg) => arg.trim() !== "");
+  const [accountId, ...tokenContractIds] = positional;
+
+  if (!accountId) {
+    throw new Error("Missing <accountId>. Usage: <accountId> <tokenContractId...>");
+  }
+  if (tokenContractIds.length === 0) {
+    throw new Error("At least one <tokenContractId> is required");
+  }
+
+  return { accountId, tokenContractIds: [...new Set(tokenContractIds)] };
+}
+
+/**
+ * A BalanceReader backed by MOCK_LEDGER. Unknown token contracts are rejected
+ * — a real token read against a non-token address fails too — while an unknown
+ * holder simply reads as zero.
+ */
+export function createMockBalanceReader(): BalanceReader {
+  return {
+    async getTokenBalance(tokenContractId: string, holder: string): Promise<bigint> {
+      if (!MOCK_TOKENS[tokenContractId]) {
+        throw new Error(`Unknown token contract ${tokenContractId}`);
+      }
+      return MOCK_LEDGER[`${tokenContractId}:${holder}`] ?? 0n;
+    },
+  };
+}
+
+/** Resolves contract ids to the TokenInfo the balance service needs, failing
+ * with the full list of known ids rather than a bare "not found". */
+export function resolveTokens(tokenContractIds: string[]): TokenInfo[] {
+  return tokenContractIds.map((contractId) => {
+    const token = MOCK_TOKENS[contractId];
+    if (!token) {
+      throw new Error(
+        `Unknown token contract "${contractId}". Known contracts:\n  ${Object.keys(MOCK_TOKENS).join("\n  ")}`,
+      );
+    }
+    return token;
+  });
+}
+
+/** Renders balances as an aligned text table: symbol and contract id left
+ * aligned, the formatted amount right aligned so decimal points line up. */
+export function formatBalanceTable(accountId: string, balances: TokenBalance[]): string {
+  const rows = balances.map((balance) => ({
+    token: balance.symbol,
+    contract: balance.contractId,
+    amount: formatTokenAmount(balance.amount, balance.decimals),
+  }));
+
+  const headers = { token: "TOKEN", contract: "CONTRACT", amount: "BALANCE" };
+  const width = (key: keyof typeof headers) =>
+    Math.max(headers[key].length, ...rows.map((row) => row[key].length));
+  const tokenWidth = width("token");
+  const contractWidth = width("contract");
+  const amountWidth = width("amount");
+
+  const line = (row: typeof headers) =>
+    `${row.token.padEnd(tokenWidth)}  ${row.contract.padEnd(contractWidth)}  ${row.amount.padStart(amountWidth)}`;
+
+  return [
+    `Account: ${accountId}`,
+    "",
+    line(headers),
+    "-".repeat(line(headers).length),
+    ...rows.map(line),
+  ].join("\n");
+}
+
+/**
+ * Runs one CLI invocation: resolve the tokens, read every balance through the
+ * SDK's balance service, and return the rendered table. Separated from `main`
+ * so it is directly testable without touching `process.argv`.
+ */
+export async function printBalances(
+  args: CliArgs,
+  reader: BalanceReader = createMockBalanceReader(),
+): Promise<string> {
+  const tokens = resolveTokens(args.tokenContractIds);
+  const balances = await createBalanceService(reader, tokens).getBalances(args.accountId);
+  return formatBalanceTable(args.accountId, balances);
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  console.log(await printBalances(args));
+}
+
+// pathToFileURL rather than a `file://` template so the entrypoint check also
+// holds on Windows, where argv[1] is a drive-letter path.
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main().catch((err) => {
+    console.error(`Error: ${(err as Error).message}`);
+    process.exitCode = 1;
+  });
+}

--- a/contrib/examples/cli-send-payment/README.md
+++ b/contrib/examples/cli-send-payment/README.md
@@ -1,0 +1,53 @@
+# CLI: send a test payment
+
+A small command-line tool that drives a real `createVellarWallet` handle —
+wired to fully in-memory mock `kit`, `sac`, and `backend` dependencies — through
+a create-then-pay sequence. No WebAuthn prompt, no RPC call, no relayer: it's a
+reference for exercising the wallet's `pay()` flow end to end from a script.
+
+## Usage
+
+```sh
+npx tsx cli-send-payment.ts --to <recipient> --amount <decimal> --token <USDC|XLM>
+```
+
+- `--to` — the recipient address (any non-empty string works against the mock;
+  the real SDK validates against actual Stellar address rules).
+- `--amount` — a decimal amount, e.g. `12.5`. Rejected if it has more
+  fractional digits than the token supports (7, for both mock tokens).
+- `--token` — `USDC` or `XLM` (case-insensitive). These map to fake contract
+  ids defined in `cli-send-payment.ts`'s `MOCK_TOKENS`.
+
+Flags may be given in any order.
+
+## Sample run
+
+```sh
+$ npx tsx cli-send-payment.ts --to GRECIPIENTXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX --amount 12.5 --token USDC
+Creating a mock wallet...
+Wallet created: CMOCKSMARTACCOUNTXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+Sending 12.5 USDC to GRECIPIENTXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX...
+Payment submitted. Transaction hash: mockhash1000000
+```
+
+## How the mocks are wired
+
+`createMockWallet` builds the three seams `createVellarWallet` needs
+(`PasskeyKitLike`, `WalletBackend & submitTransaction`, `SacClientLike`) as
+plain in-memory objects — `kit.sign` just prefixes the input with `signed:`,
+`sac.getSACClient(...).transfer` returns a placeholder unsigned-tx string, and
+`backend.submitTransaction` hands back an incrementing fake hash. This is the
+same shape a real integration wires (a real `PasskeyKit` instance, a real
+`SACClient`, and your app's backend), just swapped for deterministic fakes —
+useful as a starting point for scripting SDK flows or for integration tests
+that shouldn't touch a live network.
+
+## Tests
+
+```sh
+npx vitest run contrib/examples/cli-send-payment
+```
+
+Covers argument parsing (order-independence, missing flags/values), the full
+create-then-pay sequence producing a hash, an unknown `--token` being rejected
+before any payment is attempted, and an over-precise `--amount` being rejected.

--- a/contrib/examples/cli-send-payment/cli-send-payment.test.ts
+++ b/contrib/examples/cli-send-payment/cli-send-payment.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "vitest";
+import { createMockWallet, parseArgs, runSendPayment } from "./cli-send-payment";
+
+describe("parseArgs", () => {
+  it("parses all three required flags regardless of order", () => {
+    const args = parseArgs(["--amount", "10.5", "--to", "GRECIPIENT", "--token", "USDC"]);
+    expect(args).toEqual({ to: "GRECIPIENT", amount: "10.5", token: "USDC" });
+  });
+
+  it("throws naming every missing flag, not just the first", () => {
+    expect(() => parseArgs(["--to", "GRECIPIENT"])).toThrow(/--amount.*--token|--token.*--amount/);
+  });
+
+  it("throws when a flag is missing its value", () => {
+    expect(() => parseArgs(["--to", "--amount", "10"])).toThrow(/Missing value for --to/);
+  });
+});
+
+describe("runSendPayment", () => {
+  it("creates a wallet and submits a payment, returning a transaction hash", async () => {
+    const { wallet } = createMockWallet("testnet");
+    const logs: string[] = [];
+
+    const result = await runSendPayment(
+      { to: "GRECIPIENTXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX", amount: "12.5", token: "USDC" },
+      wallet,
+      (line) => logs.push(line),
+    );
+
+    expect(result.hash).toBeTruthy();
+    expect(logs.some((l) => l.includes("Wallet created"))).toBe(true);
+    expect(logs.some((l) => l.includes("Payment submitted"))).toBe(true);
+  });
+
+  it("rejects an unknown token before attempting to pay", async () => {
+    const { wallet } = createMockWallet("testnet");
+    await expect(
+      runSendPayment({ to: "GRECIPIENT", amount: "1", token: "DOGE" }, wallet),
+    ).rejects.toThrow(/Unknown --token/);
+  });
+
+  it("rejects an amount with too many decimal places", async () => {
+    const { wallet } = createMockWallet("testnet");
+    await expect(
+      runSendPayment({ to: "GRECIPIENT", amount: "1.12345678", token: "USDC" }, wallet),
+    ).rejects.toThrow(/at most 7 decimal places/);
+  });
+
+  it("produces a different hash for each payment submitted through the same mock wallet", async () => {
+    const { wallet } = createMockWallet("testnet");
+    await wallet.create();
+    const first = await wallet.pay({
+      to: "GRECIPIENT1",
+      amount: 1_0000000n,
+      token: { symbol: "USDC", contractId: "CUSDC", decimals: 7 },
+    });
+    const second = await wallet.pay({
+      to: "GRECIPIENT2",
+      amount: 2_0000000n,
+      token: { symbol: "USDC", contractId: "CUSDC", decimals: 7 },
+    });
+    expect(first.hash).not.toBe(second.hash);
+  });
+});

--- a/contrib/examples/cli-send-payment/cli-send-payment.ts
+++ b/contrib/examples/cli-send-payment/cli-send-payment.ts
@@ -1,0 +1,171 @@
+// Example: a command-line tool that sends a payment through a Vellar wallet
+// handle wired to mock kit/sac/backend dependencies, so it runs end to end
+// with no live network call.
+//
+// Run with:
+//   npx tsx cli-send-payment.ts --to GRECIPIENTXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX --amount 12.5 --token USDC
+
+import { createVellarWallet, type VellarWallet } from "../../../src/client";
+import type { PasskeyKitLike, WalletBackend } from "../../../src/passkeykit-connector";
+import type { SacClientLike, TokenContractClientLike } from "../../../src/payments-client";
+import type { Network } from "../../../src/types";
+import type { TokenInfo } from "../../../src/balances";
+
+/** The recognized `--token` values and the TokenInfo each maps to (contract ids
+ * are obviously fake — this tool never touches a real network). */
+const MOCK_TOKENS: Record<string, TokenInfo> = {
+  USDC: { symbol: "USDC", contractId: "CUSDCMOCKCONTRACTXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX", decimals: 7 },
+  XLM: { symbol: "XLM", contractId: "CXLMMOCKCONTRACTXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX", decimals: 7 },
+};
+
+export interface CliArgs {
+  to: string;
+  amount: string;
+  token: string;
+}
+
+/** Parses `--to <addr> --amount <decimal> --token <symbol>` (any order). Throws
+ * a descriptive Error naming every missing flag rather than failing on the first. */
+export function parseArgs(argv: string[]): CliArgs {
+  const flags: Record<string, string> = {};
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    if (arg?.startsWith("--")) {
+      const name = arg.slice(2);
+      const value = argv[i + 1];
+      if (value === undefined || value.startsWith("--")) {
+        throw new Error(`Missing value for --${name}`);
+      }
+      flags[name] = value;
+      i++;
+    }
+  }
+
+  const missing = ["to", "amount", "token"].filter((name) => !(name in flags));
+  if (missing.length > 0) {
+    throw new Error(`Missing required flag(s): ${missing.map((m) => `--${m}`).join(", ")}`);
+  }
+
+  return { to: flags.to!, amount: flags.amount!, token: flags.token! };
+}
+
+/** Builds a wallet handle wired to fully in-memory mock dependencies — no
+ * WebAuthn prompt, no RPC, no relayer. `sentAmount`/`sentTo` are captured on
+ * the mock SAC transfer call so a caller (or a test) can assert on them
+ * without depending on the fake XDR string. */
+export function createMockWallet(network: Network): {
+  wallet: VellarWallet;
+  submittedHashes: string[];
+} {
+  const submittedHashes: string[] = [];
+
+  const kit: PasskeyKitLike = {
+    async createWallet(_app, _user) {
+      return {
+        keyIdBase64: "mock-key-id",
+        contractId: "CMOCKSMARTACCOUNTXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+        signedTx: "mock-create-tx",
+      };
+    },
+    async connectWallet() {
+      return { keyIdBase64: "mock-key-id", contractId: "CMOCKSMARTACCOUNTXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX" };
+    },
+    async sign(tx: unknown) {
+      return typeof tx === "string" ? `signed:${tx}` : "signed:mock-payment-tx";
+    },
+  };
+
+  const backend: WalletBackend & {
+    submitTransaction(input: { signedXdr: string; network: Network }): Promise<{ hash: string }>;
+  } = {
+    async submitWalletCreation() {
+      return { sessionId: "mock-session-id" };
+    },
+    async lookupContractId() {
+      return undefined;
+    },
+    async submitTransaction() {
+      const hash = `mockhash${submittedHashes.length + 1}`.padEnd(16, "0");
+      submittedHashes.push(hash);
+      return { hash };
+    },
+  };
+
+  const sac: SacClientLike = {
+    getSACClient(tokenContractId: string): TokenContractClientLike {
+      return {
+        async transfer() {
+          // Simulated build; the actual "on-chain effect" is just returning a
+          // placeholder XDR-shaped payload for kit.sign to sign.
+          return `unsigned-transfer-tx:${tokenContractId}`;
+        },
+      };
+    },
+  };
+
+  const wallet = createVellarWallet({
+    network,
+    appName: "cli-send-payment example",
+    kit,
+    backend,
+    sac,
+    isValidAddress: (address: string) => address.length > 0 && !address.includes(" "),
+  });
+
+  return { wallet, submittedHashes };
+}
+
+/** Runs the full create-then-pay sequence for one CLI invocation, returning
+ * the submitted transaction hash. Separated from `main` so it's directly
+ * testable without touching `process.argv`. */
+export async function runSendPayment(
+  args: CliArgs,
+  wallet: VellarWallet,
+  log: (line: string) => void = console.log,
+): Promise<{ hash: string }> {
+  const token = MOCK_TOKENS[args.token.toUpperCase()];
+  if (!token) {
+    throw new Error(
+      `Unknown --token "${args.token}". Known tokens: ${Object.keys(MOCK_TOKENS).join(", ")}`,
+    );
+  }
+
+  log(`Creating a mock wallet...`);
+  const session = await wallet.create({ username: "cli-test-user" });
+  log(`Wallet created: ${session.accountId}`);
+
+  const amount = parseTokenAmountLoose(args.amount, token.decimals);
+  log(`Sending ${args.amount} ${token.symbol} to ${args.to}...`);
+  const result = await wallet.pay({ to: args.to, amount, token });
+  log(`Payment submitted. Transaction hash: ${result.hash}`);
+
+  return result;
+}
+
+/** Local decimal->base-units conversion so this example has no import-time
+ * dependency ordering on payments.ts beyond the type-only imports above;
+ * mirrors src/payments.ts's parseTokenAmount rules (no silent rounding). */
+function parseTokenAmountLoose(input: string, decimals: number): bigint {
+  const trimmed = input.trim();
+  if (!/^\d+(\.\d+)?$/.test(trimmed)) {
+    throw new Error(`"${input}" is not a valid amount`);
+  }
+  const [whole = "0", fraction = ""] = trimmed.split(".");
+  if (fraction.length > decimals) {
+    throw new Error(`Amount supports at most ${decimals} decimal places`);
+  }
+  return BigInt(whole) * 10n ** BigInt(decimals) + BigInt(fraction.padEnd(decimals, "0") || "0");
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const { wallet } = createMockWallet("testnet");
+  await runSendPayment(args, wallet);
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main().catch((err) => {
+    console.error(`Error: ${(err as Error).message}`);
+    process.exitCode = 1;
+  });
+}

--- a/contrib/examples/compare-addresses/README.md
+++ b/contrib/examples/compare-addresses/README.md
@@ -1,0 +1,26 @@
+# Compare two Stellar addresses for equality
+
+Compares two address strings for equality after normalizing case. `null` or
+`undefined` inputs return `false` rather than throwing.
+
+## Examples
+
+| A | B | Result |
+| --- | --- | --- |
+| `GABC123DEF456` | `GABC123DEF456` | `true` |
+| `GABC123DEF456` | `gabc123def456` | `true` (case-insensitive) |
+| `GABC123DEF456` | `GDIFFERENT789` | `false` |
+| `null` | `GABC123DEF456` | `false` |
+| `undefined` | `undefined` | `false` |
+
+## Run it
+
+```sh
+npx tsx compare-addresses.ts
+```
+
+## Tests
+
+```sh
+npx vitest run contrib/examples/compare-addresses
+```

--- a/contrib/examples/compare-addresses/compare-addresses.test.ts
+++ b/contrib/examples/compare-addresses/compare-addresses.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+import { addressesEqual } from "./compare-addresses";
+
+describe("addressesEqual", () => {
+  it("returns true for identical addresses", () => {
+    expect(addressesEqual("GABC123DEF456", "GABC123DEF456")).toBe(true);
+  });
+
+  it("is case-insensitive", () => {
+    expect(addressesEqual("GABC123DEF456", "gabc123def456")).toBe(true);
+  });
+
+  it("returns false for different addresses", () => {
+    expect(addressesEqual("GABC123DEF456", "GDIFFERENT789")).toBe(false);
+  });
+
+  it("returns false rather than throwing when either input is null", () => {
+    expect(addressesEqual(null, "GABC123DEF456")).toBe(false);
+    expect(addressesEqual("GABC123DEF456", null)).toBe(false);
+  });
+
+  it("returns false rather than throwing when either input is undefined", () => {
+    expect(addressesEqual(undefined, "GABC123DEF456")).toBe(false);
+    expect(addressesEqual(undefined, undefined)).toBe(false);
+  });
+});

--- a/contrib/examples/compare-addresses/compare-addresses.ts
+++ b/contrib/examples/compare-addresses/compare-addresses.ts
@@ -1,0 +1,30 @@
+// Example: compare two Stellar address strings for equality after
+// normalizing case (Stellar strkey addresses are conventionally uppercase,
+// but comparisons should be case-insensitive against a source that isn't).
+//
+// Run with: npx tsx compare-addresses.ts
+
+export function addressesEqual(a: string | null | undefined, b: string | null | undefined): boolean {
+  if (a == null || b == null) {
+    return false;
+  }
+  return a.toUpperCase() === b.toUpperCase();
+}
+
+function main() {
+  const examples: [string | null | undefined, string | null | undefined][] = [
+    ["GABC123DEF456", "GABC123DEF456"],
+    ["GABC123DEF456", "gabc123def456"],
+    ["GABC123DEF456", "GDIFFERENT789"],
+    [null, "GABC123DEF456"],
+    [undefined, undefined],
+  ];
+
+  for (const [a, b] of examples) {
+    console.log(`${a ?? "(null)"} === ${b ?? "(null)"}  ->  ${addressesEqual(a, b)}`);
+  }
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main();
+}

--- a/contrib/examples/compare-policies/README.md
+++ b/contrib/examples/compare-policies/README.md
@@ -1,0 +1,34 @@
+# Compare two policy definitions for equality
+
+`policiesEqual(a, b)` compares two `PolicyDefinition` objects field by field
+and reports whether they describe the same policy. Array-valued fields
+(`owners`, `allowlistedContracts`) are compared **as sets** — two policies
+listing the same owners in a different order are still equal.
+
+## Example input pairs
+
+| `a` | `b` | `policiesEqual(a, b)` | Why |
+| --- | --- | --- | --- |
+| `owners: ["GALICE", "GBOB"]` | `owners: ["GBOB", "GALICE"]` (all else identical) | `true` | Same owners, different order |
+| `threshold: 2` | `threshold: 1` (all else identical) | `false` | Different threshold |
+| `owners: ["GALICE", "GBOB"]` | `owners: ["GALICE", "GCAROL"]` | `false` | Different owner set, not just reordered |
+| `spendingLimits: { dailyXlm: "500" }` | `spendingLimits: { dailyXlm: "999" }` | `false` | Different spending limit |
+
+## Run it
+
+```sh
+npx tsx compare-policies.ts
+```
+
+Expected output:
+
+```
+policyA vs policyB (owners reordered): true
+policyA vs policyC (different threshold): false
+```
+
+## Tests
+
+```sh
+npx vitest run contrib/examples/compare-policies
+```

--- a/contrib/examples/compare-policies/compare-policies.test.ts
+++ b/contrib/examples/compare-policies/compare-policies.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest";
+import { policiesEqual } from "./compare-policies";
+import type { PolicyDefinition } from "../../../src/types";
+
+const base: PolicyDefinition = {
+  version: "1",
+  type: "spending-limit",
+  owners: ["GALICE", "GBOB"],
+  threshold: 2,
+  spendingLimits: { dailyXlm: "500", perTxXlm: "200" },
+  allowlistedContracts: ["CFIRST", "CSECOND"],
+  timelocks: { adminActionDelaySeconds: 3600 },
+};
+
+describe("policiesEqual", () => {
+  it("returns true for identical policies", () => {
+    expect(policiesEqual(base, { ...base })).toBe(true);
+  });
+
+  it("ignores owners order", () => {
+    const reordered = { ...base, owners: ["GBOB", "GALICE"] };
+    expect(policiesEqual(base, reordered)).toBe(true);
+  });
+
+  it("ignores allowlistedContracts order", () => {
+    const reordered = { ...base, allowlistedContracts: ["CSECOND", "CFIRST"] };
+    expect(policiesEqual(base, reordered)).toBe(true);
+  });
+
+  it("detects a different threshold", () => {
+    expect(policiesEqual(base, { ...base, threshold: 1 })).toBe(false);
+  });
+
+  it("detects a different owners set (not just reordered)", () => {
+    expect(policiesEqual(base, { ...base, owners: ["GALICE", "GCAROL"] })).toBe(false);
+  });
+
+  it("detects a different owners count", () => {
+    expect(policiesEqual(base, { ...base, owners: ["GALICE", "GBOB", "GCAROL"] })).toBe(false);
+  });
+
+  it("detects a different spendingLimits value", () => {
+    expect(
+      policiesEqual(base, { ...base, spendingLimits: { dailyXlm: "999", perTxXlm: "200" } }),
+    ).toBe(false);
+  });
+
+  it("detects a different timelocks value", () => {
+    expect(policiesEqual(base, { ...base, timelocks: { adminActionDelaySeconds: 60 } })).toBe(false);
+  });
+
+  it("treats missing optional fields on both sides as equal", () => {
+    const minimalA: PolicyDefinition = { version: "1", type: "none", owners: ["GALICE"] };
+    const minimalB: PolicyDefinition = { version: "1", type: "none", owners: ["GALICE"] };
+    expect(policiesEqual(minimalA, minimalB)).toBe(true);
+  });
+});

--- a/contrib/examples/compare-policies/compare-policies.ts
+++ b/contrib/examples/compare-policies/compare-policies.ts
@@ -1,0 +1,73 @@
+// Example: compare two PolicyDefinition objects field by field and report
+// whether they are equivalent, ignoring the order of array-valued fields
+// (owners, allowlistedContracts) — two policies listing the same owners in
+// a different order are still the same policy.
+//
+// Run with: npx tsx compare-policies.ts
+
+import type { PolicyDefinition } from "../../../src/types";
+
+function sameStringSet(a: string[] = [], b: string[] = []): boolean {
+  if (a.length !== b.length) return false;
+  const sortedA = [...a].sort();
+  const sortedB = [...b].sort();
+  return sortedA.every((value, i) => value === sortedB[i]);
+}
+
+function sameSpendingLimits(
+  a?: PolicyDefinition["spendingLimits"],
+  b?: PolicyDefinition["spendingLimits"],
+): boolean {
+  return (a?.dailyXlm ?? undefined) === (b?.dailyXlm ?? undefined)
+    && (a?.perTxXlm ?? undefined) === (b?.perTxXlm ?? undefined);
+}
+
+function sameTimelocks(a?: PolicyDefinition["timelocks"], b?: PolicyDefinition["timelocks"]): boolean {
+  return (a?.adminActionDelaySeconds ?? undefined) === (b?.adminActionDelaySeconds ?? undefined);
+}
+
+/**
+ * Reports whether `a` and `b` describe the same policy: every scalar field
+ * matches exactly, and `owners`/`allowlistedContracts` match as sets (order
+ * doesn't matter, duplicates and length do).
+ */
+export function policiesEqual(a: PolicyDefinition, b: PolicyDefinition): boolean {
+  return (
+    a.version === b.version &&
+    a.type === b.type &&
+    a.threshold === b.threshold &&
+    sameStringSet(a.owners, b.owners) &&
+    sameStringSet(a.allowlistedContracts, b.allowlistedContracts) &&
+    sameSpendingLimits(a.spendingLimits, b.spendingLimits) &&
+    sameTimelocks(a.timelocks, b.timelocks)
+  );
+}
+
+function main() {
+  const policyA: PolicyDefinition = {
+    version: "1",
+    type: "spending-limit",
+    owners: ["GALICE", "GBOB"],
+    threshold: 2,
+    spendingLimits: { dailyXlm: "500", perTxXlm: "200" },
+  };
+
+  // Same policy, owners listed in the opposite order — still equal.
+  const policyB: PolicyDefinition = {
+    ...policyA,
+    owners: ["GBOB", "GALICE"],
+  };
+
+  // A genuinely different policy — different threshold.
+  const policyC: PolicyDefinition = {
+    ...policyA,
+    threshold: 1,
+  };
+
+  console.log(`policyA vs policyB (owners reordered): ${policiesEqual(policyA, policyB)}`);
+  console.log(`policyA vs policyC (different threshold): ${policiesEqual(policyA, policyC)}`);
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main();
+}

--- a/contrib/examples/config-validator/README.md
+++ b/contrib/examples/config-validator/README.md
@@ -1,0 +1,53 @@
+# Config validation helper
+
+`validateConfig(config, schema)` checks a plain configuration object against
+a schema of required field names and expected types (`string` | `number` |
+`boolean` | `object` | `array`). Returns a list of human-readable error
+messages instead of throwing on the first problem, so every issue can be
+shown at once.
+
+## Usage
+
+```ts
+import { validateConfig, type FieldSchema } from "./config-validator";
+
+const schema: FieldSchema[] = [
+  { name: "network", type: "string" },
+  { name: "enableX402", type: "boolean" },
+];
+
+validateConfig({ network: "testnet", enableX402: true }, schema);
+// -> [] (valid)
+
+validateConfig({ enableX402: "yes" }, schema);
+// -> [
+//   'Missing required field "network"',
+//   'Field "enableX402" expected type "boolean", got "string"',
+// ]
+```
+
+Fields present in the config but not listed in the schema are ignored —
+this validates required shape, not a strict allowlist.
+
+## Run it
+
+```sh
+npx tsx config-validator.ts
+```
+
+Expected output:
+
+```
+Valid config errors: []
+Broken config errors: [
+  'Missing required field "appName"',
+  'Field "rpcUrl" expected type "string", got "number"',
+  'Field "enableX402" expected type "boolean", got "string"'
+]
+```
+
+## Tests
+
+```sh
+npx vitest run contrib/examples/config-validator
+```

--- a/contrib/examples/config-validator/config-validator.test.ts
+++ b/contrib/examples/config-validator/config-validator.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+import { validateConfig, type FieldSchema } from "./config-validator";
+
+const schema: FieldSchema[] = [
+  { name: "network", type: "string" },
+  { name: "appName", type: "string" },
+  { name: "rpcUrl", type: "string" },
+  { name: "enableX402", type: "boolean" },
+];
+
+describe("validateConfig", () => {
+  it("returns no errors for a valid config", () => {
+    const config = { network: "testnet", appName: "My App", rpcUrl: "https://rpc.example", enableX402: true };
+    expect(validateConfig(config, schema)).toEqual([]);
+  });
+
+  it("reports a missing field", () => {
+    const config = { network: "testnet", rpcUrl: "https://rpc.example", enableX402: true };
+    expect(validateConfig(config, schema)).toEqual(['Missing required field "appName"']);
+  });
+
+  it("reports a type mismatch", () => {
+    const config = { network: "testnet", appName: "My App", rpcUrl: "https://rpc.example", enableX402: "yes" };
+    expect(validateConfig(config, schema)).toEqual([
+      'Field "enableX402" expected type "boolean", got "string"',
+    ]);
+  });
+
+  it("reports every issue, not just the first", () => {
+    const config = { network: "testnet", rpcUrl: 12345, enableX402: "yes" };
+    const errors = validateConfig(config, schema);
+    expect(errors).toEqual([
+      'Missing required field "appName"',
+      'Field "rpcUrl" expected type "string", got "number"',
+      'Field "enableX402" expected type "boolean", got "string"',
+    ]);
+  });
+
+  it("distinguishes array from object", () => {
+    const errors = validateConfig({ tags: [] }, [{ name: "tags", type: "object" }]);
+    expect(errors).toEqual(['Field "tags" expected type "object", got "array"']);
+  });
+
+  it("ignores fields in config that are not in the schema", () => {
+    const config = { network: "testnet", appName: "x", rpcUrl: "y", enableX402: false, extra: "unchecked" };
+    expect(validateConfig(config, schema)).toEqual([]);
+  });
+});

--- a/contrib/examples/config-validator/config-validator.ts
+++ b/contrib/examples/config-validator/config-validator.ts
@@ -1,0 +1,60 @@
+// Example: validate a plain configuration object against a small schema of
+// required field names and expected types, collecting every problem instead
+// of throwing on the first one.
+//
+// Run with: npx tsx config-validator.ts
+
+export type FieldType = "string" | "number" | "boolean" | "object" | "array";
+
+export interface FieldSchema {
+  name: string;
+  type: FieldType;
+}
+
+function actualType(value: unknown): string {
+  if (Array.isArray(value)) return "array";
+  if (value === null) return "null";
+  return typeof value;
+}
+
+/**
+ * Validates `config` against `schema`: every listed field must be present
+ * and match the declared type. Returns a list of human-readable error
+ * messages — empty when the config is valid. Every issue is reported, not
+ * just the first, so a caller can show a user all their mistakes at once.
+ */
+export function validateConfig(config: Record<string, unknown>, schema: FieldSchema[]): string[] {
+  const errors: string[] = [];
+
+  for (const field of schema) {
+    if (!(field.name in config)) {
+      errors.push(`Missing required field "${field.name}"`);
+      continue;
+    }
+    const found = actualType(config[field.name]);
+    if (found !== field.type) {
+      errors.push(`Field "${field.name}" expected type "${field.type}", got "${found}"`);
+    }
+  }
+
+  return errors;
+}
+
+function main() {
+  const schema: FieldSchema[] = [
+    { name: "network", type: "string" },
+    { name: "appName", type: "string" },
+    { name: "rpcUrl", type: "string" },
+    { name: "enableX402", type: "boolean" },
+  ];
+
+  const validConfig = { network: "testnet", appName: "My App", rpcUrl: "https://rpc.example", enableX402: true };
+  const brokenConfig = { network: "testnet", rpcUrl: 12345, enableX402: "yes" };
+
+  console.log("Valid config errors:", validateConfig(validConfig, schema));
+  console.log("Broken config errors:", validateConfig(brokenConfig, schema));
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main();
+}

--- a/contrib/examples/connect-wallet-mock/README.md
+++ b/contrib/examples/connect-wallet-mock/README.md
@@ -1,0 +1,34 @@
+# Connect to an existing wallet by keyId (mock)
+
+Demonstrates the `connect()` flow shape: look up a wallet's `contractId` from
+its passkey `keyId` via a backend, without a real WebAuthn prompt or network
+call. Uses a small in-file `MockWalletBackend` seeded with one known `keyId`.
+
+## What it shows
+
+- A known `keyId` resolves to a session (`{ accountId, keyId, connected }`).
+- An unknown `keyId` produces a clear, catchable error instead of a raw
+  `undefined` or an unhandled crash.
+
+## Run it
+
+```sh
+npx tsx connect-wallet.ts
+```
+
+Expected output:
+
+```
+Connected: {
+  accountId: 'CABC123KNOWNWALLETCONTRACTADDRESSXXXXXXXXXXXXXXXXXXXXXXXX',
+  keyId: 'keyid-known-abc123',
+  connected: true
+}
+Could not connect: connectWallet: no wallet is registered for keyId "keyid-unknown-does-not-exist"
+```
+
+## Tests
+
+```sh
+npx vitest run contrib/examples/connect-wallet-mock
+```

--- a/contrib/examples/connect-wallet-mock/connect-wallet.test.ts
+++ b/contrib/examples/connect-wallet-mock/connect-wallet.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+import { MockWalletBackend, connectWallet } from "./connect-wallet";
+
+describe("connectWallet (mock backend)", () => {
+  const backend = new MockWalletBackend({
+    "keyid-known-abc123": { contractId: "CABC123" },
+  });
+
+  it("resolves a known keyId to its session", async () => {
+    await expect(connectWallet(backend, "keyid-known-abc123")).resolves.toEqual({
+      accountId: "CABC123",
+      keyId: "keyid-known-abc123",
+      connected: true,
+    });
+  });
+
+  it("throws a clear error for an unknown keyId", async () => {
+    await expect(connectWallet(backend, "nope")).rejects.toThrow(
+      'no wallet is registered for keyId "nope"',
+    );
+  });
+});

--- a/contrib/examples/connect-wallet-mock/connect-wallet.ts
+++ b/contrib/examples/connect-wallet-mock/connect-wallet.ts
@@ -1,0 +1,62 @@
+// Example: connect to an existing wallet by keyId against a small in-file
+// mock backend, and print the resolved session.
+//
+// Run with: npx tsx connect-wallet.ts
+
+export interface MockBackendRecord {
+  contractId: string;
+}
+
+/** A tiny stand-in for the real WalletBackend.lookupContractId round trip. */
+export class MockWalletBackend {
+  #byKeyId: Map<string, MockBackendRecord>;
+
+  constructor(seed: Record<string, MockBackendRecord>) {
+    this.#byKeyId = new Map(Object.entries(seed));
+  }
+
+  async lookupContractId(keyId: string): Promise<MockBackendRecord | undefined> {
+    return this.#byKeyId.get(keyId);
+  }
+}
+
+export interface ConnectResult {
+  accountId: string;
+  keyId: string;
+  connected: true;
+}
+
+export async function connectWallet(
+  backend: MockWalletBackend,
+  keyId: string,
+): Promise<ConnectResult> {
+  const record = await backend.lookupContractId(keyId);
+  if (!record) {
+    throw new Error(`connectWallet: no wallet is registered for keyId "${keyId}"`);
+  }
+  return { accountId: record.contractId, keyId, connected: true };
+}
+
+async function main() {
+  const backend = new MockWalletBackend({
+    "keyid-known-abc123": { contractId: "CABC123KNOWNWALLETCONTRACTADDRESSXXXXXXXXXXXXXXXXXXXXXXXX" },
+  });
+
+  // Known keyId: resolves and prints the session.
+  const session = await connectWallet(backend, "keyid-known-abc123");
+  console.log("Connected:", session);
+
+  // Unknown keyId: caught and reported clearly, not a raw stack trace.
+  const unknownKeyId = "keyid-unknown-does-not-exist";
+  try {
+    await connectWallet(backend, unknownKeyId);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    console.log(`Could not connect: ${message}`);
+  }
+}
+
+// Only run when executed directly (not when imported by the test file).
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main();
+}

--- a/contrib/examples/create-wallet-mock/README.md
+++ b/contrib/examples/create-wallet-mock/README.md
@@ -1,0 +1,31 @@
+# Create a wallet with a mock passkey kit
+
+Calls the real `createVellarWallet()` from the SDK with a small in-file mock
+`PasskeyKit` and backend — no real WebAuthn prompt, no network call — and
+prints the resulting session's `accountId` and `keyId`.
+
+## How the mock works
+
+- `createMockPasskeyKit()` returns fixed, deterministic identifiers from
+  `createWallet()` instead of prompting a real passkey ceremony.
+- `createMockBackend()` accepts the deployment and hands back a session id
+  without touching a real gateway.
+
+## Run it
+
+```sh
+npx tsx create-wallet.ts
+```
+
+Expected output:
+
+```
+accountId: CMOCKWALLETCONTRACTADDRESSXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+keyId:     mock-keyid-example-user
+```
+
+## Tests
+
+```sh
+npx vitest run contrib/examples/create-wallet-mock
+```

--- a/contrib/examples/create-wallet-mock/create-wallet.test.ts
+++ b/contrib/examples/create-wallet-mock/create-wallet.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+import { createVellarWallet } from "../../../src/index";
+import { createMockBackend, createMockPasskeyKit } from "./create-wallet";
+
+describe("createVellarWallet with a mocked passkey kit", () => {
+  it("creates a wallet and returns a session with accountId and keyId", async () => {
+    const wallet = createVellarWallet({
+      network: "testnet",
+      appName: "vellar-example-test",
+      kit: createMockPasskeyKit(),
+      backend: createMockBackend(),
+      sac: { getSACClient: () => ({ transfer: async () => "mock-tx" }) },
+      isValidAddress: () => true,
+    });
+
+    const session = await wallet.create({ username: "Test User" });
+
+    expect(session.accountId).toBe(
+      "CMOCKWALLETCONTRACTADDRESSXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+    );
+    expect(session.keyId).toBe("mock-keyid-test-user");
+    expect(session.connected).toBe(true);
+    expect(session.network).toBe("testnet");
+  });
+});

--- a/contrib/examples/create-wallet-mock/create-wallet.ts
+++ b/contrib/examples/create-wallet-mock/create-wallet.ts
@@ -1,0 +1,66 @@
+// Example: call the real createVellarWallet() with a small in-file mocked
+// PasskeyKit and backend (no real WebAuthn prompt, no network call), and
+// print the resulting session's accountId and keyId.
+//
+// Run with: npx tsx create-wallet.ts
+
+import { createVellarWallet, type PasskeyKitLike, type WalletBackend } from "../../../src/index";
+
+/** A minimal PasskeyKit stand-in: "creates" a wallet by returning fixed,
+ * deterministic identifiers instead of prompting WebAuthn. */
+function createMockPasskeyKit(): PasskeyKitLike {
+  return {
+    async createWallet(_app: string, user: string) {
+      return {
+        keyIdBase64: `mock-keyid-${user.toLowerCase().replace(/\s+/g, "-")}`,
+        contractId: "CMOCKWALLETCONTRACTADDRESSXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+        signedTx: "mock-signed-deployment-tx",
+      };
+    },
+    async connectWallet() {
+      throw new Error("mock kit: connectWallet is not used by this example");
+    },
+    async sign(tx: unknown) {
+      return tx;
+    },
+  };
+}
+
+/** A minimal backend stand-in: accepts the deployment and hands back a
+ * session id, without ever touching a real gateway. */
+function createMockBackend(): WalletBackend & {
+  submitTransaction(input: { signedXdr: string; network: "testnet" | "mainnet" }): Promise<{ hash: string }>;
+} {
+  return {
+    async submitWalletCreation() {
+      return { sessionId: "mock-session-id" };
+    },
+    async lookupContractId() {
+      return undefined;
+    },
+    async submitTransaction() {
+      return { hash: "mock-tx-hash" };
+    },
+  };
+}
+
+async function main() {
+  const wallet = createVellarWallet({
+    network: "testnet",
+    appName: "vellar-example",
+    kit: createMockPasskeyKit(),
+    backend: createMockBackend(),
+    sac: { getSACClient: () => ({ transfer: async () => "mock-tx" }) },
+    isValidAddress: () => true,
+  });
+
+  const session = await wallet.create({ username: "Example User" });
+  console.log("accountId:", session.accountId);
+  console.log("keyId:    ", session.keyId);
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main();
+}
+
+export { createMockPasskeyKit, createMockBackend };

--- a/contrib/examples/debounce-refresh/README.md
+++ b/contrib/examples/debounce-refresh/README.md
@@ -1,0 +1,35 @@
+# Debounce a balance refresh call
+
+Debounces repeated calls to a mock `refreshBalance` function so only the
+last call in a burst actually runs, after the burst goes quiet for
+`delayMs`.
+
+## Where this helps in a wallet UI
+
+A balance display that refetches on every relevant event (a poll tick, a
+websocket update, a tab regaining focus, a user hitting "refresh" a few
+times) can trigger a burst of near-simultaneous refresh calls. Debouncing
+collapses that burst into a single network request — instead of firing 5
+redundant balance reads for a single user action, only the last one runs.
+
+## Run it
+
+```sh
+npx tsx debounce-refresh.ts
+```
+
+Expected output (5 rapid calls collapse into 1 actual refresh):
+
+```
+Firing 5 rapid calls in a burst...
+refreshBalance called (call #1) for CACCOUNTSAMPLEADDRESSXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+Total actual refreshes: 1 (expected 1, despite 5 calls)
+```
+
+## Tests
+
+Uses vitest's fake timers, so the tests run instantly with no real delays:
+
+```sh
+npx vitest run contrib/examples/debounce-refresh
+```

--- a/contrib/examples/debounce-refresh/debounce-refresh.test.ts
+++ b/contrib/examples/debounce-refresh/debounce-refresh.test.ts
@@ -1,0 +1,50 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { debounce } from "./debounce-refresh";
+
+describe("debounce", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("collapses a burst of calls into a single call", () => {
+    const fn = vi.fn();
+    const debounced = debounce(fn, 100);
+
+    debounced();
+    debounced();
+    debounced();
+    expect(fn).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(100);
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  it("calls the wrapped function with the arguments from the last call in the burst", () => {
+    const fn = vi.fn();
+    const debounced = debounce(fn, 100);
+
+    debounced("first");
+    debounced("second");
+    debounced("third");
+    vi.advanceTimersByTime(100);
+
+    expect(fn).toHaveBeenCalledExactlyOnceWith("third");
+  });
+
+  it("fires again for a call after the debounce window has elapsed", () => {
+    const fn = vi.fn();
+    const debounced = debounce(fn, 100);
+
+    debounced();
+    vi.advanceTimersByTime(100);
+    expect(fn).toHaveBeenCalledTimes(1);
+
+    debounced();
+    vi.advanceTimersByTime(100);
+    expect(fn).toHaveBeenCalledTimes(2);
+  });
+});

--- a/contrib/examples/debounce-refresh/debounce-refresh.ts
+++ b/contrib/examples/debounce-refresh/debounce-refresh.ts
@@ -1,0 +1,42 @@
+// Example: debounce repeated calls to a mock refreshBalance function so
+// only the last call in a burst actually runs.
+//
+// Run with: npx tsx debounce-refresh.ts
+
+export type DebouncedFn<Args extends unknown[]> = (...args: Args) => void;
+
+/** Wraps `fn` so that a burst of calls within `delayMs` of each other
+ * collapses into a single call — the last one, after the burst goes quiet. */
+export function debounce<Args extends unknown[]>(
+  fn: (...args: Args) => void,
+  delayMs: number,
+): DebouncedFn<Args> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  return (...args: Args) => {
+    clearTimeout(timer);
+    timer = setTimeout(() => fn(...args), delayMs);
+  };
+}
+
+async function main() {
+  let refreshCount = 0;
+  const refreshBalance = (accountId: string) => {
+    refreshCount++;
+    console.log(`refreshBalance called (call #${refreshCount}) for ${accountId}`);
+  };
+
+  const debouncedRefresh = debounce(refreshBalance, 100);
+
+  console.log("Firing 5 rapid calls in a burst...");
+  for (let i = 0; i < 5; i++) {
+    debouncedRefresh("CACCOUNTSAMPLEADDRESSXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX");
+  }
+
+  // Wait past the debounce window to let the last (and only) call fire.
+  await new Promise((resolve) => setTimeout(resolve, 200));
+  console.log(`Total actual refreshes: ${refreshCount} (expected 1, despite 5 calls)`);
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main();
+}

--- a/contrib/examples/decode-payment-required/README.md
+++ b/contrib/examples/decode-payment-required/README.md
@@ -1,0 +1,48 @@
+# Decode a mock PAYMENT-REQUIRED header
+
+Decodes a base64-encoded JSON string as a mock x402 `PAYMENT-REQUIRED`
+header value. x402 v2 carries payment requirements in the 402 response's
+`PAYMENT-REQUIRED` header as base64 JSON — see `vellar-sdk`'s
+`decodePaymentRequired` in `src/x402-client.ts` (this example reimplements
+the same base64-decode step, standalone, for a raw string instead of a
+`Response` object).
+
+## Example
+
+Encoded value:
+
+```
+eyJ4NDAyVmVyc2lvbiI6MiwiYWNjZXB0cyI6W3sic2NoZW1lIjoiZXhhY3QiLCJuZXR3b3JrIjoic3RlbGxhcjp0ZXN0bmV0IiwiYXNzZXQiOiJDVVNEQyIsImFtb3VudCI6IjI1MDAwMDAiLCJwYXlUbyI6IkNQQVlUTyJ9XX0=
+```
+
+Decoded output:
+
+```json
+{
+  "x402Version": 2,
+  "accepts": [
+    {
+      "scheme": "exact",
+      "network": "stellar:testnet",
+      "asset": "CUSDC",
+      "amount": "2500000",
+      "payTo": "CPAYTO"
+    }
+  ]
+}
+```
+
+## Run it
+
+```sh
+npx tsx decode-payment-required.ts <base64String>
+```
+
+A string that isn't valid base64, or that decodes to something that isn't
+valid JSON, prints a clear error instead of a raw exception.
+
+## Tests
+
+```sh
+npx vitest run contrib/examples/decode-payment-required
+```

--- a/contrib/examples/decode-payment-required/decode-payment-required.test.ts
+++ b/contrib/examples/decode-payment-required/decode-payment-required.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+import { decodePaymentRequiredHeader } from "./decode-payment-required";
+
+describe("decodePaymentRequiredHeader", () => {
+  it("decodes a valid base64 JSON payload", () => {
+    const sample = { x402Version: 2, accepts: [{ scheme: "exact" }] };
+    const encoded = btoa(JSON.stringify(sample));
+    expect(decodePaymentRequiredHeader(encoded)).toEqual(sample);
+  });
+
+  it("throws a clear error for a string that is not valid base64", () => {
+    expect(() => decodePaymentRequiredHeader("not-valid-base64!!!")).toThrow(
+      /not valid base64/,
+    );
+  });
+
+  it("throws a clear error when the decoded content is not valid JSON", () => {
+    const notJson = btoa("this is not json");
+    expect(() => decodePaymentRequiredHeader(notJson)).toThrow(/not valid JSON/);
+  });
+});

--- a/contrib/examples/decode-payment-required/decode-payment-required.ts
+++ b/contrib/examples/decode-payment-required/decode-payment-required.ts
@@ -1,0 +1,49 @@
+// Example: decode a base64-encoded JSON string as a mock x402
+// PAYMENT-REQUIRED header value (x402 v2 carries payment requirements this
+// way — see vellar-sdk's src/x402-client.ts decodePaymentRequired).
+//
+// Run with: npx tsx decode-payment-required.ts <base64String>
+
+// Browser-safe base64 helpers, matching src/x402-client.ts's utf8ToBase64 /
+// base64ToUtf8 (this package targets bundlers/browsers, no Buffer).
+function base64ToUtf8(b64: string): string {
+  const bin = atob(b64);
+  const bytes = new Uint8Array(bin.length);
+  for (let i = 0; i < bin.length; i++) bytes[i] = bin.charCodeAt(i);
+  return new TextDecoder().decode(bytes);
+}
+
+export function decodePaymentRequiredHeader(base64: string): unknown {
+  let json: string;
+  try {
+    json = base64ToUtf8(base64);
+  } catch {
+    throw new Error(`"${base64}" is not valid base64`);
+  }
+  try {
+    return JSON.parse(json);
+  } catch {
+    throw new Error(`Decoded base64 is not valid JSON: ${json}`);
+  }
+}
+
+function main() {
+  const base64 = process.argv[2];
+  if (!base64) {
+    console.error("Usage: npx tsx decode-payment-required.ts <base64String>");
+    process.exitCode = 1;
+    return;
+  }
+
+  try {
+    const decoded = decodePaymentRequiredHeader(base64);
+    console.log(JSON.stringify(decoded, null, 2));
+  } catch (err) {
+    console.error(`Error: ${err instanceof Error ? err.message : String(err)}`);
+    process.exitCode = 1;
+  }
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main();
+}

--- a/contrib/examples/derive-public-key/README.md
+++ b/contrib/examples/derive-public-key/README.md
@@ -1,0 +1,34 @@
+# Derive a public key from a secret key
+
+Derives and prints the public key for a given ed25519 secret key using
+`@stellar/stellar-sdk`'s `Keypair.fromSecret`.
+
+> ⚠️ **Never use a real mainnet secret with this script.** Treat any secret
+> passed as a command-line argument as compromised — it's visible in your
+> shell history and process list. Testnet keys only.
+
+## Run it
+
+```sh
+npx tsx derive-public-key.ts <secretKey>
+```
+
+Example:
+
+```sh
+npx tsx derive-public-key.ts SBLSDBW6NOP5AA6P2M4ZOIRP3MCZEOGTHDFENNAMTES4TCSPJYR4MCT6
+# Public key: GAMKAXTK27YHSNPNEFBUGFJXKFQKSB32R6KVVNZP4V2DEWBIFPGPE4UG
+```
+
+A malformed secret key prints a clear error instead of a raw stack trace:
+
+```sh
+npx tsx derive-public-key.ts not-a-real-key
+# Error: "not-a-real-key" is not a valid ed25519 secret key (expected a 56-char string starting with "S")
+```
+
+## Tests
+
+```sh
+npx vitest run contrib/examples/derive-public-key
+```

--- a/contrib/examples/derive-public-key/derive-public-key.test.ts
+++ b/contrib/examples/derive-public-key/derive-public-key.test.ts
@@ -1,0 +1,20 @@
+import { Keypair } from "@stellar/stellar-sdk";
+import { describe, expect, it } from "vitest";
+import { derivePublicKey } from "./derive-public-key";
+
+describe("derivePublicKey", () => {
+  it("derives the matching public key for a valid secret", () => {
+    const keypair = Keypair.random();
+    expect(derivePublicKey(keypair.secret())).toBe(keypair.publicKey());
+  });
+
+  it("throws a clear error for a malformed secret key", () => {
+    expect(() => derivePublicKey("not-a-secret-key")).toThrow(
+      /is not a valid ed25519 secret key/,
+    );
+  });
+
+  it("throws a clear error for an empty string", () => {
+    expect(() => derivePublicKey("")).toThrow(/is not a valid ed25519 secret key/);
+  });
+});

--- a/contrib/examples/derive-public-key/derive-public-key.ts
+++ b/contrib/examples/derive-public-key/derive-public-key.ts
@@ -1,0 +1,42 @@
+// Example: derive and print the public key for a given ed25519 secret key.
+//
+// ⚠️  Never pass a real mainnet secret to this (or any) example script —
+// treat it as compromised the moment it touches a command line argument or
+// a script you didn't write yourself. Testnet keys only.
+//
+// Run with: npx tsx derive-public-key.ts <secretKey>
+
+import { Keypair } from "@stellar/stellar-sdk";
+
+export function derivePublicKey(secretKey: string): string {
+  let keypair: Keypair;
+  try {
+    keypair = Keypair.fromSecret(secretKey);
+  } catch {
+    throw new Error(
+      `"${secretKey}" is not a valid ed25519 secret key (expected a 56-char string starting with "S")`,
+    );
+  }
+  return keypair.publicKey();
+}
+
+function main() {
+  const secretKey = process.argv[2];
+  if (!secretKey) {
+    console.error("Usage: npx tsx derive-public-key.ts <secretKey>");
+    process.exitCode = 1;
+    return;
+  }
+
+  try {
+    console.log("Public key:", derivePublicKey(secretKey));
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    console.error(`Error: ${message}`);
+    process.exitCode = 1;
+  }
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main();
+}

--- a/contrib/examples/encode-payment-signature/README.md
+++ b/contrib/examples/encode-payment-signature/README.md
@@ -1,0 +1,34 @@
+# Encode a mock PAYMENT-SIGNATURE header
+
+Encodes a JSON object describing a payment as a base64 string suitable for
+an x402 `PAYMENT-SIGNATURE` request header — the same shape `vellar-sdk`'s
+`buildSignedPayment` produces internally (`src/x402-client.ts`):
+`{ x402Version, accepted, payload: { transaction } }`.
+
+## How a server decodes this value
+
+The server reverses the same encoding: base64-decode the header value to a
+UTF-8 string, then `JSON.parse` it. In this SDK that's
+`decodePaymentRequired`'s `base64ToUtf8` step in `src/x402-client.ts` (used
+there for the `PAYMENT-REQUIRED` header, but the same decode logic applies to
+`PAYMENT-SIGNATURE`).
+
+## Run it
+
+With the hardcoded sample payload:
+
+```sh
+npx tsx encode-payment-signature.ts
+```
+
+Or with your own JSON (as a single quoted argument):
+
+```sh
+npx tsx encode-payment-signature.ts '{"x402Version":2,"accepted":{"scheme":"exact"}}'
+```
+
+## Tests
+
+```sh
+npx vitest run contrib/examples/encode-payment-signature
+```

--- a/contrib/examples/encode-payment-signature/encode-payment-signature.test.ts
+++ b/contrib/examples/encode-payment-signature/encode-payment-signature.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from "vitest";
+import { encodePaymentSignature } from "./encode-payment-signature";
+
+describe("encodePaymentSignature", () => {
+  it("base64-encodes the JSON payload, decodable back to the original", () => {
+    const payload = { x402Version: 2, accepted: { scheme: "exact" } };
+    const encoded = encodePaymentSignature(payload);
+    expect(JSON.parse(atob(encoded))).toEqual(payload);
+  });
+
+  it("produces a stable encoding for the same input", () => {
+    const payload = { a: 1, b: "two" };
+    expect(encodePaymentSignature(payload)).toBe(encodePaymentSignature(payload));
+  });
+});

--- a/contrib/examples/encode-payment-signature/encode-payment-signature.ts
+++ b/contrib/examples/encode-payment-signature/encode-payment-signature.ts
@@ -1,0 +1,52 @@
+// Example: encode a small JSON object describing a payment as a base64
+// string suitable for an x402 PAYMENT-SIGNATURE request header (the shape
+// vellar-sdk's src/x402-client.ts buildSignedPayment produces).
+//
+// Run with: npx tsx encode-payment-signature.ts ['<json>']
+// If no argument is given, a hardcoded sample payload is used.
+
+// Browser-safe base64 helper, matching src/x402-client.ts's utf8ToBase64
+// (this package targets bundlers/browsers, no Buffer).
+function utf8ToBase64(s: string): string {
+  const bytes = new TextEncoder().encode(s);
+  let bin = "";
+  for (const b of bytes) bin += String.fromCharCode(b);
+  return btoa(bin);
+}
+
+export function encodePaymentSignature(payload: unknown): string {
+  return utf8ToBase64(JSON.stringify(payload));
+}
+
+const SAMPLE_PAYLOAD = {
+  x402Version: 2,
+  accepted: {
+    scheme: "exact",
+    network: "stellar:testnet",
+    asset: "CUSDCAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+    amount: "2500000",
+    payTo: "CPAYTOSAMPLEADDRESSXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+  },
+  payload: { transaction: "MOCKXDRTRANSACTIONBASE64==" },
+};
+
+function main() {
+  const jsonArg = process.argv[2];
+  let payload: unknown = SAMPLE_PAYLOAD;
+
+  if (jsonArg) {
+    try {
+      payload = JSON.parse(jsonArg);
+    } catch {
+      console.error(`Error: "${jsonArg}" is not valid JSON`);
+      process.exitCode = 1;
+      return;
+    }
+  }
+
+  console.log(encodePaymentSignature(payload));
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main();
+}

--- a/contrib/examples/exponential-backoff/README.md
+++ b/contrib/examples/exponential-backoff/README.md
@@ -1,0 +1,32 @@
+# exponential-backoff
+
+Self-contained example that computes increasing delay values for retry attempts
+using exponential backoff with a maximum cap.
+
+## Usage
+
+```ts
+import { computeBackoffDelay, backoffDelays } from "./index";
+
+const options = { baseDelay: 500, multiplier: 2, maxDelay: 5000 };
+
+console.log(computeBackoffDelay(options, 0)); // 500
+console.log(computeBackoffDelay(options, 3)); // 4000
+console.log(computeBackoffDelay(options, 5)); // 5000 (capped)
+
+for (const delay of backoffDelays(options)) {
+  console.log(delay);
+  if (delay === options.maxDelay) break;
+}
+```
+
+## API
+
+- `computeBackoffDelay(options, attempt)` — returns delay in ms for the given attempt.
+- `backoffDelays(options)` — infinite generator yielding delays for attempts 0, 1, 2, …
+
+## Options
+
+- `baseDelay: number` — base delay in ms for attempt 0.
+- `multiplier?: number` — multiplier applied per attempt. Default: 2.
+- `maxDelay: number` — ceiling for any returned delay.

--- a/contrib/examples/exponential-backoff/index.ts
+++ b/contrib/examples/exponential-backoff/index.ts
@@ -1,0 +1,41 @@
+/**
+ * Simple exponential backoff helper.
+ *
+ * Computes an increasing delay (in milliseconds) for successive retry attempts.
+ * Values grow by `multiplier` each attempt, but never exceed `maxDelay`.
+ *
+ * Delay formula:
+ *   delay = min(baseDelay * (multiplier ^ attempt), maxDelay)
+ */
+
+export interface ExponentialBackoffOptions {
+  /** Base delay in milliseconds for attempt 0. */
+  baseDelay: number;
+  /** Multiplier applied per attempt. Default: 2. */
+  multiplier?: number;
+  /** Maximum delay in milliseconds. Default: 30_000. */
+  maxDelay: number;
+}
+
+export function computeBackoffDelay(options: ExponentialBackoffOptions, attempt: number): number {
+  if (attempt < 0) throw new RangeError("attempt must be >= 0");
+
+  const { baseDelay, multiplier = 2, maxDelay } = options;
+  if (baseDelay < 0) throw new RangeError("baseDelay must be >= 0");
+  if (multiplier <= 0) throw new RangeError("multiplier must be > 0");
+  if (maxDelay < 0) throw new RangeError("maxDelay must be >= 0");
+
+  const raw = baseDelay * Math.pow(multiplier, attempt);
+  return Math.min(raw, maxDelay);
+}
+
+/**
+ * Convenience generator of delay values for increasing attempt counts.
+ */
+export function* backoffDelays(options: ExponentialBackoffOptions): Generator<number> {
+  let attempt = 0;
+  while (true) {
+    yield computeBackoffDelay(options, attempt);
+    attempt++;
+  }
+}

--- a/contrib/examples/exponential-backoff/test.ts
+++ b/contrib/examples/exponential-backoff/test.ts
@@ -1,0 +1,19 @@
+import { computeBackoffDelay, backoffDelays } from "./index";
+
+const options = { baseDelay: 500, multiplier: 2, maxDelay: 5000 };
+
+console.log("computed delays (ms):");
+for (const attempt of [0, 1, 2, 3, 4, 5, 6, 7, 8]) {
+  const d = computeBackoffDelay(options, attempt);
+  console.log(`  attempt ${attempt}: ${d}ms`);
+  if (attempt === 0) console.assert(d === 500, "base delay mismatch");
+  if (attempt === 3) console.assert(d === 4000, "4th delay mismatch");
+  if (attempt >= 4) console.assert(d === 5000, "expected capped at maxDelay");
+}
+
+const gen = backoffDelays(options);
+for (let i = 0; i < 8; i++) {
+  const d = gen.next().value;
+  console.assert(typeof d === "number", "generator should yield numbers");
+}
+console.log("exponential-backoff tests passed");

--- a/contrib/examples/faucet-helper/README.md
+++ b/contrib/examples/faucet-helper/README.md
@@ -1,0 +1,21 @@
+# faucet-helper
+
+Helper to request testnet funds from the public friendbot faucet.
+
+## Usage
+
+```ts
+import { requestTestnetFunds, FaucetError } from "./index";
+
+try {
+  const result = await requestTestnetFunds("GACC");
+  console.log(result.funded); // true
+} catch (err) {
+  console.error(err instanceof FaucetError ? err.message : err);
+}
+```
+
+## Notes
+
+- This only works against testnet.
+- Throws `FaucetError` on non-200 responses.

--- a/contrib/examples/faucet-helper/index.ts
+++ b/contrib/examples/faucet-helper/index.ts
@@ -1,0 +1,64 @@
+/**
+ * Helper to request testnet funds from the public friendbot faucet.
+ *
+ * Throws on non-200 responses with the faucet's error message.
+ */
+
+const FRIENDBOT_BASE = "https://friendbot.stellar.org";
+
+export interface FaucetResult {
+  funded: boolean;
+}
+
+export interface FaucetOptions {
+  /** Friendbot base URL. Default: https://friendbot.stellar.org */
+  baseUrl?: string;
+  /** Additional query params forwarded to friendbot (e.g. `{ asset: "USDC:..." }`). */
+  params?: Record<string, string>;
+}
+
+export class FaucetError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "FaucetError";
+  }
+}
+
+export async function requestTestnetFunds(accountId: string, opts?: FaucetOptions): Promise<FaucetResult> {
+  const baseUrl = opts?.baseUrl ?? FRIENDBOT_BASE;
+  const url = new URL(baseUrl);
+  url.searchParams.set("addr", accountId);
+  if (opts?.params) {
+    for (const [k, v] of Object.entries(opts.params)) {
+      url.searchParams.set(k, v);
+    }
+  }
+
+  let res: Response;
+  try {
+    res = await fetch(url.toString());
+  } catch (err) {
+    throw new FaucetError(err instanceof Error ? err.message : "network request failed");
+  }
+
+  if (!res.ok) {
+    let message = `Faucet request failed (${res.status})`;
+    try {
+      const body = (await res.json()) as { detail?: string; error?: string };
+      message = body.detail ?? body.error ?? message;
+    } catch {
+      // ignore JSON parse errors
+    }
+    throw new FaucetError(message);
+  }
+
+  // Best-effort parse: friendbot returns the funded account on success.
+  try {
+    const data = (await res.json()) as { account_id?: string };
+    if (!data.account_id) throw new Error("missing account_id");
+  } catch {
+    // If parsing fails, still treat 200 as success per friendbot behavior.
+  }
+
+  return { funded: true };
+}

--- a/contrib/examples/faucet-helper/test.ts
+++ b/contrib/examples/faucet-helper/test.ts
@@ -1,0 +1,20 @@
+import { requestTestnetFunds, FaucetError } from "./index";
+
+console.log("faucet-helper tests:");
+
+{
+  const result = await requestTestnetFunds("GACC");
+  console.assert(result.funded === true, "expected funded true on 200");
+  console.log("ok: success funded=true");
+}
+
+{
+  try {
+    await requestTestnetFunds("invalid", { baseUrl: "https://httpbin.org/status/500" });
+  } catch (err) {
+    console.assert(err instanceof FaucetError, "expected FaucetError on 500");
+    console.log("ok: non-200 throws FaucetError:", (err as FaucetError).message);
+  }
+}
+
+console.log("faucet-helper tests passed");

--- a/contrib/examples/fee-comparison-tool/README.md
+++ b/contrib/examples/fee-comparison-tool/README.md
@@ -1,0 +1,55 @@
+# Transaction fee comparison tool
+
+`recommendFeeOption(maxWaitSeconds)` compares estimated fees for a payment
+across `low`, `medium`, and `high` priority levels and recommends the
+**cheapest** option whose estimated confirmation time still meets a
+caller-supplied maximum wait time. If no priority level confirms within the
+deadline, it returns `recommended: null` with a reason rather than silently
+picking an option that would miss it.
+
+## Fee table
+
+A hardcoded sample fee and expected confirmation time per priority level
+(a real integration would read this from a fee oracle):
+
+| Priority | Fee (stroops) | Est. confirmation |
+| -------- | ------------- | ------------------ |
+| low      | 100           | 300s                |
+| medium   | 10,000        | 60s                 |
+| high     | 1,000,000     | 5s                  |
+
+## Usage
+
+```ts
+import { recommendFeeOption } from "./fee-comparison-tool";
+
+const result = recommendFeeOption(120); // must confirm within 120s
+
+result.recommended?.priority; // "medium" (low misses the 120s deadline)
+result.reasoning;
+// '"medium" is the cheapest of 2 option(s) confirming within 120s (10000 stroops, ~60s).'
+```
+
+## Run it
+
+```sh
+npx tsx fee-comparison-tool.ts
+```
+
+Expected output (for a sample 120s deadline):
+
+```
+Comparing fee options for a deadline of 120s:
+  low          100 stroops, ~300s (misses deadline)
+  medium     10000 stroops, ~60s
+  high     1000000 stroops, ~5s
+
+Recommendation: medium
+Reasoning: "medium" is the cheapest of 2 option(s) confirming within 120s (10000 stroops, ~60s).
+```
+
+## Tests
+
+```sh
+npx vitest run contrib/examples/fee-comparison-tool
+```

--- a/contrib/examples/fee-comparison-tool/fee-comparison-tool.test.ts
+++ b/contrib/examples/fee-comparison-tool/fee-comparison-tool.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+import { FEE_TABLE, recommendFeeOption } from "./fee-comparison-tool";
+
+describe("recommendFeeOption", () => {
+  it("recommends the cheapest option that meets a generous deadline", () => {
+    const result = recommendFeeOption(600);
+    expect(result.recommended?.priority).toBe("low");
+    expect(result.eligibleOptions.map((o) => o.priority)).toEqual(["low", "medium", "high"]);
+  });
+
+  it("excludes options that miss a tighter deadline and recommends the cheapest remaining one", () => {
+    const result = recommendFeeOption(120);
+    expect(result.eligibleOptions.map((o) => o.priority)).toEqual(["medium", "high"]);
+    expect(result.recommended?.priority).toBe("medium");
+  });
+
+  it("recommends the only option meeting a very tight deadline", () => {
+    const result = recommendFeeOption(10);
+    expect(result.eligibleOptions.map((o) => o.priority)).toEqual(["high"]);
+    expect(result.recommended?.priority).toBe("high");
+  });
+
+  it("returns a null recommendation with a reason when no option meets the deadline", () => {
+    const result = recommendFeeOption(1);
+    expect(result.recommended).toBeNull();
+    expect(result.eligibleOptions).toEqual([]);
+    expect(result.reasoning).toMatch(/No priority level confirms within 1s/);
+  });
+
+  it("does not mutate the default FEE_TABLE export", () => {
+    const before = FEE_TABLE.map((o) => ({ ...o }));
+    recommendFeeOption(60);
+    expect(FEE_TABLE).toEqual(before);
+  });
+
+  it("accepts a custom fee table instead of the default one", () => {
+    const customTable = [
+      { priority: "low" as const, feeStroops: 50n, estimatedConfirmationSeconds: 400 },
+      { priority: "high" as const, feeStroops: 900n, estimatedConfirmationSeconds: 20 },
+    ];
+    const result = recommendFeeOption(30, customTable);
+    expect(result.recommended?.priority).toBe("high");
+  });
+});

--- a/contrib/examples/fee-comparison-tool/fee-comparison-tool.ts
+++ b/contrib/examples/fee-comparison-tool/fee-comparison-tool.ts
@@ -1,0 +1,85 @@
+// Example: compare estimated fees for a payment across a few sample
+// priority levels and recommend the cheapest option that still confirms
+// within a caller-supplied maximum wait time.
+//
+// Run with: npx tsx fee-comparison-tool.ts
+
+export type FeePriority = "low" | "medium" | "high";
+
+export interface FeeOption {
+  priority: FeePriority;
+  /** Estimated fee, in stroops. */
+  feeStroops: bigint;
+  /** Estimated confirmation time, in seconds. */
+  estimatedConfirmationSeconds: number;
+}
+
+/** Hardcoded sample fee and expected confirmation time table, one entry per
+ * priority level (a real integration would read this from a fee oracle). */
+export const FEE_TABLE: FeeOption[] = [
+  { priority: "low", feeStroops: 100n, estimatedConfirmationSeconds: 300 },
+  { priority: "medium", feeStroops: 10_000n, estimatedConfirmationSeconds: 60 },
+  { priority: "high", feeStroops: 1_000_000n, estimatedConfirmationSeconds: 5 },
+];
+
+export interface FeeRecommendation {
+  /** null when no option in the table confirms within maxWaitSeconds. */
+  recommended: FeeOption | null;
+  /** Every option that meets the maxWaitSeconds deadline, in table order. */
+  eligibleOptions: FeeOption[];
+  reasoning: string;
+}
+
+/**
+ * Recommends the lowest-fee option in `table` whose estimated confirmation
+ * time is at or under `maxWaitSeconds`. Returns `recommended: null` (with a
+ * reason) rather than silently picking an option that misses the deadline —
+ * the whole point of a deadline constraint is that it's not optional.
+ */
+export function recommendFeeOption(maxWaitSeconds: number, table: FeeOption[] = FEE_TABLE): FeeRecommendation {
+  const eligibleOptions = table.filter((option) => option.estimatedConfirmationSeconds <= maxWaitSeconds);
+
+  if (eligibleOptions.length === 0) {
+    return {
+      recommended: null,
+      eligibleOptions: [],
+      reasoning: `No priority level confirms within ${maxWaitSeconds}s (fastest available is ${Math.min(...table.map((o) => o.estimatedConfirmationSeconds))}s).`,
+    };
+  }
+
+  const recommended = eligibleOptions.reduce((cheapest, option) =>
+    option.feeStroops < cheapest.feeStroops ? option : cheapest,
+  );
+
+  return {
+    recommended,
+    eligibleOptions,
+    reasoning: `"${recommended.priority}" is the cheapest of ${eligibleOptions.length} option(s) confirming within ${maxWaitSeconds}s (${recommended.feeStroops} stroops, ~${recommended.estimatedConfirmationSeconds}s).`,
+  };
+}
+
+function main() {
+  const maxWaitSeconds = 120;
+  const result = recommendFeeOption(maxWaitSeconds);
+
+  console.log(`Comparing fee options for a deadline of ${maxWaitSeconds}s:`);
+  for (const option of FEE_TABLE) {
+    const meetsDeadline = option.estimatedConfirmationSeconds <= maxWaitSeconds;
+    console.log(
+      `  ${option.priority.padEnd(6)} ${option.feeStroops.toString().padStart(9)} stroops, ~${option.estimatedConfirmationSeconds}s` +
+        (meetsDeadline ? "" : " (misses deadline)"),
+    );
+  }
+
+  console.log();
+  if (result.recommended) {
+    console.log(`Recommendation: ${result.recommended.priority}`);
+  } else {
+    console.log("Recommendation: none");
+  }
+  console.log(`Reasoning: ${result.reasoning}`);
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main();
+}

--- a/contrib/examples/fetch-with-timeout/README.md
+++ b/contrib/examples/fetch-with-timeout/README.md
@@ -1,0 +1,43 @@
+# Fetch with a timeout
+
+Wraps the global `fetch` function with a timeout using `AbortController`.
+Prints a clear timeout error if the request does not complete in time,
+instead of the default (and much less informative) `AbortError`.
+
+## How this applies to x402 retries
+
+`vellar-sdk`'s x402 client (`src/x402-client.ts`) accepts an injectable
+`fetchImpl: FetchLike` for every request it makes (the initial fetch, and the
+paid retry after a 402 challenge). Wrapping that injected fetch with a
+timeout — as this example does — prevents a hung facilitator or resource
+server from leaving an x402 payment flow stuck indefinitely; a caller that
+wants bounded retries around x402 requests can compose this wrapper with a
+retry loop (see the `simple-retry` example) around the same injected
+`fetchImpl`.
+
+## Run it
+
+```sh
+npx tsx fetch-with-timeout.ts <url> <timeoutMs>
+```
+
+Example:
+
+```sh
+npx tsx fetch-with-timeout.ts https://example.com 5000
+```
+
+A request that doesn't complete in time prints a clear error:
+
+```
+Error: Request to https://example.com did not complete within 1ms
+```
+
+## Tests
+
+Uses a mock fetch that respects the abort signal, so the tests run without
+depending on network timing:
+
+```sh
+npx vitest run contrib/examples/fetch-with-timeout
+```

--- a/contrib/examples/fetch-with-timeout/fetch-with-timeout.test.ts
+++ b/contrib/examples/fetch-with-timeout/fetch-with-timeout.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+import { FetchTimeoutError, fetchWithTimeout } from "./fetch-with-timeout";
+
+/** A mock fetch that resolves after `delayMs`, respecting the abort signal
+ * like a real fetch implementation would. */
+function createDelayedFetch(delayMs: number): typeof fetch {
+  return ((_url: string, init?: RequestInit) =>
+    new Promise((resolve, reject) => {
+      const timer = setTimeout(() => resolve(new Response("ok")), delayMs);
+      init?.signal?.addEventListener("abort", () => {
+        clearTimeout(timer);
+        reject(new DOMException("The operation was aborted", "AbortError"));
+      });
+    })) as typeof fetch;
+}
+
+describe("fetchWithTimeout", () => {
+  it("resolves normally when the request completes before the timeout", async () => {
+    const response = await fetchWithTimeout("https://example.com", 100, createDelayedFetch(10));
+    expect(response.status).toBe(200);
+  });
+
+  it("throws FetchTimeoutError when the request exceeds the timeout", async () => {
+    await expect(
+      fetchWithTimeout("https://example.com", 10, createDelayedFetch(1000)),
+    ).rejects.toThrow(FetchTimeoutError);
+  });
+
+  it("propagates a non-abort error unchanged", async () => {
+    const failingFetch: typeof fetch = (async () => {
+      throw new Error("DNS failure");
+    }) as typeof fetch;
+    await expect(fetchWithTimeout("https://example.com", 100, failingFetch)).rejects.toThrow(
+      "DNS failure",
+    );
+  });
+});

--- a/contrib/examples/fetch-with-timeout/fetch-with-timeout.ts
+++ b/contrib/examples/fetch-with-timeout/fetch-with-timeout.ts
@@ -1,0 +1,53 @@
+// Example: wrap the global fetch function with a timeout using
+// AbortController.
+//
+// Run with: npx tsx fetch-with-timeout.ts <url> <timeoutMs>
+
+export class FetchTimeoutError extends Error {
+  constructor(url: string, timeoutMs: number) {
+    super(`Request to ${url} did not complete within ${timeoutMs}ms`);
+    this.name = "FetchTimeoutError";
+  }
+}
+
+export async function fetchWithTimeout(
+  url: string,
+  timeoutMs: number,
+  fetchImpl: typeof fetch = fetch,
+): Promise<Response> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+
+  try {
+    return await fetchImpl(url, { signal: controller.signal });
+  } catch (err) {
+    if (err instanceof Error && err.name === "AbortError") {
+      throw new FetchTimeoutError(url, timeoutMs);
+    }
+    throw err;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+async function main() {
+  const [url, timeoutArg] = process.argv.slice(2);
+  if (!url || !timeoutArg) {
+    console.error("Usage: npx tsx fetch-with-timeout.ts <url> <timeoutMs>");
+    process.exitCode = 1;
+    return;
+  }
+  const timeoutMs = Number(timeoutArg);
+
+  try {
+    const response = await fetchWithTimeout(url, timeoutMs);
+    console.log(`Response: ${response.status} ${response.statusText}`);
+  } catch (err) {
+    console.error(`Error: ${err instanceof Error ? err.message : String(err)}`);
+    process.exitCode = 1;
+  }
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main();
+}

--- a/contrib/examples/format-policy-summary/README.md
+++ b/contrib/examples/format-policy-summary/README.md
@@ -1,0 +1,41 @@
+# format-policy-summary
+
+Formats a policy spending limit and a window (in seconds) as a human
+readable sentence, such as `"100 XLM per day"`.
+
+## Usage
+
+```ts
+import { formatPolicySummary } from "./format-policy-summary";
+
+formatPolicySummary(100, 86400); // "100 XLM per day"
+```
+
+Or run it as a script:
+
+```sh
+npx tsx format-policy-summary.ts 100 86400
+```
+
+## API
+
+```ts
+function formatPolicySummary(
+  limit: bigint | number | string,
+  windowSeconds: number,
+  options?: { unit?: string }, // defaults to "XLM"
+): string;
+```
+
+Recognized windows (`60`, `3600`, `86400`, `604800`) get a friendly label.
+Any other window length falls back to printing the raw seconds.
+
+## Examples
+
+| Limit | Window (s) | Output                     |
+| ----- | ---------- | --------------------------- |
+| `100`   | `3600`       | `100 XLM per hour`          |
+| `50`    | `86400`      | `50 XLM per day`            |
+| `1000`  | `604800`     | `1000 XLM per week`         |
+| `25`    | `60`         | `25 XLM per minute`         |
+| `10`    | `120`        | `10 XLM per 120 seconds`    |

--- a/contrib/examples/format-policy-summary/format-policy-summary.ts
+++ b/contrib/examples/format-policy-summary/format-policy-summary.ts
@@ -1,0 +1,47 @@
+/**
+ * Formats a spending limit and a window (in seconds) as a human readable
+ * sentence, e.g. "100 XLM per day". Falls back to printing the raw seconds
+ * for window lengths that don't have a friendly label.
+ */
+
+const WINDOW_LABELS: Record<number, string> = {
+  60: "minute",
+  3600: "hour",
+  86400: "day",
+  604800: "week",
+};
+
+export interface FormatPolicySummaryOptions {
+  unit?: string;
+}
+
+export function formatPolicySummary(
+  limit: bigint | number | string,
+  windowSeconds: number,
+  options: FormatPolicySummaryOptions = {},
+): string {
+  const unit = options.unit ?? "XLM";
+  const label = WINDOW_LABELS[windowSeconds];
+
+  if (label) {
+    return `${limit} ${unit} per ${label}`;
+  }
+
+  return `${limit} ${unit} per ${windowSeconds} seconds`;
+}
+
+function main(): void {
+  const [limit, windowSeconds] = process.argv.slice(2);
+
+  if (!limit || !windowSeconds) {
+    console.error("Usage: tsx format-policy-summary.ts <limit> <windowSeconds>");
+    process.exitCode = 1;
+    return;
+  }
+
+  console.log(formatPolicySummary(limit, Number(windowSeconds)));
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main();
+}

--- a/contrib/examples/format-settlement-receipt/README.md
+++ b/contrib/examples/format-settlement-receipt/README.md
@@ -1,0 +1,21 @@
+# format-settlement-receipt
+
+Formats an x402 settlement object into a readable receipt.
+
+## Usage
+
+```ts
+import { formatSettlementReceipt } from "./index";
+
+const receipt = formatSettlementReceipt({
+  transaction: "aaa111...",
+  payer: "CAAAA...",
+  asset: "CAAAA...",
+  amount: 1000000n,
+  network: "testnet",
+});
+
+console.log(receipt.lines.join("\n"));
+```
+
+Output includes Transaction, Payer, Asset, Amount (human-readable plus base), and Network. Missing optional fields are omitted cleanly.

--- a/contrib/examples/format-settlement-receipt/index.ts
+++ b/contrib/examples/format-settlement-receipt/index.ts
@@ -1,0 +1,42 @@
+/**
+ * Format an x402 settlement receipt for display.
+ */
+
+export interface FormattedReceipt {
+  lines: string[];
+}
+
+export interface FormatSettlementOptions {
+  /** Decimals used to convert base units to a human-readable amount. Default: 7. */
+  assetDecimals?: number;
+}
+
+const REQUIRED_FIELDS: { key: keyof import("../../../src/x402-types").X402Settlement; label: string }[] = [
+  { key: "transaction", label: "Transaction" },
+  { key: "payer", label: "Payer" },
+  { key: "asset", label: "Asset" },
+  { key: "amount", label: "Amount" },
+  { key: "network", label: "Network" },
+];
+
+export function formatSettlementReceipt(
+  settlement: import("../../../src/x402-types").X402Settlement,
+  opts?: FormatSettlementOptions,
+): FormattedReceipt {
+  const decimals = opts?.assetDecimals ?? 7;
+  const lines: string[] = [];
+
+  for (const field of REQUIRED_FIELDS) {
+    let value = settlement[field.key];
+    if (value === undefined || value === null) continue;
+
+    if (field.key === "amount") {
+      const num = Number(value) / Math.pow(10, decimals);
+      value = `${num} (base ${value.toString()})`;
+    }
+
+    lines.push(`${field.label}: ${value}`);
+  }
+
+  return { lines };
+}

--- a/contrib/examples/format-settlement-receipt/test.ts
+++ b/contrib/examples/format-settlement-receipt/test.ts
@@ -1,0 +1,35 @@
+import { formatSettlementReceipt } from "./index";
+import type { X402Settlement } from "../../../src/x402-types";
+
+console.log("format-settlement-receipt tests:");
+
+{
+  const settlement: X402Settlement = {
+    transaction: "aaa111bbb222ccc333ddd444eee555fff666777888",
+    payer: "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHHHHH",
+    asset: "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHHHHH",
+    amount: 1000000n,
+    network: "testnet",
+  };
+
+  const receipt = formatSettlementReceipt(settlement);
+  console.log(receipt.lines.join("\n"));
+  console.assert(receipt.lines.length >= 4, "expected at least 4 lines");
+}
+
+{
+  // Optional fields present/absent are handled cleanly.
+  const settlement: X402Settlement = {
+    transaction: "aaa111bbb222ccc333ddd444eee555fff666777888",
+    payer: "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHHHHH",
+    asset: "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHHHHH",
+    amount: 2500000n,
+    network: "testnet",
+  };
+
+  const receipt = formatSettlementReceipt(settlement, { assetDecimals: 7 });
+  console.log(receipt.lines.join("\n"));
+  console.assert(receipt.lines.some((l) => l.startsWith("Network:")), "network rendered when present");
+}
+
+console.log("format-settlement-receipt tests passed");

--- a/contrib/examples/format-signer-list/README.md
+++ b/contrib/examples/format-signer-list/README.md
@@ -1,0 +1,19 @@
+# format-signer-list
+
+Formats an array of signer records into a readable list sorted by weight
+descending.
+
+## Usage
+
+```ts
+import { formatSignerList } from "./index";
+
+const signers = [
+  { key: "GAAAA", type: "ed25519", weight: 1 },
+  { key: "GZZZZZ", type: "ed25519", weight: 5 },
+];
+
+const result = formatSignerList(signers);
+console.log(result.lines.join("\n"));
+// 1. ed25519 key GZZZZZ (weight 5)
+// 2. ed25519 key GAAAA (weight 1)

--- a/contrib/examples/format-signer-list/index.ts
+++ b/contrib/examples/format-signer-list/index.ts
@@ -1,0 +1,30 @@
+/**
+ * Format an array of signer records into a readable display list,
+ * sorted by weight descending.
+ */
+
+export interface SignerRecord {
+  key: string;
+  type: string;
+  weight: number;
+}
+
+export interface FormattedSigner {
+  key: string;
+  type: string;
+  weight: number;
+}
+
+export function formatSignerList(signers: SignerRecord[]): { lines: string[]; signers: FormattedSigner[] } {
+  if (signers.length === 0) {
+    return { lines: ["No signers"], signers: [] };
+  }
+
+  const sorted = [...signers].sort((a, b) => b.weight - a.weight);
+
+  const lines = sorted.map((s, idx) => {
+    return `${idx + 1}. ${s.type} key ${s.key} (weight ${s.weight})`;
+  });
+
+  return { lines, signers: sorted };
+}

--- a/contrib/examples/format-signer-list/test.ts
+++ b/contrib/examples/format-signer-list/test.ts
@@ -1,0 +1,26 @@
+import { formatSignerList } from "./index";
+
+console.log("format-signer-list tests:");
+
+{
+  const result = formatSignerList([]);
+  console.assert(result.lines.length === 1 && result.lines[0] === "No signers", "expected empty message");
+  console.log("ok: empty array → no signers");
+}
+
+{
+  const signers = [
+    { key: "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA", type: "ed25519", weight: 1 },
+    { key: "GZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZ", type: "ed25519", weight: 5 },
+    { key: "SAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA", type: "sha256", weight: 3 },
+  ];
+
+  const result = formatSignerList(signers);
+  console.assert(result.signers[0].weight === 5, "expected highest weight first");
+  console.assert(result.signers[1].weight === 3, "expected mid weight second");
+  console.assert(result.signers[2].weight === 1, "expected lowest weight last");
+  console.log("ok: sort by weight desc");
+  console.log(result.lines.join("\n"));
+}
+
+console.log("format-signer-list tests passed");

--- a/contrib/examples/format-stroops/README.md
+++ b/contrib/examples/format-stroops/README.md
@@ -1,0 +1,38 @@
+# format-stroops
+
+Converts a raw stroops amount into a human readable XLM string with up to 7
+decimal places, using `BigInt` so large balances don't lose precision.
+
+## Usage
+
+```ts
+import { formatStroops } from "./format-stroops";
+
+formatStroops(10_000_000n); // "1"
+```
+
+Or run it as a script:
+
+```sh
+npx tsx format-stroops.ts 10000000
+```
+
+## API
+
+```ts
+function formatStroops(stroops: bigint | number | string): string;
+```
+
+Trailing zero decimal digits are trimmed, and a whole-XLM amount is returned
+without a decimal point.
+
+## Examples
+
+| Input (stroops) | Output       |
+| ---------------- | ------------ |
+| `0`               | `0`          |
+| `1`               | `0.0000001`  |
+| `100000`          | `0.01`       |
+| `10000000`        | `1`          |
+| `123456789`       | `12.3456789` |
+| `9999999999999999` | `999999999.9999999` |

--- a/contrib/examples/format-stroops/format-stroops.ts
+++ b/contrib/examples/format-stroops/format-stroops.ts
@@ -1,0 +1,40 @@
+/**
+ * Formats a raw stroops amount as a human readable XLM string.
+ *
+ * 1 XLM = 10,000,000 stroops (7 decimal places). All math is done with
+ * BigInt so arbitrarily large balances don't lose precision the way they
+ * would if we divided with floating point numbers.
+ */
+
+const STROOPS_PER_XLM = 10_000_000n;
+
+export function formatStroops(stroops: bigint | number | string): string {
+  const value = typeof stroops === "bigint" ? stroops : BigInt(stroops);
+  const negative = value < 0n;
+  const abs = negative ? -value : value;
+
+  const whole = abs / STROOPS_PER_XLM;
+  const fraction = abs % STROOPS_PER_XLM;
+
+  const fractionDigits = fraction.toString().padStart(7, "0").replace(/0+$/, "");
+
+  const formatted = fractionDigits.length > 0 ? `${whole}.${fractionDigits}` : whole.toString();
+
+  return negative ? `-${formatted}` : formatted;
+}
+
+function main(): void {
+  const input = process.argv[2];
+
+  if (!input) {
+    console.error("Usage: tsx format-stroops.ts <stroops>");
+    process.exitCode = 1;
+    return;
+  }
+
+  console.log(formatStroops(input));
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main();
+}

--- a/contrib/examples/format-tx-hash/README.md
+++ b/contrib/examples/format-tx-hash/README.md
@@ -1,0 +1,25 @@
+# Format a transaction hash for display
+
+Formats a full transaction hash as a shortened display string (first six and
+last four characters), for showing in a UI without wrapping or truncation
+mid-layout.
+
+## Examples
+
+| Input | Output |
+| --- | --- |
+| `a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1b2` | `a1b2c3...a1b2` |
+| `shorthash123` | `shorth...h123` |
+| `abc` (shorter than 6+4) | `abc` (returned unchanged) |
+
+## Run it
+
+```sh
+npx tsx format-tx-hash.ts
+```
+
+## Tests
+
+```sh
+npx vitest run contrib/examples/format-tx-hash
+```

--- a/contrib/examples/format-tx-hash/format-tx-hash.test.ts
+++ b/contrib/examples/format-tx-hash/format-tx-hash.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+import { formatTxHash } from "./format-tx-hash";
+
+describe("formatTxHash", () => {
+  it("shortens a long hash to first 6 + last 4 characters", () => {
+    const hash = "a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1b2";
+    expect(formatTxHash(hash)).toBe("a1b2c3...a1b2");
+  });
+
+  it("returns a hash exactly at the head+tail length unchanged", () => {
+    expect(formatTxHash("1234567890")).toBe("1234567890"); // 10 chars = 6 + 4
+  });
+
+  it("returns a shorter hash unchanged without throwing", () => {
+    expect(formatTxHash("abc")).toBe("abc");
+    expect(formatTxHash("")).toBe("");
+  });
+
+  it("supports custom head/tail lengths", () => {
+    expect(formatTxHash("abcdefghijklmnop", 3, 2)).toBe("abc...op");
+  });
+});

--- a/contrib/examples/format-tx-hash/format-tx-hash.ts
+++ b/contrib/examples/format-tx-hash/format-tx-hash.ts
@@ -1,0 +1,31 @@
+// Example: format a full transaction hash as a shortened display string
+// (first six + last four characters), for showing in a UI without wrapping.
+//
+// Run with: npx tsx format-tx-hash.ts
+
+/**
+ * Shortens a hash to "<first 6>...<last 4>". A hash no longer than
+ * headLen + tailLen is returned unchanged rather than throwing or producing
+ * a nonsensical (or negative-length) slice.
+ */
+export function formatTxHash(hash: string, headLen = 6, tailLen = 4): string {
+  if (hash.length <= headLen + tailLen) {
+    return hash;
+  }
+  return `${hash.slice(0, headLen)}...${hash.slice(-tailLen)}`;
+}
+
+function main() {
+  const examples = [
+    "a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1b2",
+    "shorthash123",
+    "abc",
+  ];
+  for (const hash of examples) {
+    console.log(`${hash}  ->  ${formatTxHash(hash)}`);
+  }
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main();
+}

--- a/contrib/examples/full-create-connect/README.md
+++ b/contrib/examples/full-create-connect/README.md
@@ -1,0 +1,29 @@
+# full-create-connect
+
+Reference example demonstrating a full create and connect wallet flow using mocked passkey kit and backend dependencies.
+
+## Flow
+
+1. Create a new wallet (passkey registration + backend submission).
+2. Build a session from the result.
+3. Simulate a page reload.
+4. Reconnect using the resulting keyId.
+5. Backend lookup confirms the mapping.
+
+All dependencies are mocked within the example.
+
+## Usage
+
+```ts
+import { createMockPasskeyKit, createMockBackend, createWalletSession } from "./index";
+
+const kit = createMockPasskeyKit();
+const backend = createMockBackend();
+
+const { keyIdBase64, contractId, signedTx } = await kit.createWallet("App", "user");
+const { sessionId } = await backend.submitWalletCreation({ keyId: keyIdBase64, contractId, network: "testnet", signedTx });
+const session = createWalletSession(contractId, keyIdBase64, sessionId);
+
+// After reload:
+const reconnected = await kit.connectWallet({ keyId: keyIdBase64 });
+const lookup = await backend.lookupContractId({ keyId: keyIdBase64, network: "testnet" });

--- a/contrib/examples/full-create-connect/index.ts
+++ b/contrib/examples/full-create-connect/index.ts
@@ -1,0 +1,65 @@
+/**
+ * Reference example: full create and connect wallet flow with mocked passkey kit
+ * and backend dependencies.
+ *
+ * Demonstrates:
+ * - Creating a new wallet (passkey registration + backend submission)
+ * - Simulating a page reload
+ * - Reconnecting using the resulting keyId
+ */
+
+import type { WalletSession } from "../../../src/types";
+
+export interface MockPasskeyKitLike {
+  createWallet(app: string, user: string): Promise<{ keyIdBase64: string; contractId: string; signedTx: unknown }>;
+  connectWallet(opts?: { keyId?: string }): Promise<{ keyIdBase64: string; contractId: string }>;
+  wallet?: unknown;
+}
+
+export interface MockBackend {
+  submitWalletCreation(input: { keyId: string; contractId: string; network: string; signedTx: unknown }): Promise<{ sessionId: string }>;
+  lookupContractId(input: { keyId: string; network: string }): Promise<{ contractId: string; sessionId: string } | undefined>;
+}
+
+export function createMockPasskeyKit(): MockPasskeyKitLike {
+  return {
+    wallet: undefined,
+    async createWallet() {
+      return {
+        keyIdBase64: "key-" + Math.random().toString(36).slice(2, 10),
+        contractId: "C" + "A".repeat(55),
+        signedTx: "AAAA...",
+      };
+    },
+    async connectWallet(opts) {
+      return {
+        keyIdBase64: opts?.keyId ?? "key-reconnected",
+        contractId: "C" + "B".repeat(55),
+      };
+    },
+  };
+}
+
+export function createMockBackend(): MockBackend {
+  return {
+    async submitWalletCreation() {
+      return { sessionId: "sess-" + Math.random().toString(36).slice(2, 10) };
+    },
+    async lookupContractId(input) {
+      return { contractId: "C" + "B".repeat(55), sessionId: "sess-restored" };
+    },
+  };
+}
+
+export function createWalletSession(contractId: string, keyId: string | undefined, sessionId: string | undefined): WalletSession {
+  return {
+    accountId: contractId,
+    network: "testnet",
+    connected: true,
+    authMethod: "passkey",
+    createdAt: new Date().toISOString(),
+    lastActiveAt: new Date().toISOString(),
+    ...(keyId !== undefined && { keyId }),
+    ...(sessionId !== undefined && { serverSessionId: sessionId }),
+  };
+}

--- a/contrib/examples/full-create-connect/test.ts
+++ b/contrib/examples/full-create-connect/test.ts
@@ -1,0 +1,38 @@
+import { createMockPasskeyKit, createMockBackend, createWalletSession } from "./index";
+
+console.log("full-create-connect tests:");
+
+{
+  const kit = createMockPasskeyKit();
+  const backend = createMockBackend();
+
+  // 1) Create wallet
+  const { keyIdBase64, contractId, signedTx } = await kit.createWallet("TestApp", "test-user");
+  console.assert(keyIdBase64.length > 0, "expected keyId");
+  console.assert(contractId.length > 0, "expected contractId");
+  console.log("ok: createWallet → keyId:", keyIdBase64, "contractId:", contractId);
+
+  // 2) Backend submission
+  const { sessionId } = await backend.submitWalletCreation({ keyId: keyIdBase64, contractId, network: "testnet", signedTx });
+  console.assert(sessionId.length > 0, "expected sessionId");
+  console.log("ok: submitWalletCreation → sessionId:", sessionId);
+
+  // 3) Build session
+  const session = createWalletSession(contractId, keyIdBase64, sessionId);
+  console.assert(session.connected === true, "expected connected");
+  console.assert(session.keyId === keyIdBase64, "expected keyId in session");
+  console.log("ok: session created with keyId");
+
+  // 4) Simulate reload: reconnect using keyId
+  const reconnected = await kit.connectWallet({ keyId: keyIdBase64 });
+  console.assert(reconnected.keyIdBase64 === keyIdBase64, "expected same keyId on reconnect");
+  console.log("ok: reconnect with keyId → same keyId");
+
+  // 5) Backend lookup
+  const lookup = await backend.lookupContractId({ keyId: keyIdBase64, network: "testnet" });
+  console.assert(lookup !== undefined, "expected lookup result");
+  console.assert(lookup!.contractId.length > 0, "expected contractId from lookup");
+  console.log("ok: backend lookup → contractId:", lookup!.contractId);
+}
+
+console.log("full-create-connect tests passed");

--- a/contrib/examples/full-payment-flow/README.md
+++ b/contrib/examples/full-payment-flow/README.md
@@ -1,0 +1,28 @@
+# full-payment-flow
+
+Reference example demonstrating a full payment build, review, and submit flow using mocked SAC and backend clients.
+
+## Flow
+
+1. Build + simulate the SAC transfer.
+2. Review the payment details.
+3. Submit (with a simulated first-attempt failure and retry).
+
+All API calls are mocked within the example.
+
+## Usage
+
+```ts
+import { createMockSacClient, createMockBackend, runPaymentFlow } from "./index";
+
+const result = await runPaymentFlow({
+  from: "G...",
+  to: "G...",
+  token: { contractId: "C...", symbol: "USDC", decimals: 7 },
+  amount: 1000000n,
+  network: "testnet",
+  sac: createMockSacClient(),
+  backend: createMockBackend(true), // first submit fails
+});
+
+console.log(result.attempts, result.hash);

--- a/contrib/examples/full-payment-flow/index.ts
+++ b/contrib/examples/full-payment-flow/index.ts
@@ -1,0 +1,92 @@
+/**
+ * Reference example: full payment build, review, submit flow with mocked SAC and backend clients.
+ *
+ * Demonstrates:
+ * - Building a payment (SAC transfer simulation)
+ * - Reviewing the payment details
+ * - First submit attempt failing
+ * - Successful retry
+ */
+
+import type { TokenInfo } from "../../../src/balances";
+import type { PaymentReview } from "../../../src/payments";
+
+export interface MockSacClient {
+  transfer(
+    args: { from: string; to: string; amount: bigint },
+    options?: { timeoutInSeconds?: number },
+  ): Promise<unknown>;
+}
+
+export interface MockBackend {
+  submitTransaction(input: { signedXdr: string; network: "testnet" | "mainnet" }): Promise<{ hash: string }>;
+}
+
+export interface PaymentFlowResult {
+  review: PaymentReview;
+  hash: string;
+  attempts: number;
+}
+
+export function createMockSacClient(failFirst: boolean = false): MockSacClient {
+  let callCount = 0;
+  return {
+    async transfer() {
+      callCount++;
+      // Simulate a successful build/simulation.
+      return { toXDR: () => "AAAAAgAAAABk..." };
+    },
+  };
+}
+
+export function createMockBackend(failFirst: boolean = false): MockBackend {
+  let callCount = 0;
+  return {
+    async submitTransaction() {
+      callCount++;
+      if (failFirst && callCount === 1) {
+        throw new Error("simulated_submit_failure");
+      }
+      return { hash: `tx-hash-${callCount}-${Date.now()}` };
+    },
+  };
+}
+
+export async function runPaymentFlow(options: {
+  from: string;
+  to: string;
+  token: TokenInfo;
+  amount: bigint;
+  network: string;
+  sac: MockSacClient;
+  backend: MockBackend;
+}): Promise<PaymentFlowResult> {
+  const { from, to, token, amount, network, sac, backend } = options;
+
+  // 1. Build + simulate the transfer
+  const tx = await sac.transfer({ from, to, amount }, { timeoutInSeconds: 30 });
+
+  // 2. Review
+  const review: PaymentReview = { from, to, token, amount, network: network as "testnet" | "mainnet" };
+
+  // 3. Submit (with retry on failure)
+  let attempts = 0;
+  let lastError: Error | undefined;
+
+  for (let i = 0; i < 2; i++) {
+    attempts++;
+    try {
+      const result = await backend.submitTransaction({
+        signedXdr: typeof tx === "object" && tx !== null && "toXDR" in tx
+          ? (tx as { toXDR: () => string }).toXDR()
+          : String(tx),
+        network: network as "testnet" | "mainnet",
+      });
+      return { review, hash: result.hash, attempts };
+    } catch (err) {
+      lastError = err instanceof Error ? err : new Error(String(err));
+    }
+  }
+
+  throw lastError ?? new Error("submit failed after retries");
+}

--- a/contrib/examples/full-payment-flow/test.ts
+++ b/contrib/examples/full-payment-flow/test.ts
@@ -1,0 +1,44 @@
+import { createMockSacClient, createMockBackend, runPaymentFlow } from "./index";
+
+console.log("full-payment-flow tests:");
+
+// 1) Successful submit on first attempt
+{
+  const sac = createMockSacClient();
+  const backend = createMockBackend(false);
+
+  const result = await runPaymentFlow({
+    from: "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+    to: "GBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB",
+    token: { contractId: "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHHHHH", symbol: "USDC", decimals: 7 },
+    amount: 1000000n,
+    network: "testnet",
+    sac,
+    backend,
+  });
+
+  console.assert(result.attempts === 1, "expected 1 attempt on success");
+  console.assert(result.hash.length > 0, "expected hash");
+  console.log("ok: successful submit → 1 attempt, hash:", result.hash);
+}
+
+// 2) First attempt fails, retry succeeds
+{
+  const sac = createMockSacClient();
+  const backend = createMockBackend(true);
+
+  const result = await runPaymentFlow({
+    from: "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+    to: "GBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB",
+    token: { contractId: "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHHHHH", symbol: "USDC", decimals: 7 },
+    amount: 1000000n,
+    network: "testnet",
+    sac,
+    backend,
+  });
+
+  console.assert(result.attempts === 2, "expected 2 attempts on retry");
+  console.log("ok: first attempt failed, retry succeeded → 2 attempts, hash:", result.hash);
+}
+
+console.log("full-payment-flow tests passed");

--- a/contrib/examples/full-policy-flow/README.md
+++ b/contrib/examples/full-policy-flow/README.md
@@ -1,0 +1,29 @@
+# full-policy-flow
+
+Reference example demonstrating a full policy generate and simulate flow using a mocked policy API.
+
+## Flow
+
+1. List available templates.
+2. Generate a policy from a definition.
+3. Simulate the policy for a wallet (both accepted and rejected outcomes).
+4. Deploy an instance and record the deployment.
+
+All API calls are mocked within the example.
+
+## Usage
+
+```ts
+import { createMockPolicyApi } from "./index";
+
+const api = createMockPolicyApi();
+
+const templates = await api.listTemplates();
+const generated = await api.generate({ version: "1", type: "spending-limit", owners: ["G..."] });
+const simulate = await api.simulate(generated.id, "G...");
+
+if (simulate.ok) {
+  const { contractId } = await api.deployInstance(generated.id, "G...");
+  const recorded = await api.recordDeployment(generated.id, "tx-hash", contractId);
+  console.log(recorded.status);
+}

--- a/contrib/examples/full-policy-flow/index.ts
+++ b/contrib/examples/full-policy-flow/index.ts
@@ -1,0 +1,93 @@
+/**
+ * Reference example: full policy generate and simulate flow with a mocked policy API.
+ */
+
+import type {
+  PolicyDefinition,
+  PolicyTemplateInfo,
+  GeneratedPolicy,
+  SimulateResult,
+} from "../../../src/policy-types";
+
+export interface MockPolicyApi {
+  listTemplates(): Promise<PolicyTemplateInfo[]>;
+  generate(definition: PolicyDefinition): Promise<GeneratedPolicy>;
+  simulate(policyId: string, wallet: string): Promise<SimulateResult>;
+  deployInstance(policyId: string, wallet: string): Promise<{ contractId: string }>;
+  recordDeployment(policyId: string, txHash: string, contractId?: string): Promise<GeneratedPolicy>;
+}
+
+const TEMPLATES: PolicyTemplateInfo[] = [
+  {
+    type: "spending-limit",
+    title: "Daily spending limit",
+    description: "Limits total outbound spend per rolling day.",
+    enforcement: {
+      kind: "policy-contract",
+      wasmHash: "a".repeat(64),
+      constructorArgs: { dailyLimitStroops: "1000000000", windowSeconds: 86400 },
+    },
+  },
+  {
+    type: "signer-limits",
+    title: "Signer limits",
+    description: "Enforces on-chain signer thresholds.",
+    enforcement: { kind: "signer-limits" },
+  },
+];
+
+const POLICIES = new Map<string, GeneratedPolicy>();
+
+export function createMockPolicyApi(): MockPolicyApi {
+  return {
+    async listTemplates() {
+      return TEMPLATES;
+    },
+
+    async generate(definition) {
+      const policyId = `policy-${definition.type || "custom"}-${Date.now()}`;
+      const policy: GeneratedPolicy = {
+        id: policyId,
+        createdAt: new Date().toISOString(),
+        status: "generated",
+        definition,
+        policyHash: "b".repeat(64),
+        manifest: {
+          template: definition.type || "custom",
+          enforcement: { kind: "policy-contract", wasmHash: "a".repeat(64) },
+          network: "testnet",
+        },
+      };
+      POLICIES.set(policyId, policy);
+      return policy;
+    },
+
+    async simulate(policyId, wallet) {
+      // Example: reject when wallet starts with "GZZZ", accept otherwise.
+      if (wallet.startsWith("GZZZ")) {
+        return { ok: false, error: "simulated_failure" };
+      }
+      return { ok: true, minResourceFee: "100000" };
+    },
+
+    async deployInstance(policyId, wallet) {
+      if (!POLICIES.has(policyId)) {
+        throw new Error(`policy ${policyId} not generated`);
+      }
+      return { contractId: `C${policyId}`.slice(0, 56) };
+    },
+
+    async recordDeployment(policyId, txHash, contractId) {
+      const existing = POLICIES.get(policyId);
+      if (!existing) throw new Error(`policy ${policyId} not generated`);
+      const policy: GeneratedPolicy = {
+        ...existing,
+        status: "deployed",
+        instance: { contractId: contractId || "", txHash, deployedAt: new Date().toISOString() },
+        deployment: { contractId, txHash, deployedAt: new Date().toISOString() },
+      };
+      POLICIES.set(policyId, policy);
+      return policy;
+    },
+  };
+}

--- a/contrib/examples/full-policy-flow/test.ts
+++ b/contrib/examples/full-policy-flow/test.ts
@@ -1,0 +1,37 @@
+import { createMockPolicyApi } from "./index";
+
+console.log("full-policy-flow tests:");
+
+{
+  const api = createMockPolicyApi();
+
+  // 1) list templates
+  const templates = await api.listTemplates();
+  console.assert(templates.length >= 1, "expected templates");
+  console.log("ok: listTemplates →", templates.length, "templates");
+
+  // 2) generate policy
+  const definition: Parameters<typeof api.generate>[0] = { version: "1", type: "spending-limit", owners: ["GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"] };
+  const generated = await api.generate(definition);
+  console.assert(generated.status === "generated", "expected generated");
+  console.log("ok: generate →", generated.id);
+
+  // 3) simulate accepted
+  const accepted = await api.simulate(generated.id, "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA");
+  console.assert(accepted.ok === true, "expected accepted simulation");
+  console.log("ok: simulate accepted → ok=true");
+
+  // 4) simulate rejected
+  const rejected = await api.simulate(generated.id, "GZZZxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx");
+  console.assert(rejected.ok === false, "expected rejected simulation");
+  console.log("ok: simulate rejected → ok=false, error=", rejected.error);
+
+  // 5) deploy instance + record
+  const { contractId } = await api.deployInstance(generated.id, "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA");
+  const recorded = await api.recordDeployment(generated.id, "tx-hash-123", contractId);
+  console.assert(recorded.status === "deployed", "expected deployed status");
+  console.assert(recorded.instance !== undefined, "expected instance");
+  console.log("ok: deployInstance + recordDeployment → status=deployed");
+}
+
+console.log("full-policy-flow tests passed");

--- a/contrib/examples/generate-policy-body/README.md
+++ b/contrib/examples/generate-policy-body/README.md
@@ -1,0 +1,39 @@
+# Generate a spending-limit policy body
+
+Builds a spending-limit policy request body from a daily limit (in stroops)
+and a rolling window (in seconds), mirroring `vellar-sdk`'s
+`SpendingConstructor` shape (`src/policy-types.ts`).
+
+## Run it
+
+```sh
+npx tsx generate-policy-body.ts <dailyLimitStroops> <windowSeconds>
+```
+
+Example invocation — a 100 XLM (1,000,000,000 stroops) daily limit over a
+24-hour window:
+
+```sh
+npx tsx generate-policy-body.ts 1000000000 86400
+```
+
+Expected output:
+
+```json
+{
+  "type": "spending-limit",
+  "constructorArgs": {
+    "dailyLimitStroops": "1000000000",
+    "windowSeconds": 86400
+  }
+}
+```
+
+Both arguments must be positive integers — the script exits with an error
+otherwise (e.g. `0`, a negative number, or non-numeric input).
+
+## Tests
+
+```sh
+npx vitest run contrib/examples/generate-policy-body
+```

--- a/contrib/examples/generate-policy-body/generate-policy-body.test.ts
+++ b/contrib/examples/generate-policy-body/generate-policy-body.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+import { buildSpendingPolicyBody } from "./generate-policy-body";
+
+describe("buildSpendingPolicyBody", () => {
+  it("builds a spending-limit body from a limit and window", () => {
+    expect(buildSpendingPolicyBody("1000000000", "86400")).toEqual({
+      type: "spending-limit",
+      constructorArgs: {
+        dailyLimitStroops: "1000000000",
+        windowSeconds: 86400,
+      },
+    });
+  });
+
+  it("rejects a non-positive limit", () => {
+    expect(() => buildSpendingPolicyBody("0", "86400")).toThrow(RangeError);
+    expect(() => buildSpendingPolicyBody("-5", "86400")).toThrow(RangeError);
+  });
+
+  it("rejects a non-positive window", () => {
+    expect(() => buildSpendingPolicyBody("1000000000", "0")).toThrow(RangeError);
+  });
+
+  it("rejects a non-numeric argument", () => {
+    expect(() => buildSpendingPolicyBody("abc", "86400")).toThrow(RangeError);
+    expect(() => buildSpendingPolicyBody("1000000000", "abc")).toThrow(RangeError);
+  });
+});

--- a/contrib/examples/generate-policy-body/generate-policy-body.ts
+++ b/contrib/examples/generate-policy-body/generate-policy-body.ts
@@ -1,0 +1,63 @@
+// Example: build a spending-limit policy request body from a daily limit
+// (in stroops) and a rolling window (in seconds), given as CLI arguments.
+// Mirrors vellar-sdk's SpendingConstructor shape (src/policy-types.ts).
+//
+// Run with: npx tsx generate-policy-body.ts <dailyLimitStroops> <windowSeconds>
+// Example:  npx tsx generate-policy-body.ts 1000000000 86400
+
+export interface SpendingPolicyBody {
+  type: "spending-limit";
+  constructorArgs: {
+    dailyLimitStroops: string;
+    windowSeconds: number;
+  };
+}
+
+function parsePositiveInteger(raw: string, label: string): number {
+  const value = Number(raw);
+  if (!Number.isFinite(value) || !Number.isInteger(value) || value <= 0) {
+    throw new RangeError(`${label} must be a positive integer, got "${raw}"`);
+  }
+  return value;
+}
+
+export function buildSpendingPolicyBody(
+  dailyLimitStroops: string,
+  windowSeconds: string,
+): SpendingPolicyBody {
+  // dailyLimitStroops is validated as a positive integer but kept as a string
+  // in the body — spending limits are i128 stroop amounts, too large for a
+  // JS number to represent exactly.
+  parsePositiveInteger(dailyLimitStroops, "limit");
+  const window = parsePositiveInteger(windowSeconds, "windowSeconds");
+
+  return {
+    type: "spending-limit",
+    constructorArgs: {
+      dailyLimitStroops,
+      windowSeconds: window,
+    },
+  };
+}
+
+function main() {
+  const [limitArg, windowArg] = process.argv.slice(2);
+  if (!limitArg || !windowArg) {
+    console.error("Usage: npx tsx generate-policy-body.ts <dailyLimitStroops> <windowSeconds>");
+    process.exitCode = 1;
+    return;
+  }
+
+  try {
+    const body = buildSpendingPolicyBody(limitArg, windowArg);
+    console.log(JSON.stringify(body, null, 2));
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    console.error(`Error: ${message}`);
+    process.exitCode = 1;
+  }
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main();
+}

--- a/contrib/examples/generate-session-key/README.md
+++ b/contrib/examples/generate-session-key/README.md
@@ -1,0 +1,40 @@
+# Generate a random ed25519 session key pair
+
+Generates a random ed25519 keypair suitable for use as an x402 session key
+signer (`createSessionKeySigner` from `vellar-sdk`), and prints both the
+public key and the secret key.
+
+> ⚠️ **Testnet only.** The keypair printed by this script is generated fresh
+> on every run and holds no funds. Never fund a key generated this way on
+> mainnet, and never reuse a printed secret for anything real — treat every
+> run's output as disposable.
+
+## Using the keypair with createSessionKeySigner
+
+`createSessionKeySigner` (from `vellar-sdk`'s `src/x402-signer.ts`) takes the
+secret key plus the smart-account C-address it's authorized to sign for:
+
+```ts
+import { createSessionKeySigner } from "vellar-sdk";
+
+const signer = createSessionKeySigner({
+  address: "C...", // the wallet's smart-account contract id
+  secretKey: "S...", // the secret key this script printed
+});
+```
+
+The session key's spending authority is bounded on-chain by the
+spending-limit policy attached to it — this script only generates the raw
+keypair, it does not attach any policy.
+
+## Run it
+
+```sh
+npx tsx generate-session-key.ts
+```
+
+## Tests
+
+```sh
+npx vitest run contrib/examples/generate-session-key
+```

--- a/contrib/examples/generate-session-key/generate-session-key.test.ts
+++ b/contrib/examples/generate-session-key/generate-session-key.test.ts
@@ -1,0 +1,19 @@
+import { Keypair } from "@stellar/stellar-sdk";
+import { describe, expect, it } from "vitest";
+import { generateSessionKeyPair } from "./generate-session-key";
+
+describe("generateSessionKeyPair", () => {
+  it("returns a public/secret key pair that round-trips through Keypair.fromSecret", () => {
+    const { publicKey, secretKey } = generateSessionKeyPair();
+
+    expect(publicKey.startsWith("G")).toBe(true);
+    expect(secretKey.startsWith("S")).toBe(true);
+    expect(Keypair.fromSecret(secretKey).publicKey()).toBe(publicKey);
+  });
+
+  it("generates a different keypair on each call", () => {
+    const first = generateSessionKeyPair();
+    const second = generateSessionKeyPair();
+    expect(first.secretKey).not.toBe(second.secretKey);
+  });
+});

--- a/contrib/examples/generate-session-key/generate-session-key.ts
+++ b/contrib/examples/generate-session-key/generate-session-key.ts
@@ -1,0 +1,31 @@
+// Example: generate a random ed25519 keypair suitable for use as an x402
+// session key signer (vellar-sdk's createSessionKeySigner).
+//
+// ⚠️  TESTNET ONLY. The secret key printed here is generated fresh each run
+// and has no funds — never fund it on mainnet or reuse it for a real wallet.
+//
+// Run with: npx tsx generate-session-key.ts
+
+import { Keypair } from "@stellar/stellar-sdk";
+
+export interface SessionKeyPair {
+  publicKey: string;
+  secretKey: string;
+}
+
+export function generateSessionKeyPair(): SessionKeyPair {
+  const keypair = Keypair.random();
+  return { publicKey: keypair.publicKey(), secretKey: keypair.secret() };
+}
+
+function main() {
+  const { publicKey, secretKey } = generateSessionKeyPair();
+  console.log("Public key:", publicKey);
+  console.log("Secret key:", secretKey);
+  console.log();
+  console.log("⚠️  Testnet only — do not fund this key or reuse it on mainnet.");
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main();
+}

--- a/contrib/examples/group-tx-by-day/README.md
+++ b/contrib/examples/group-tx-by-day/README.md
@@ -1,0 +1,33 @@
+# Group transaction history by day
+
+A standalone example that takes an array of sample transactions with
+timestamps and groups them into buckets keyed by calendar day.
+
+## What it does
+
+`groupTransactionsByDay(transactions)` in `group-tx-by-day.ts`:
+
+- Uses each transaction's `timestamp` field (ISO 8601 string) to compute a
+  UTC calendar-day key (`YYYY-MM-DD`).
+- Returns one group per day, in chronological order — oldest day first.
+- Within a day, transactions keep their original input order.
+
+The SDK doesn't ship a dedicated "transaction history" type, so
+`SampleTransaction` here is a minimal shape (`hash`, `timestamp`, `amount`,
+`status`) combining an ISO timestamp with `TxStatus` from
+`src/tx-status.ts`, the pattern a wallet activity feed would typically use.
+
+The bundled `SAMPLE_TRANSACTIONS` span three different days
+(2026-07-20, 2026-07-22, and 2026-07-25/26) to exercise the day boundary.
+
+## Run it
+
+```sh
+npx tsx contrib/examples/group-tx-by-day/group-tx-by-day.ts
+```
+
+## Test it
+
+```sh
+npm test -- contrib/examples/group-tx-by-day
+```

--- a/contrib/examples/group-tx-by-day/group-tx-by-day.test.ts
+++ b/contrib/examples/group-tx-by-day/group-tx-by-day.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+import { groupTransactionsByDay, type SampleTransaction } from "./group-tx-by-day";
+
+const TRANSACTIONS: SampleTransaction[] = [
+  { hash: "tx-b", timestamp: "2026-01-02T10:00:00Z", amount: "1", status: "success" },
+  { hash: "tx-a", timestamp: "2026-01-01T23:00:00Z", amount: "2", status: "success" },
+  { hash: "tx-c", timestamp: "2026-01-01T01:00:00Z", amount: "3", status: "pending" },
+  { hash: "tx-d", timestamp: "2026-01-03T00:00:01Z", amount: "4", status: "failed" },
+];
+
+describe("groupTransactionsByDay", () => {
+  it("buckets transactions spanning three days into three chronologically ordered groups", () => {
+    const groups = groupTransactionsByDay(TRANSACTIONS);
+
+    expect(groups.map((g) => g.day)).toEqual(["2026-01-01", "2026-01-02", "2026-01-03"]);
+    expect(groups[0]!.transactions.map((t) => t.hash)).toEqual(["tx-a", "tx-c"]);
+    expect(groups[1]!.transactions.map((t) => t.hash)).toEqual(["tx-b"]);
+    expect(groups[2]!.transactions.map((t) => t.hash)).toEqual(["tx-d"]);
+  });
+
+  it("returns an empty array for no transactions", () => {
+    expect(groupTransactionsByDay([])).toEqual([]);
+  });
+});

--- a/contrib/examples/group-tx-by-day/group-tx-by-day.ts
+++ b/contrib/examples/group-tx-by-day/group-tx-by-day.ts
@@ -1,0 +1,66 @@
+// Standalone example: group an array of sample transactions (with
+// timestamps) into buckets keyed by calendar day, oldest day first.
+
+import type { TxStatus } from "../../../src/tx-status";
+
+/** A minimal "transaction history item" shape. The SDK doesn't ship a
+ * dedicated history type; this mirrors how `src/tx-status.ts`'s `TxStatus`
+ * and the ISO timestamps used elsewhere in the SDK (e.g. `WalletSession`,
+ * `GeneratedPolicy`) would typically be combined for a wallet activity feed. */
+export interface SampleTransaction {
+  hash: string;
+  /** ISO 8601 timestamp string. */
+  timestamp: string;
+  amount: string;
+  status: TxStatus;
+}
+
+export interface DayGroup {
+  /** Calendar day key, UTC, `YYYY-MM-DD`. */
+  day: string;
+  transactions: SampleTransaction[];
+}
+
+function dayKey(timestamp: string): string {
+  const iso = new Date(timestamp).toISOString();
+  return iso.slice(0, 10);
+}
+
+/** Groups `transactions` by their UTC calendar day, using `timestamp` as the
+ * day key. Groups are returned in chronological order (oldest day first);
+ * within a group, transactions keep their input order. */
+export function groupTransactionsByDay(transactions: SampleTransaction[]): DayGroup[] {
+  const byDay = new Map<string, SampleTransaction[]>();
+  for (const tx of transactions) {
+    const key = dayKey(tx.timestamp);
+    const bucket = byDay.get(key);
+    if (bucket) {
+      bucket.push(tx);
+    } else {
+      byDay.set(key, [tx]);
+    }
+  }
+  return [...byDay.keys()].sort().map((day) => ({ day, transactions: byDay.get(day)! }));
+}
+
+const SAMPLE_TRANSACTIONS: SampleTransaction[] = [
+  { hash: "tx-1", timestamp: "2026-07-20T09:15:00Z", amount: "10.0000000", status: "success" },
+  { hash: "tx-2", timestamp: "2026-07-20T18:42:00Z", amount: "2.5000000", status: "success" },
+  { hash: "tx-3", timestamp: "2026-07-22T08:03:00Z", amount: "1.2500000", status: "pending" },
+  { hash: "tx-4", timestamp: "2026-07-25T23:59:59Z", amount: "5.0000000", status: "failed" },
+  { hash: "tx-5", timestamp: "2026-07-26T00:00:01Z", amount: "7.0000000", status: "success" },
+];
+
+export function main(): void {
+  const groups = groupTransactionsByDay(SAMPLE_TRANSACTIONS);
+  for (const group of groups) {
+    console.log(`${group.day}: ${group.transactions.length} transaction(s)`);
+    for (const tx of group.transactions) {
+      console.log(`  ${tx.hash} ${tx.timestamp} ${tx.status}`);
+    }
+  }
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main();
+}

--- a/contrib/examples/headless-agent-signer/README.md
+++ b/contrib/examples/headless-agent-signer/README.md
@@ -1,0 +1,63 @@
+# Headless agent signer
+
+Constructs a `createSessionKeySigner` from a **freshly generated** ed25519
+keypair and uses it to sign a hand-built sample x402 auth entry — entirely
+headless: no browser, no passkey, no external input.
+
+This is the **agent** x402 signing path (as opposed to the human passkey path).
+An ed25519 session key the agent holds signs each V1
+(`sorobanCredentialsAddress`) auth entry directly, producing the smart-wallet
+signature map a Vellar wallet's `__check_auth` accepts. The key's spending
+authority would be bounded on-chain by the spending-limit policy attached to it.
+
+It uses the SDK's real exports:
+[`createSessionKeySigner`](../../../src/x402-signer.ts),
+[`SmartAccountX402Signer`](../../../src/x402-types.ts), and `TESTNET` (for the
+network passphrase).
+
+> **Testnet only.** The keypair is generated fresh on every run and holds no
+> funds. Never fund it or reuse the secret for anything real.
+
+## Flow
+
+1. Generate a fresh ed25519 session keypair (`Keypair.random()`).
+2. Pick the smart-account wallet C-address the key signs for.
+3. Build the headless signer around the raw secret via `createSessionKeySigner`.
+4. Hand-build a minimal V1 auth entry (a dummy SEP-41 `transfer`) and sign it
+   with `signer.signAuthEntry(...)`, passing the testnet passphrase and an
+   expiration ledger.
+
+The result is inspected to confirm the credentials stayed **V1** (hosted x402
+facilitators reject V2), that the embedded signer key matches the generated
+public key, and that the signature is 64 bytes.
+
+## Run it
+
+```sh
+npx tsx headless-agent-signer.ts
+```
+
+```
+Headless agent signer (TESTNET ONLY — disposable key)
+
+1. Generated session key : GB...
+2. Smart-account wallet   : CA...
+3. Built + signed a sample V1 auth entry (expiration ledger 1000)
+4. Credentials kept V1    : true
+   Signature expiration   : 1000
+   Signer key matches      : true
+   Signature length (bytes): 64
+5. Signed entry XDR length: 288 chars
+
+WARNING: the session key above is disposable — do not fund or reuse it.
+```
+
+## Tests
+
+The test decodes the signed entry and additionally **cryptographically
+verifies** the ed25519 signature against the recomputed auth payload, proving
+the headless signer produced a valid signature:
+
+```sh
+npx vitest run contrib/examples/headless-agent-signer
+```

--- a/contrib/examples/headless-agent-signer/headless-agent-signer.test.ts
+++ b/contrib/examples/headless-agent-signer/headless-agent-signer.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "vitest";
+import { buildAuthorizationEntryPreimage, hash, xdr } from "@stellar/stellar-sdk";
+import { TESTNET } from "../../../src/config";
+import { runHeadlessSigning } from "./headless-agent-signer";
+
+describe("runHeadlessSigning", () => {
+  it("signs a sample auth entry with a freshly generated session key", async () => {
+    const { sessionKeypair, walletAddress, signer, signedEntryXdr } = await runHeadlessSigning();
+
+    // The signer is wired to the generated wallet address.
+    expect(signer.address).toBe(walletAddress);
+    expect(walletAddress.startsWith("C")).toBe(true);
+    expect(walletAddress).toHaveLength(56);
+
+    const signed = xdr.SorobanAuthorizationEntry.fromXDR(signedEntryXdr, "base64");
+
+    // Credentials stay V1 (NOT upgraded to V2 — hosted facilitators require V1).
+    expect(signed.credentials().switch().name).toBe("sorobanCredentialsAddress");
+    const creds = signed.credentials().address();
+    expect(creds.signatureExpirationLedger()).toBe(1000);
+
+    // Signature is the smart-wallet map: Vec[ Map[ SignerKey -> Signature ] ].
+    const map = creds.signature().vec()?.[0]?.map();
+    expect(map).toHaveLength(1);
+    const key = map?.[0]?.key();
+    const val = map?.[0]?.val();
+
+    // SignerKey.Ed25519(pubkey) == the generated session key's raw public key.
+    expect(key?.vec()?.[0]?.sym().toString()).toBe("Ed25519");
+    expect(new Uint8Array(key?.vec()?.[1]?.bytes() ?? new Uint8Array())).toEqual(
+      new Uint8Array(sessionKeypair.rawPublicKey()),
+    );
+
+    // Signature.Ed25519(sig) — 64 bytes.
+    expect(val?.vec()?.[0]?.sym().toString()).toBe("Ed25519");
+    const sig = val?.vec()?.[1]?.bytes();
+    expect(sig).toHaveLength(64);
+  });
+
+  it("produces a signature that cryptographically verifies against the auth payload", async () => {
+    const { sessionKeypair, signedEntryXdr } = await runHeadlessSigning();
+
+    const signed = xdr.SorobanAuthorizationEntry.fromXDR(signedEntryXdr, "base64");
+    const creds = signed.credentials().address();
+
+    // Recompute the payload the signer hashed and signed: the preimage does not
+    // include the signature itself, so the signed entry reproduces it exactly.
+    const preimage = buildAuthorizationEntryPreimage(
+      signed,
+      creds.signatureExpirationLedger(),
+      TESTNET.networkPassphrase,
+    );
+    const payload = hash(preimage.toXDR());
+
+    const sig = creds.signature().vec()?.[0]?.map()?.[0]?.val().vec()?.[1]?.bytes();
+    expect(sig).toBeDefined();
+    expect(sessionKeypair.verify(payload, sig as Buffer)).toBe(true);
+  });
+
+  it("generates a different key on every run", async () => {
+    const a = await runHeadlessSigning();
+    const b = await runHeadlessSigning();
+    expect(a.sessionKeypair.publicKey()).not.toBe(b.sessionKeypair.publicKey());
+    expect(a.walletAddress).not.toBe(b.walletAddress);
+  });
+});

--- a/contrib/examples/headless-agent-signer/headless-agent-signer.ts
+++ b/contrib/examples/headless-agent-signer/headless-agent-signer.ts
@@ -1,0 +1,128 @@
+// Example: a fully HEADLESS agent signer. It generates a fresh ed25519 session
+// keypair, wraps it in vellar-sdk's real `createSessionKeySigner`
+// (src/x402-signer.ts), and signs a hand-built sample x402 auth entry — no
+// browser, no passkey, no external input.
+//
+// This is the "agent" x402 path: an ed25519 session key the agent holds signs
+// each V1 (`sorobanCredentialsAddress`) auth entry directly. The produced
+// signature is a smart-wallet signature map `Vec[Map[SignerKey -> Signature]]`
+// that a Vellar wallet's `__check_auth` accepts. Its spending authority would
+// be bounded on-chain by the spending-limit policy attached to the key.
+//
+// WARNING: TESTNET ONLY. The keypair is generated fresh on every run and holds
+// no funds. Never fund it or reuse it for anything real.
+//
+// Run with: npx tsx headless-agent-signer.ts
+
+import { Address, Keypair, StrKey, nativeToScVal, xdr } from "@stellar/stellar-sdk";
+import { createSessionKeySigner } from "../../../src/x402-signer";
+import type { SmartAccountX402Signer } from "../../../src/x402-types";
+import { TESTNET } from "../../../src/config";
+
+const EXPIRATION_LEDGER = 1_000;
+
+/**
+ * Build a minimal V1 (`sorobanCredentialsAddress`) auth entry for `payer`,
+ * authorizing a dummy SEP-41 `transfer` — just enough structure for the signer
+ * to set the expiration, hash the preimage, and sign. Mirrors the fixture used
+ * in `src/x402-signer.test.ts`.
+ */
+export function makeSampleAuthEntry(
+  payer: string,
+  tokenContract: string,
+  payTo: string,
+): xdr.SorobanAuthorizationEntry {
+  const credentials = xdr.SorobanCredentials.sorobanCredentialsAddress(
+    new xdr.SorobanAddressCredentials({
+      address: new Address(payer).toScAddress(),
+      nonce: xdr.Int64.fromString("42"),
+      signatureExpirationLedger: 0,
+      signature: xdr.ScVal.scvVoid(),
+    }),
+  );
+  const rootInvocation = new xdr.SorobanAuthorizedInvocation({
+    function: xdr.SorobanAuthorizedFunction.sorobanAuthorizedFunctionTypeContractFn(
+      new xdr.InvokeContractArgs({
+        contractAddress: new Address(tokenContract).toScAddress(),
+        functionName: "transfer",
+        args: [
+          nativeToScVal(payer, { type: "address" }),
+          nativeToScVal(payTo, { type: "address" }),
+          nativeToScVal(1n, { type: "i128" }),
+        ],
+      }),
+    ),
+    subInvocations: [],
+  });
+  return new xdr.SorobanAuthorizationEntry({ credentials, rootInvocation });
+}
+
+/** A fresh, disposable contract (C…) address — StrKey-encoded random bytes. */
+function randomContractAddress(): string {
+  return StrKey.encodeContract(Keypair.random().rawPublicKey());
+}
+
+export interface HeadlessSigningResult {
+  /** The freshly generated session key (TESTNET ONLY, disposable). */
+  sessionKeypair: Keypair;
+  /** The smart-account C-address the key signs for. */
+  walletAddress: string;
+  /** The signer built from the session key. */
+  signer: SmartAccountX402Signer;
+  /** The signed auth entry, base64 XDR. */
+  signedEntryXdr: string;
+}
+
+/**
+ * Generate a fresh session key, build the signer, and sign a sample auth entry
+ * end-to-end. Returns everything needed to inspect (or verify) the result.
+ */
+export async function runHeadlessSigning(): Promise<HeadlessSigningResult> {
+  // 1. Generate a fresh ed25519 session keypair (no external input).
+  const sessionKeypair = Keypair.random();
+
+  // 2. Pick the smart-account wallet the key is authorized to sign for.
+  const walletAddress = randomContractAddress();
+
+  // 3. Build the headless signer around the raw secret.
+  const signer = createSessionKeySigner({
+    address: walletAddress,
+    secretKey: sessionKeypair.secret(),
+  });
+
+  // 4. Hand-build a sample auth entry for that wallet and sign it.
+  const entry = makeSampleAuthEntry(walletAddress, randomContractAddress(), randomContractAddress());
+  const signedEntryXdr = await signer.signAuthEntry(entry.toXDR("base64"), {
+    networkPassphrase: TESTNET.networkPassphrase,
+    expirationLedger: EXPIRATION_LEDGER,
+  });
+
+  return { sessionKeypair, walletAddress, signer, signedEntryXdr };
+}
+
+async function main(): Promise<void> {
+  console.log("Headless agent signer (TESTNET ONLY — disposable key)\n");
+
+  const { sessionKeypair, walletAddress, signedEntryXdr } = await runHeadlessSigning();
+
+  console.log(`1. Generated session key : ${sessionKeypair.publicKey()}`);
+  console.log(`2. Smart-account wallet   : ${walletAddress}`);
+  console.log(`3. Built + signed a sample V1 auth entry (expiration ledger ${EXPIRATION_LEDGER})`);
+
+  const signed = xdr.SorobanAuthorizationEntry.fromXDR(signedEntryXdr, "base64");
+  const creds = signed.credentials().address();
+  const sigMap = creds.signature().vec()?.[0]?.map();
+  const signerKeyBytes = sigMap?.[0]?.key().vec()?.[1]?.bytes();
+  const sigBytes = sigMap?.[0]?.val().vec()?.[1]?.bytes();
+
+  console.log(`4. Credentials kept V1    : ${signed.credentials().switch().name === "sorobanCredentialsAddress"}`);
+  console.log(`   Signature expiration   : ${creds.signatureExpirationLedger()}`);
+  console.log(`   Signer key matches      : ${Buffer.compare(signerKeyBytes ?? Buffer.alloc(0), sessionKeypair.rawPublicKey()) === 0}`);
+  console.log(`   Signature length (bytes): ${sigBytes?.length}`);
+  console.log(`5. Signed entry XDR length: ${signedEntryXdr.length} chars`);
+  console.log("\nWARNING: the session key above is disposable — do not fund or reuse it.");
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main();
+}

--- a/contrib/examples/issue-109-percentage-of-amount/README.md
+++ b/contrib/examples/issue-109-percentage-of-amount/README.md
@@ -1,0 +1,3 @@
+# Percentage of Amount Example (#109)
+
+See [`contrib/examples/percentage-of-amount/README.md`](../percentage-of-amount/README.md) for full documentation.

--- a/contrib/examples/issue-109-percentage-of-amount/percentage-of-amount.ts
+++ b/contrib/examples/issue-109-percentage-of-amount/percentage-of-amount.ts
@@ -1,0 +1,1 @@
+export * from '../percentage-of-amount/percentage-of-amount';

--- a/contrib/examples/issue-110-check-trailing-zeros/README.md
+++ b/contrib/examples/issue-110-check-trailing-zeros/README.md
@@ -1,0 +1,3 @@
+# Check Trailing Zeros Example (#110)
+
+See [`contrib/examples/check-trailing-zeros/README.md`](../check-trailing-zeros/README.md) for full documentation.

--- a/contrib/examples/issue-110-check-trailing-zeros/check-trailing-zeros.ts
+++ b/contrib/examples/issue-110-check-trailing-zeros/check-trailing-zeros.ts
@@ -1,0 +1,1 @@
+export * from '../check-trailing-zeros/check-trailing-zeros';

--- a/contrib/examples/issue-111-list-caip2-ids/README.md
+++ b/contrib/examples/issue-111-list-caip2-ids/README.md
@@ -1,0 +1,3 @@
+# CAIP-2 Network Identifiers Example (#111)
+
+See [`contrib/examples/list-caip2-ids/README.md`](../list-caip2-ids/README.md) for full documentation.

--- a/contrib/examples/issue-111-list-caip2-ids/list-caip2-ids.ts
+++ b/contrib/examples/issue-111-list-caip2-ids/list-caip2-ids.ts
@@ -1,0 +1,1 @@
+export * from '../list-caip2-ids/list-caip2-ids';

--- a/contrib/examples/issue-112-relative-time/README.md
+++ b/contrib/examples/issue-112-relative-time/README.md
@@ -1,0 +1,3 @@
+# Format Relative Time Example (#112)
+
+See [`contrib/examples/relative-time/README.md`](../relative-time/README.md) for full documentation.

--- a/contrib/examples/issue-112-relative-time/relative-time.ts
+++ b/contrib/examples/issue-112-relative-time/relative-time.ts
@@ -1,0 +1,1 @@
+export * from '../relative-time/relative-time';

--- a/contrib/examples/issue-113-mask-secret/README.md
+++ b/contrib/examples/issue-113-mask-secret/README.md
@@ -1,0 +1,3 @@
+# Mask Secret Key Example (#113)
+
+See [`contrib/examples/mask-secret/README.md`](../mask-secret/README.md) for full documentation.

--- a/contrib/examples/issue-113-mask-secret/mask-secret.ts
+++ b/contrib/examples/issue-113-mask-secret/mask-secret.ts
@@ -1,0 +1,1 @@
+export * from '../mask-secret/mask-secret';

--- a/contrib/examples/issue-114-check-bigint-string/README.md
+++ b/contrib/examples/issue-114-check-bigint-string/README.md
@@ -1,0 +1,3 @@
+# Check BigInt String Example (#114)
+
+See [`contrib/examples/check-bigint-string/README.md`](../check-bigint-string/README.md) for full documentation.

--- a/contrib/examples/issue-114-check-bigint-string/check-bigint-string.ts
+++ b/contrib/examples/issue-114-check-bigint-string/check-bigint-string.ts
@@ -1,0 +1,1 @@
+export * from '../check-bigint-string/check-bigint-string';

--- a/contrib/examples/issue-115-build-wallet-session/README.md
+++ b/contrib/examples/issue-115-build-wallet-session/README.md
@@ -1,0 +1,3 @@
+# Build WalletSession Example (#115)
+
+See [`contrib/examples/build-wallet-session/README.md`](../build-wallet-session/README.md) for full documentation.

--- a/contrib/examples/issue-115-build-wallet-session/build-wallet-session.ts
+++ b/contrib/examples/issue-115-build-wallet-session/build-wallet-session.ts
@@ -1,0 +1,1 @@
+export * from '../build-wallet-session/build-wallet-session';

--- a/contrib/examples/issue-52-mock-x402-facilitator/README.md
+++ b/contrib/examples/issue-52-mock-x402-facilitator/README.md
@@ -1,0 +1,189 @@
+# Mock x402 Facilitator
+
+A self-contained example module implementing a mock x402 facilitator client
+with `verify` and `settle` functions that return canned success or failure
+results based on input flags.
+
+Contributed for [issue #52](https://github.com/Vellar-Wallet/vellar-sdk/issues/52).
+
+---
+
+## Background
+
+In the x402 payment flow the **facilitator** is a server-side component that
+sits between the paying client and the Stellar network:
+
+```
+Client ──PAYMENT-SIGNATURE──► Resource server
+                                  │
+                                  ▼
+                            Facilitator.verify()  ← validate the signed tx
+                                  │  (success)
+                                  ▼
+                            Facilitator.settle()  ← submit on-chain
+                                  │
+                                  ▼
+                            Resource server grants access
+```
+
+1. `verify` — validates the signed Soroban auth entry without touching the
+   network. Fast, cheap, used to gate access.
+2. `settle` — submits the signed transaction and returns the on-chain hash.
+
+This mock skips all XDR/network work and instead returns canned responses
+controlled by configuration flags. It is useful for:
+
+- Unit-testing x402 client code without a live network
+- Testing resource-server middleware (verify → gate access → settle)
+- Exercising failure paths (spending limit exceeded, invalid signature, etc.)
+
+---
+
+## API
+
+### `createMockFacilitator(config?)`
+
+Creates a new mock facilitator. All config fields are optional.
+
+```ts
+const facilitator = createMockFacilitator({
+  rejectVerify: false,        // set true to simulate a rejected payment
+  rejectReason: "DAILY_LIMIT_EXCEEDED",  // error code on rejection
+  rejectSettle: false,        // set true to simulate on-chain submission failure
+  settleRejectReason: "SUBMISSION_FAILED",
+  settleTxHash: undefined,    // fixed hash; derived deterministically when omitted
+  latencyMs: 0,               // simulate network latency
+});
+```
+
+#### `verify(paymentHeader, requirements): Promise<VerifyResult>`
+
+```ts
+const result = await facilitator.verify(header, requirements);
+if (!result.success) {
+  console.error(result.error);   // e.g. "DAILY_LIMIT_EXCEEDED"
+}
+```
+
+#### `settle(paymentHeader, requirements): Promise<SettleResult>`
+
+```ts
+const result = await facilitator.settle(header, requirements);
+if (result.success) {
+  console.log(result.transaction); // on-chain tx hash
+}
+```
+
+### `makeRequirements(overrides?)`
+
+Returns a minimal valid `PaymentRequirements` fixture. Useful in tests:
+
+```ts
+const req = makeRequirements({ amount: "5000000", network: "stellar:pubnet" });
+```
+
+### `makePaymentHeader(requirements?)`
+
+Returns a base64-encoded `PAYMENT-SIGNATURE` header value matching the shape
+the Vellar SDK client produces:
+
+```ts
+const header = makePaymentHeader(makeRequirements());
+```
+
+---
+
+## Usage examples
+
+### Happy path
+
+```ts
+import { createMockFacilitator, makeRequirements, makePaymentHeader } from "./mock-x402-facilitator";
+
+const req = makeRequirements();
+const header = makePaymentHeader(req);
+const facilitator = createMockFacilitator();
+
+const verifyResult = await facilitator.verify(header, req);
+// { success: true, message: "..." }
+
+if (verifyResult.success) {
+  const settleResult = await facilitator.settle(header, req);
+  // { success: true, transaction: "a1b2c3..." }
+}
+```
+
+### Simulating a spending-limit rejection
+
+```ts
+const facilitator = createMockFacilitator({
+  rejectVerify: true,
+  rejectReason: "DAILY_LIMIT_EXCEEDED",
+});
+
+const result = await facilitator.verify(header, req);
+// { success: false, error: "DAILY_LIMIT_EXCEEDED", message: "..." }
+```
+
+### Simulating an on-chain submission failure
+
+```ts
+const facilitator = createMockFacilitator({
+  rejectSettle: true,
+  settleRejectReason: "NETWORK_CONGESTION",
+});
+
+const settle = await facilitator.settle(header, req);
+// { success: false, error: "NETWORK_CONGESTION" }
+```
+
+### Simulating network latency
+
+```ts
+const facilitator = createMockFacilitator({ latencyMs: 200 });
+// verify and settle will each take ~200 ms
+```
+
+---
+
+## Common `rejectReason` codes
+
+These mirror the error codes a real hosted facilitator returns:
+
+| Code | Meaning |
+|---|---|
+| `DAILY_LIMIT_EXCEEDED` | On-chain spending policy blocked the payment |
+| `INVALID_SIGNATURE` | The auth-entry signature did not verify |
+| `AMOUNT_MISMATCH` | Signed amount does not match the requirements |
+| `EXPIRED` | The signature expiration ledger has passed |
+| `ASSET_NOT_SUPPORTED` | The token is not accepted by this facilitator |
+| `MISSING_HEADER` | `PAYMENT-SIGNATURE` header was absent or empty |
+| `INVALID_REQUIREMENTS` | Requirements were structurally malformed |
+
+---
+
+## Running the tests
+
+The tests use [vitest](https://vitest.dev/), already a dev dependency of the repo.
+
+```bash
+# Run just this example's tests (from the repo root)
+npx vitest run contrib/examples/issue-52-mock-x402-facilitator/mock-x402-facilitator.test.ts
+```
+
+Or run the full suite:
+
+```bash
+npm test
+```
+
+---
+
+## File structure
+
+```
+contrib/examples/issue-52-mock-x402-facilitator/
+├── README.md                          ← you are here
+├── mock-x402-facilitator.ts           ← the module
+└── mock-x402-facilitator.test.ts      ← vitest tests
+```

--- a/contrib/examples/issue-52-mock-x402-facilitator/mock-x402-facilitator.test.ts
+++ b/contrib/examples/issue-52-mock-x402-facilitator/mock-x402-facilitator.test.ts
@@ -1,0 +1,315 @@
+/**
+ * mock-x402-facilitator.test.ts
+ *
+ * Tests for the mock x402 facilitator client.
+ *
+ * Run from the repo root:
+ *   npx vitest run contrib/examples/issue-52-mock-x402-facilitator/mock-x402-facilitator.test.ts
+ *
+ * Or run the full suite:
+ *   npm test
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  createMockFacilitator,
+  makeRequirements,
+  makePaymentHeader,
+  type PaymentRequirements,
+} from "./mock-x402-facilitator";
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Fixtures
+// ─────────────────────────────────────────────────────────────────────────────
+
+const REQ = makeRequirements();
+const HEADER = makePaymentHeader(REQ);
+
+// ─────────────────────────────────────────────────────────────────────────────
+// verify — success path
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("verify — success path", () => {
+  it("returns success: true for a valid header + requirements", async () => {
+    const f = createMockFacilitator();
+    const result = await f.verify(HEADER, REQ);
+    expect(result.success).toBe(true);
+    expect(result.error).toBeUndefined();
+  });
+
+  it("rejectVerify defaults to false — no config needed for happy path", async () => {
+    const f = createMockFacilitator({});
+    const result = await f.verify(HEADER, REQ);
+    expect(result.success).toBe(true);
+  });
+
+  it("result.message is a non-empty string on success", async () => {
+    const f = createMockFacilitator();
+    const result = await f.verify(HEADER, REQ);
+    expect(typeof result.message).toBe("string");
+    expect(result.message!.length).toBeGreaterThan(0);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// verify — rejection path
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("verify — rejection path", () => {
+  it("returns success: false when rejectVerify is true", async () => {
+    const f = createMockFacilitator({ rejectVerify: true });
+    const result = await f.verify(HEADER, REQ);
+    expect(result.success).toBe(false);
+  });
+
+  it("defaults to DAILY_LIMIT_EXCEEDED error code when rejectReason is not set", async () => {
+    const f = createMockFacilitator({ rejectVerify: true });
+    const result = await f.verify(HEADER, REQ);
+    expect(result.error).toBe("DAILY_LIMIT_EXCEEDED");
+  });
+
+  it("uses custom rejectReason when provided", async () => {
+    const f = createMockFacilitator({ rejectVerify: true, rejectReason: "INVALID_SIGNATURE" });
+    const result = await f.verify(HEADER, REQ);
+    expect(result.success).toBe(false);
+    expect(result.error).toBe("INVALID_SIGNATURE");
+  });
+
+  it("supports EXPIRED as a rejectReason", async () => {
+    const f = createMockFacilitator({ rejectVerify: true, rejectReason: "EXPIRED" });
+    const result = await f.verify(HEADER, REQ);
+    expect(result.error).toBe("EXPIRED");
+  });
+
+  it("supports ASSET_NOT_SUPPORTED as a rejectReason", async () => {
+    const f = createMockFacilitator({
+      rejectVerify: true,
+      rejectReason: "ASSET_NOT_SUPPORTED",
+    });
+    const result = await f.verify(HEADER, REQ);
+    expect(result.error).toBe("ASSET_NOT_SUPPORTED");
+  });
+
+  it("result.message describes the rejection on failure", async () => {
+    const f = createMockFacilitator({ rejectVerify: true, rejectReason: "AMOUNT_MISMATCH" });
+    const result = await f.verify(HEADER, REQ);
+    expect(result.message).toBeDefined();
+    expect(result.message!.toLowerCase()).toContain("amount_mismatch");
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// verify — structural validation
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("verify — structural validation", () => {
+  it("rejects an empty header with MISSING_HEADER", async () => {
+    const f = createMockFacilitator();
+    const result = await f.verify("", REQ);
+    expect(result.success).toBe(false);
+    expect(result.error).toBe("MISSING_HEADER");
+  });
+
+  it("rejects requirements missing the asset field", async () => {
+    const f = createMockFacilitator();
+    const bad: PaymentRequirements = { ...REQ, asset: "" };
+    const result = await f.verify(HEADER, bad);
+    expect(result.success).toBe(false);
+    expect(result.error).toBe("INVALID_REQUIREMENTS");
+  });
+
+  it("rejects requirements missing the payTo field", async () => {
+    const f = createMockFacilitator();
+    const bad: PaymentRequirements = { ...REQ, payTo: "" };
+    const result = await f.verify(HEADER, bad);
+    expect(result.success).toBe(false);
+    expect(result.error).toBe("INVALID_REQUIREMENTS");
+  });
+
+  it("rejects a non-integer amount string", async () => {
+    const f = createMockFacilitator();
+    const bad: PaymentRequirements = { ...REQ, amount: "1.5" };
+    const result = await f.verify(HEADER, bad);
+    expect(result.success).toBe(false);
+    expect(result.error).toBe("INVALID_REQUIREMENTS");
+  });
+
+  it("rejects a non-numeric amount string", async () => {
+    const f = createMockFacilitator();
+    const bad: PaymentRequirements = { ...REQ, amount: "abc" };
+    const result = await f.verify(HEADER, bad);
+    expect(result.success).toBe(false);
+    expect(result.error).toBe("INVALID_REQUIREMENTS");
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// settle — success path
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("settle — success path", () => {
+  it("returns success: true for a valid header + requirements", async () => {
+    const f = createMockFacilitator();
+    const result = await f.settle(HEADER, REQ);
+    expect(result.success).toBe(true);
+    expect(result.error).toBeUndefined();
+  });
+
+  it("returns a transaction hash on success", async () => {
+    const f = createMockFacilitator();
+    const result = await f.settle(HEADER, REQ);
+    expect(result.transaction).toBeDefined();
+    expect(typeof result.transaction).toBe("string");
+    expect(result.transaction!.length).toBeGreaterThan(0);
+  });
+
+  it("returns the configured settleTxHash when provided", async () => {
+    const fixed = "a".repeat(64);
+    const f = createMockFacilitator({ settleTxHash: fixed });
+    const result = await f.settle(HEADER, REQ);
+    expect(result.transaction).toBe(fixed);
+  });
+
+  it("returns the same derived hash for the same header (deterministic)", async () => {
+    const f = createMockFacilitator();
+    const r1 = await f.settle(HEADER, REQ);
+    const r2 = await f.settle(HEADER, REQ);
+    expect(r1.transaction).toBe(r2.transaction);
+  });
+
+  it("returns different hashes for different headers", async () => {
+    const f = createMockFacilitator();
+    const reqB = makeRequirements({ amount: "5000000" });
+    const headerB = makePaymentHeader(reqB);
+    const r1 = await f.settle(HEADER, REQ);
+    const r2 = await f.settle(headerB, reqB);
+    expect(r1.transaction).not.toBe(r2.transaction);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// settle — rejection path
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("settle — rejection path", () => {
+  it("returns success: false when rejectVerify is true (settle should not proceed)", async () => {
+    const f = createMockFacilitator({ rejectVerify: true });
+    const result = await f.settle(HEADER, REQ);
+    expect(result.success).toBe(false);
+    expect(result.transaction).toBeUndefined();
+  });
+
+  it("returns success: false when rejectSettle is true", async () => {
+    const f = createMockFacilitator({ rejectSettle: true });
+    const result = await f.settle(HEADER, REQ);
+    expect(result.success).toBe(false);
+    expect(result.error).toBe("SUBMISSION_FAILED");
+  });
+
+  it("uses custom settleRejectReason when provided", async () => {
+    const f = createMockFacilitator({
+      rejectSettle: true,
+      settleRejectReason: "NETWORK_CONGESTION",
+    });
+    const result = await f.settle(HEADER, REQ);
+    expect(result.error).toBe("NETWORK_CONGESTION");
+  });
+
+  it("rejects settlement for an empty header", async () => {
+    const f = createMockFacilitator();
+    const result = await f.settle("", REQ);
+    expect(result.success).toBe(false);
+    expect(result.error).toBe("MISSING_HEADER");
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Full verify → settle flow
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("full verify → settle flow", () => {
+  it("happy path: verify succeeds then settle returns a tx hash", async () => {
+    const f = createMockFacilitator();
+
+    const verifyResult = await f.verify(HEADER, REQ);
+    expect(verifyResult.success).toBe(true);
+
+    const settleResult = await f.settle(HEADER, REQ);
+    expect(settleResult.success).toBe(true);
+    expect(settleResult.transaction).toBeDefined();
+  });
+
+  it("rejection path: verify fails, no settlement attempted", async () => {
+    const f = createMockFacilitator({ rejectVerify: true });
+
+    const verifyResult = await f.verify(HEADER, REQ);
+    expect(verifyResult.success).toBe(false);
+    expect(verifyResult.error).toBe("DAILY_LIMIT_EXCEEDED");
+
+    // A well-behaved client should not call settle after a verify failure,
+    // but the mock also rejects it if called — both paths are covered.
+    const settleResult = await f.settle(HEADER, REQ);
+    expect(settleResult.success).toBe(false);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Fixture helpers
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("makeRequirements", () => {
+  it("returns a valid requirements object", () => {
+    const req = makeRequirements();
+    expect(req.scheme).toBe("exact");
+    expect(req.network).toBe("stellar:testnet");
+    expect(typeof req.asset).toBe("string");
+    expect(req.asset.length).toBeGreaterThan(0);
+    expect(/^\d+$/.test(req.amount)).toBe(true);
+    expect(typeof req.payTo).toBe("string");
+  });
+
+  it("accepts overrides", () => {
+    const req = makeRequirements({ amount: "99999999", network: "stellar:pubnet" });
+    expect(req.amount).toBe("99999999");
+    expect(req.network).toBe("stellar:pubnet");
+    // Non-overridden fields are still present
+    expect(req.scheme).toBe("exact");
+  });
+});
+
+describe("makePaymentHeader", () => {
+  it("returns a non-empty base64 string", () => {
+    const header = makePaymentHeader();
+    expect(typeof header).toBe("string");
+    expect(header.length).toBeGreaterThan(0);
+  });
+
+  it("encodes valid JSON containing the requirements", () => {
+    const req = makeRequirements({ amount: "2000000" });
+    const header = makePaymentHeader(req);
+    const decoded = JSON.parse(atob(header));
+    expect(decoded.x402Version).toBe(2);
+    expect(decoded.accepted.amount).toBe("2000000");
+    expect(decoded.payload.transaction).toBeDefined();
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Latency simulation
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("latency simulation", () => {
+  it("latencyMs=0 (default) completes without artificial delay", async () => {
+    const f = createMockFacilitator({ latencyMs: 0 });
+    const start = Date.now();
+    await f.verify(HEADER, REQ);
+    expect(Date.now() - start).toBeLessThan(50);
+  });
+
+  it("latencyMs introduces at least that much delay on verify", async () => {
+    const f = createMockFacilitator({ latencyMs: 50 });
+    const start = Date.now();
+    await f.verify(HEADER, REQ);
+    expect(Date.now() - start).toBeGreaterThanOrEqual(45); // allow slight timer drift
+  });
+});

--- a/contrib/examples/issue-52-mock-x402-facilitator/mock-x402-facilitator.ts
+++ b/contrib/examples/issue-52-mock-x402-facilitator/mock-x402-facilitator.ts
@@ -1,0 +1,354 @@
+/**
+ * mock-x402-facilitator.ts
+ *
+ * A self-contained mock x402 facilitator client with `verify` and `settle`
+ * functions that match the general shape used by the Vellar SDK client.
+ *
+ * The x402 facilitator is the server-side component that:
+ *   1. Receives a `PAYMENT-SIGNATURE` header from the paying client.
+ *   2. Calls `verify` — validates the signed Soroban auth entry without
+ *      settling on-chain (fast, cheap, used to gate access).
+ *   3. Calls `settle` — submits the signed transaction to the network and
+ *      returns the on-chain settlement hash.
+ *
+ * This mock skips all network/XDR work and instead returns canned responses
+ * controlled by configuration flags. It is useful for testing x402 client
+ * flows, resource-server middleware, and error-path handling in isolation.
+ *
+ * Usage in tests:
+ *
+ *   const facilitator = createMockFacilitator({ rejectVerify: false });
+ *   const verifyResult = await facilitator.verify(paymentHeader, requirements);
+ *   if (!verifyResult.success) throw new Error(verifyResult.error);
+ *   const settlement = await facilitator.settle(paymentHeader, requirements);
+ *
+ * To simulate a failure path:
+ *
+ *   const facilitator = createMockFacilitator({ rejectVerify: true });
+ *   const result = await facilitator.verify(paymentHeader, requirements);
+ *   // result.success === false, result.error === "DAILY_LIMIT_EXCEEDED"
+ */
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Shared types — mirror the real facilitator API shapes
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Payment requirements for one accepted option, as decoded from a 402 response.
+ * Mirrors `PaymentRequirements` in `src/x402-types.ts`.
+ */
+export interface PaymentRequirements {
+  scheme: string;        // "exact"
+  network: string;       // CAIP-2 e.g. "stellar:testnet"
+  asset: string;         // SAC contract id
+  amount: string;        // base units as a decimal string
+  payTo: string;         // recipient address
+  maxTimeoutSeconds?: number;
+  extra?: Record<string, unknown>;
+}
+
+/**
+ * The decoded payment payload extracted from the `PAYMENT-SIGNATURE` header
+ * (base64 JSON). The SDK sets `x402Version`, `accepted`, and `payload.transaction`
+ * (the base64 XDR of the built SEP-41 transfer).
+ */
+export interface PaymentPayload {
+  x402Version: number;
+  accepted: PaymentRequirements;
+  payload: {
+    /** Base64 XDR of the assembled + auth-signed SEP-41 transfer transaction. */
+    transaction: string;
+  };
+}
+
+/** Result of a `verify` call. */
+export interface VerifyResult {
+  /** True when the payment is valid and can be settled. */
+  success: boolean;
+  /**
+   * Machine-readable rejection reason, present when `success` is false.
+   * Common values from real facilitators:
+   *   "DAILY_LIMIT_EXCEEDED", "INVALID_SIGNATURE", "AMOUNT_MISMATCH",
+   *   "EXPIRED", "ASSET_NOT_SUPPORTED"
+   */
+  error?: string;
+  /** Optional human-readable detail for logging. */
+  message?: string;
+}
+
+/** Result of a `settle` call. */
+export interface SettleResult {
+  /** True when the transaction was successfully submitted on-chain. */
+  success: boolean;
+  /** On-chain transaction hash, present on success. */
+  transaction?: string;
+  /** Rejection reason, present on failure. */
+  error?: string;
+  /** Optional human-readable detail for logging. */
+  message?: string;
+}
+
+/**
+ * The facilitator client interface. Mirrors the surface the SDK's x402 client
+ * expects from a real hosted facilitator, adapted for direct function calls
+ * (the real client calls these via HTTP; tests call them directly).
+ */
+export interface FacilitatorClient {
+  /**
+   * Verify a signed payment without settling.
+   *
+   * @param paymentHeader - The raw value of the `PAYMENT-SIGNATURE` header.
+   * @param requirements  - The payment requirements the signature must satisfy.
+   */
+  verify(paymentHeader: string, requirements: PaymentRequirements): Promise<VerifyResult>;
+
+  /**
+   * Settle a previously verified payment by submitting the transaction on-chain.
+   *
+   * @param paymentHeader - The raw value of the `PAYMENT-SIGNATURE` header.
+   * @param requirements  - The payment requirements the signature must satisfy.
+   */
+  settle(paymentHeader: string, requirements: PaymentRequirements): Promise<SettleResult>;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Configuration
+// ─────────────────────────────────────────────────────────────────────────────
+
+export interface MockFacilitatorConfig {
+  /**
+   * When `true`, `verify` returns a failure result instead of success.
+   * Useful for testing the client's rejection-handling path (e.g. spending
+   * limit exceeded, invalid signature).
+   *
+   * `settle` is not called in the normal flow when `verify` fails, but if
+   * called directly it will also fail when this flag is set.
+   *
+   * @default false
+   */
+  rejectVerify?: boolean;
+
+  /**
+   * The machine-readable error code to return when `rejectVerify` is `true`.
+   *
+   * @default "DAILY_LIMIT_EXCEEDED"
+   */
+  rejectReason?: string;
+
+  /**
+   * When `true`, `settle` fails even if `verify` would pass. Lets you test
+   * the narrow window where on-chain submission fails after a successful verify.
+   *
+   * @default false
+   */
+  rejectSettle?: boolean;
+
+  /**
+   * The error code to return when `rejectSettle` is `true`.
+   *
+   * @default "SUBMISSION_FAILED"
+   */
+  settleRejectReason?: string;
+
+  /**
+   * A fixed transaction hash to return on successful `settle` calls. When
+   * omitted a deterministic pseudo-hash is derived from the payment header so
+   * repeated calls with the same input return the same hash (useful for
+   * assertions in tests without requiring a real network).
+   */
+  settleTxHash?: string;
+
+  /**
+   * Optional delay in milliseconds applied to both `verify` and `settle`.
+   * Simulates network latency in integration tests.
+   *
+   * @default 0
+   */
+  latencyMs?: number;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Implementation
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Produce a deterministic pseudo-hash from a payment header string. Not
+ * cryptographic — only used to generate stable mock transaction hashes so tests
+ * can assert on a consistent value without a real network.
+ */
+function deriveMockTxHash(header: string): string {
+  let h = 0x811c9dc5;
+  for (let i = 0; i < header.length; i++) {
+    h ^= header.charCodeAt(i);
+    h = (Math.imul(h, 0x01000193) >>> 0);
+  }
+  // Pad to 64 hex chars (real Stellar tx hashes are 32 bytes = 64 hex chars).
+  return h.toString(16).padStart(8, "0").repeat(8);
+}
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * Create a mock x402 facilitator client.
+ *
+ * @param config - Optional configuration flags. All fields have sensible defaults.
+ * @returns A `FacilitatorClient` with `verify` and `settle` methods.
+ *
+ * @example
+ * // Happy path
+ * const facilitator = createMockFacilitator();
+ * const result = await facilitator.verify(header, requirements);
+ * // { success: true }
+ *
+ * @example
+ * // Failure path — spending limit exceeded
+ * const facilitator = createMockFacilitator({
+ *   rejectVerify: true,
+ *   rejectReason: "DAILY_LIMIT_EXCEEDED",
+ * });
+ * const result = await facilitator.verify(header, requirements);
+ * // { success: false, error: "DAILY_LIMIT_EXCEEDED", message: "..." }
+ */
+export function createMockFacilitator(config: MockFacilitatorConfig = {}): FacilitatorClient {
+  const {
+    rejectVerify = false,
+    rejectReason = "DAILY_LIMIT_EXCEEDED",
+    rejectSettle = false,
+    settleRejectReason = "SUBMISSION_FAILED",
+    settleTxHash,
+    latencyMs = 0,
+  } = config;
+
+  return {
+    async verify(paymentHeader, requirements): Promise<VerifyResult> {
+      if (latencyMs > 0) await delay(latencyMs);
+
+      // Basic structural validation — a real facilitator does this too, and
+      // the mock mirrors it so tests catch malformed header bugs early.
+      if (!paymentHeader || typeof paymentHeader !== "string") {
+        return {
+          success: false,
+          error: "MISSING_HEADER",
+          message: "PAYMENT-SIGNATURE header is required.",
+        };
+      }
+      if (!requirements.asset || !requirements.amount || !requirements.payTo) {
+        return {
+          success: false,
+          error: "INVALID_REQUIREMENTS",
+          message: "Payment requirements are incomplete (asset, amount, payTo are required).",
+        };
+      }
+      if (!/^\d+$/.test(requirements.amount)) {
+        return {
+          success: false,
+          error: "INVALID_REQUIREMENTS",
+          message: `Payment requirements contain a non-integer amount: ${JSON.stringify(requirements.amount)}.`,
+        };
+      }
+
+      if (rejectVerify) {
+        return {
+          success: false,
+          error: rejectReason,
+          message: `Mock facilitator rejected the payment: ${rejectReason}.`,
+        };
+      }
+
+      return {
+        success: true,
+        message: "Mock facilitator: payment verified successfully.",
+      };
+    },
+
+    async settle(paymentHeader, requirements): Promise<SettleResult> {
+      if (latencyMs > 0) await delay(latencyMs);
+
+      // Settle must not proceed if the requirements are structurally invalid.
+      if (!paymentHeader || typeof paymentHeader !== "string") {
+        return {
+          success: false,
+          error: "MISSING_HEADER",
+          message: "PAYMENT-SIGNATURE header is required.",
+        };
+      }
+      if (!requirements.asset || !requirements.amount || !requirements.payTo) {
+        return {
+          success: false,
+          error: "INVALID_REQUIREMENTS",
+          message: "Payment requirements are incomplete.",
+        };
+      }
+
+      // A verify failure means settlement should never proceed in normal flow.
+      // Allow the flag to also gate settle so callers can simulate early errors.
+      if (rejectVerify || rejectSettle) {
+        const reason = rejectSettle ? settleRejectReason : rejectReason;
+        return {
+          success: false,
+          error: reason,
+          message: `Mock facilitator rejected settlement: ${reason}.`,
+        };
+      }
+
+      const transaction = settleTxHash ?? deriveMockTxHash(paymentHeader);
+      return {
+        success: true,
+        transaction,
+        message: "Mock facilitator: payment settled successfully.",
+      };
+    },
+  };
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Helpers — useful for building test fixtures
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Build a minimal valid `PaymentRequirements` fixture for tests.
+ * Override individual fields by spreading the result:
+ *
+ *   { ...makeRequirements(), amount: "99999999999" }
+ */
+export function makeRequirements(
+  overrides: Partial<PaymentRequirements> = {},
+): PaymentRequirements {
+  return {
+    scheme: "exact",
+    network: "stellar:testnet",
+    asset: "CDLZFC3SYJYDZT7K67VZ75HPJVIEUVNIXF47ZG2FB2RMQQVU2HHGCYSC",
+    amount: "1000000",  // 0.1 XLM in stroops (7 decimals)
+    payTo: "GAHJJJKMOKYE4RVPZEWZTKH5FVI4PA3VL7GK2LFNUBSGBV4HRKNXNEW",
+    maxTimeoutSeconds: 60,
+    ...overrides,
+  };
+}
+
+/**
+ * Build a minimal valid `PAYMENT-SIGNATURE` header value for tests. The
+ * content is base64 JSON matching the shape the SDK client produces.
+ *
+ * Optionally pass `requirements` to embed in the payload; defaults to
+ * `makeRequirements()`.
+ */
+export function makePaymentHeader(
+  requirements: PaymentRequirements = makeRequirements(),
+): string {
+  const payload: PaymentPayload = {
+    x402Version: 2,
+    accepted: requirements,
+    payload: {
+      // Placeholder XDR — not a real transaction; enough for structural tests.
+      transaction: "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==",
+    },
+  };
+  // Browser-safe base64 encode (no Buffer / Node.js dependency).
+  const json = JSON.stringify(payload);
+  const bytes = new TextEncoder().encode(json);
+  let bin = "";
+  for (const b of bytes) bin += String.fromCharCode(b);
+  return btoa(bin);
+}

--- a/contrib/examples/issue-55-error-to-message/README.md
+++ b/contrib/examples/issue-55-error-to-message/README.md
@@ -1,0 +1,125 @@
+# Error to Message
+
+A self-contained example module that maps known Vellar SDK error class
+instances to short, friendly display strings for a UI.
+
+Contributed for [issue #55](https://github.com/Vellar-Wallet/vellar-sdk/issues/55).
+
+---
+
+## Overview
+
+`error-to-message.ts` exports a single function:
+
+```ts
+function sdkErrorToMessage(err: unknown): string
+```
+
+Pass anything your `catch` block receives — a known SDK error, a plain
+`Error`, a string, `null`, anything. It always returns a human-readable
+sentence safe to show in a toast, banner, or form field.
+
+### Covered error classes
+
+| Error class | User-facing message theme |
+|---|---|
+| `WalletNotReadyError` | Connect your wallet first |
+| `WalletNetworkMismatchError` | Network mismatch between wallet and app |
+| `InvalidAmountError` | Invalid payment amount |
+| `InvalidRecipientError` | Invalid recipient address |
+| `MainnetConfigError` | Mainnet configuration incomplete |
+| `PolicyApiError` | Policy service error (status-aware: network, auth, not-found, server, generic) |
+| `X402NotConfiguredError` | x402 agentic payments not configured |
+| `MaxAmountExceededError` | Server requested more than your set limit |
+| `DisallowedAssetError` | Server requested a token not on your allow-list |
+| `NoUsablePaymentOptionError` | No compatible payment option available |
+| `PaymentRejectedError` | Payment declined (spending limit / facilitator rejection) |
+| `InvalidRequirementsError` | Server sent a malformed payment request |
+| _anything else_ | Generic fallback — never exposes internal detail |
+
+---
+
+## Usage
+
+```ts
+import { sdkErrorToMessage } from "./error-to-message";
+// In your real app, also import the SDK error classes from "vellar-sdk":
+//   import { WalletNotReadyError, ... } from "vellar-sdk";
+
+try {
+  await wallet.pay({ to, amount, token });
+} catch (err) {
+  // Always safe to show — no raw stack traces or internal messages.
+  showToast(sdkErrorToMessage(err));
+}
+```
+
+### Per-component example
+
+```ts
+try {
+  await wallet.connect();
+} catch (err) {
+  setErrorMessage(sdkErrorToMessage(err));
+}
+```
+
+---
+
+## Running the tests
+
+The tests use [vitest](https://vitest.dev/), already a dev dependency of the repo.
+
+```bash
+# Run just this example's tests (from the repo root)
+npx vitest run contrib/examples/issue-55-error-to-message/error-to-message.test.ts
+```
+
+Or run the full suite:
+
+```bash
+npm test
+```
+
+Expected output:
+
+```
+ ✓ contrib/examples/issue-55-error-to-message/error-to-message.test.ts (24)
+   ✓ sdkErrorToMessage — known SDK errors > WalletNotReadyError → prompt to connect
+   ✓ sdkErrorToMessage — known SDK errors > WalletNetworkMismatchError → network mismatch message
+   ✓ sdkErrorToMessage — known SDK errors > InvalidAmountError → amount guidance
+   ✓ sdkErrorToMessage — known SDK errors > InvalidRecipientError → recipient guidance
+   ✓ sdkErrorToMessage — known SDK errors > MainnetConfigError → config guidance
+   ✓ sdkErrorToMessage — known SDK errors > PolicyApiError > status 0 → network connectivity message
+   ✓ sdkErrorToMessage — known SDK errors > PolicyApiError > status 401 → access denied message
+   ✓ sdkErrorToMessage — known SDK errors > PolicyApiError > status 403 → access denied message
+   ✓ sdkErrorToMessage — known SDK errors > PolicyApiError > status 404 → not found message
+   ✓ sdkErrorToMessage — known SDK errors > PolicyApiError > status 500 → service unavailable message
+   ✓ sdkErrorToMessage — known SDK errors > PolicyApiError > other status → generic policy message
+   ✓ sdkErrorToMessage — known SDK errors > X402NotConfiguredError → x402 setup guidance
+   ✓ sdkErrorToMessage — known SDK errors > MaxAmountExceededError → amount limit message
+   ✓ sdkErrorToMessage — known SDK errors > DisallowedAssetError → disallowed token message
+   ✓ sdkErrorToMessage — known SDK errors > NoUsablePaymentOptionError → no compatible option message
+   ✓ sdkErrorToMessage — known SDK errors > PaymentRejectedError → payment declined message
+   ✓ sdkErrorToMessage — known SDK errors > InvalidRequirementsError → bad server request message
+   ✓ sdkErrorToMessage — unknown / generic error types > plain Error → generic fallback
+   ✓ sdkErrorToMessage — unknown / generic error types > string throw → generic fallback
+   ✓ sdkErrorToMessage — unknown / generic error types > null throw → generic fallback
+   ✓ sdkErrorToMessage — unknown / generic error types > undefined throw → generic fallback
+   ✓ sdkErrorToMessage — unknown / generic error types > number throw → generic fallback
+   ✓ sdkErrorToMessage — unknown / generic error types > custom error class not in SDK → generic fallback
+
+ Test Files  1 passed (1)
+ Tests       23 passed (23)
+```
+
+---
+
+## File structure
+
+```
+contrib/examples/issue-55-error-to-message/
+├── README.md                  ← you are here
+├── error-to-message.ts        ← the module
+└── error-to-message.test.ts   ← vitest tests
+```

--- a/contrib/examples/issue-55-error-to-message/error-to-message.test.ts
+++ b/contrib/examples/issue-55-error-to-message/error-to-message.test.ts
@@ -1,0 +1,208 @@
+/**
+ * error-to-message.test.ts
+ *
+ * Tests for sdkErrorToMessage.
+ *
+ * Run from the repo root:
+ *   npx vitest run contrib/examples/issue-55-error-to-message/error-to-message.test.ts
+ *
+ * Or run the whole suite:
+ *   npm test
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  sdkErrorToMessage,
+  WalletNotReadyError,
+  WalletNetworkMismatchError,
+  InvalidAmountError,
+  InvalidRecipientError,
+  MainnetConfigError,
+  PolicyApiError,
+  X402NotConfiguredError,
+  MaxAmountExceededError,
+  DisallowedAssetError,
+  NoUsablePaymentOptionError,
+  PaymentRejectedError,
+  InvalidRequirementsError,
+} from "./error-to-message";
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Helpers
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** Assert message is non-empty and does not look like a raw internal error. */
+function expectFriendly(msg: string): void {
+  expect(msg.length).toBeGreaterThan(0);
+  // Should not start with a capital error-class name like "WalletNotReadyError:"
+  expect(msg).not.toMatch(/^[A-Z][a-zA-Z]+Error:/);
+  // Should not expose internal stack hints
+  expect(msg).not.toContain("at Object.");
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Known error classes
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("sdkErrorToMessage — known SDK errors", () => {
+  it("WalletNotReadyError → prompt to connect", () => {
+    const msg = sdkErrorToMessage(new WalletNotReadyError("not ready"));
+    expectFriendly(msg);
+    expect(msg.toLowerCase()).toContain("connect");
+  });
+
+  it("WalletNetworkMismatchError → network mismatch message", () => {
+    const msg = sdkErrorToMessage(new WalletNetworkMismatchError("testnet", "mainnet"));
+    expectFriendly(msg);
+    expect(msg.toLowerCase()).toContain("network");
+  });
+
+  it("InvalidAmountError → amount guidance", () => {
+    const msg = sdkErrorToMessage(new InvalidAmountError("0 is not valid"));
+    expectFriendly(msg);
+    expect(msg.toLowerCase()).toContain("amount");
+  });
+
+  it("InvalidRecipientError → recipient guidance", () => {
+    const msg = sdkErrorToMessage(new InvalidRecipientError("bad address"));
+    expectFriendly(msg);
+    expect(msg.toLowerCase()).toContain("recipient");
+  });
+
+  it("MainnetConfigError → config guidance", () => {
+    const msg = sdkErrorToMessage(
+      new MainnetConfigError("mainnetConfig: rpcUrl is required"),
+    );
+    expectFriendly(msg);
+    expect(msg.toLowerCase()).toContain("mainnet");
+  });
+
+  describe("PolicyApiError", () => {
+    it("status 0 → network connectivity message", () => {
+      const msg = sdkErrorToMessage(new PolicyApiError("network request failed", 0));
+      expectFriendly(msg);
+      expect(msg.toLowerCase()).toContain("connection");
+    });
+
+    it("status 401 → access denied message", () => {
+      const msg = sdkErrorToMessage(new PolicyApiError("unauthorized", 401));
+      expectFriendly(msg);
+      expect(msg.toLowerCase()).toContain("access denied");
+    });
+
+    it("status 403 → access denied message", () => {
+      const msg = sdkErrorToMessage(new PolicyApiError("forbidden", 403));
+      expectFriendly(msg);
+      expect(msg.toLowerCase()).toContain("access denied");
+    });
+
+    it("status 404 → not found message", () => {
+      const msg = sdkErrorToMessage(new PolicyApiError("not found", 404));
+      expectFriendly(msg);
+      expect(msg.toLowerCase()).toContain("not found");
+    });
+
+    it("status 500 → service unavailable message", () => {
+      const msg = sdkErrorToMessage(new PolicyApiError("internal server error", 500));
+      expectFriendly(msg);
+      expect(msg.toLowerCase()).toContain("unavailable");
+    });
+
+    it("other status → generic policy message", () => {
+      const msg = sdkErrorToMessage(new PolicyApiError("bad request", 400));
+      expectFriendly(msg);
+      expect(msg.toLowerCase()).toContain("policy");
+    });
+  });
+
+  it("X402NotConfiguredError → x402 setup guidance", () => {
+    const msg = sdkErrorToMessage(
+      new X402NotConfiguredError("wallet.x402 requires x402 config"),
+    );
+    expectFriendly(msg);
+    expect(msg.toLowerCase()).toContain("x402");
+  });
+
+  it("MaxAmountExceededError → amount limit message", () => {
+    const msg = sdkErrorToMessage(
+      new MaxAmountExceededError(5_000_000n, 1_000_000n, "USDC"),
+    );
+    expectFriendly(msg);
+    expect(msg.toLowerCase()).toContain("limit");
+  });
+
+  it("DisallowedAssetError → disallowed token message", () => {
+    const msg = sdkErrorToMessage(new DisallowedAssetError("UNKNOWN", ["USDC", "XLM"]));
+    expectFriendly(msg);
+    expect(msg.toLowerCase()).toContain("token");
+  });
+
+  it("NoUsablePaymentOptionError → no compatible option message", () => {
+    const msg = sdkErrorToMessage(
+      new NoUsablePaymentOptionError("no matching scheme/asset"),
+    );
+    expectFriendly(msg);
+    expect(msg.toLowerCase()).toContain("payment option");
+  });
+
+  it("PaymentRejectedError → payment declined message", () => {
+    const msg = sdkErrorToMessage(
+      new PaymentRejectedError("over budget", "DAILY_LIMIT_EXCEEDED"),
+    );
+    expectFriendly(msg);
+    expect(msg.toLowerCase()).toContain("declined");
+  });
+
+  it("InvalidRequirementsError → bad server request message", () => {
+    const msg = sdkErrorToMessage(
+      new InvalidRequirementsError("amount is negative"),
+    );
+    expectFriendly(msg);
+    expect(msg.toLowerCase()).toContain("invalid");
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Unknown / generic error types
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("sdkErrorToMessage — unknown / generic error types", () => {
+  it("plain Error → generic fallback", () => {
+    const msg = sdkErrorToMessage(new Error("some internal detail"));
+    expectFriendly(msg);
+    // Should not leak internal detail in the user-facing string
+    expect(msg).not.toContain("some internal detail");
+    expect(msg.toLowerCase()).toContain("something went wrong");
+  });
+
+  it("string throw → generic fallback", () => {
+    const msg = sdkErrorToMessage("unexpected string error");
+    expectFriendly(msg);
+    expect(msg.toLowerCase()).toContain("something went wrong");
+  });
+
+  it("null throw → generic fallback", () => {
+    const msg = sdkErrorToMessage(null);
+    expectFriendly(msg);
+    expect(msg.toLowerCase()).toContain("something went wrong");
+  });
+
+  it("undefined throw → generic fallback", () => {
+    const msg = sdkErrorToMessage(undefined);
+    expectFriendly(msg);
+    expect(msg.toLowerCase()).toContain("something went wrong");
+  });
+
+  it("number throw → generic fallback", () => {
+    const msg = sdkErrorToMessage(42);
+    expectFriendly(msg);
+    expect(msg.toLowerCase()).toContain("something went wrong");
+  });
+
+  it("custom error class not in SDK → generic fallback", () => {
+    class MyAppError extends Error {}
+    const msg = sdkErrorToMessage(new MyAppError("app-level detail"));
+    expectFriendly(msg);
+    expect(msg.toLowerCase()).toContain("something went wrong");
+  });
+});

--- a/contrib/examples/issue-55-error-to-message/error-to-message.ts
+++ b/contrib/examples/issue-55-error-to-message/error-to-message.ts
@@ -1,0 +1,222 @@
+/**
+ * error-to-message.ts
+ *
+ * Maps known Vellar SDK error class instances to short, friendly display
+ * strings suitable for showing directly in a UI. Falls back to a generic
+ * message for any error type not explicitly handled.
+ *
+ * This is a self-contained example — it re-declares the SDK error classes
+ * locally so the module works without installing the SDK itself. In a real
+ * app you would import the error classes from "vellar-sdk" instead.
+ */
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Re-declarations of the SDK error classes (names match exactly)
+// In your own code replace these with:
+//   import {
+//     WalletNotReadyError, WalletNetworkMismatchError, InvalidAmountError,
+//     InvalidRecipientError, MainnetConfigError, PolicyApiError,
+//     X402NotConfiguredError, MaxAmountExceededError, DisallowedAssetError,
+//     NoUsablePaymentOptionError, PaymentRejectedError, InvalidRequirementsError,
+//   } from "vellar-sdk";
+// ─────────────────────────────────────────────────────────────────────────────
+
+export class WalletNotReadyError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "WalletNotReadyError";
+  }
+}
+
+export class WalletNetworkMismatchError extends Error {
+  constructor(expected: string, actual: string) {
+    super(`Connector is configured for ${expected} but was asked to operate on ${actual}`);
+    this.name = "WalletNetworkMismatchError";
+  }
+}
+
+export class InvalidAmountError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "InvalidAmountError";
+  }
+}
+
+export class InvalidRecipientError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "InvalidRecipientError";
+  }
+}
+
+export class MainnetConfigError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "MainnetConfigError";
+  }
+}
+
+export class PolicyApiError extends Error {
+  readonly status: number;
+  readonly errors?: string[];
+  constructor(message: string, status: number, errors?: string[]) {
+    super(message);
+    this.name = "PolicyApiError";
+    this.status = status;
+    this.errors = errors;
+  }
+}
+
+export class X402NotConfiguredError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "X402NotConfiguredError";
+  }
+}
+
+export class MaxAmountExceededError extends Error {
+  readonly required: bigint;
+  readonly maxAmount: bigint;
+  readonly asset: string;
+  constructor(required: bigint, maxAmount: bigint, asset: string) {
+    super(
+      `x402 payment of ${required} (${asset}) exceeds maxAmount ${maxAmount}; refusing to sign.`,
+    );
+    this.name = "MaxAmountExceededError";
+    this.required = required;
+    this.maxAmount = maxAmount;
+    this.asset = asset;
+  }
+}
+
+export class DisallowedAssetError extends Error {
+  readonly asset: string;
+  readonly allowedAssets: string[];
+  constructor(asset: string, allowedAssets: string[]) {
+    super(
+      `x402 requested asset ${asset} is not in allowedAssets [${allowedAssets.join(", ")}].`,
+    );
+    this.name = "DisallowedAssetError";
+    this.asset = asset;
+    this.allowedAssets = allowedAssets;
+  }
+}
+
+export class NoUsablePaymentOptionError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "NoUsablePaymentOptionError";
+  }
+}
+
+export class PaymentRejectedError extends Error {
+  readonly reason?: string;
+  constructor(message: string, reason?: string) {
+    super(message);
+    this.name = "PaymentRejectedError";
+    this.reason = reason;
+  }
+}
+
+export class InvalidRequirementsError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "InvalidRequirementsError";
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Error → user-facing message mapper
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Convert any value thrown by the Vellar SDK into a short, friendly string
+ * safe to display in a UI toast, banner, or form field.
+ *
+ * Covers every named error class in the SDK. Unknown errors fall back to a
+ * generic message so the UI never surfaces a raw stack trace or internal
+ * SDK message.
+ *
+ * @example
+ * try {
+ *   await wallet.pay({ to, amount, token });
+ * } catch (err) {
+ *   showToast(sdkErrorToMessage(err));
+ * }
+ */
+export function sdkErrorToMessage(err: unknown): string {
+  // ── Wallet readiness ────────────────────────────────────────────────────────
+  if (err instanceof WalletNotReadyError) {
+    return "Please connect your wallet before continuing.";
+  }
+
+  // ── Network mismatch ────────────────────────────────────────────────────────
+  if (err instanceof WalletNetworkMismatchError) {
+    return "Network mismatch — check that your wallet and app are on the same Stellar network.";
+  }
+
+  // ── Payment — bad amount ────────────────────────────────────────────────────
+  if (err instanceof InvalidAmountError) {
+    return "Invalid amount — please enter a positive number with the correct number of decimal places.";
+  }
+
+  // ── Payment — bad recipient ─────────────────────────────────────────────────
+  if (err instanceof InvalidRecipientError) {
+    return "Invalid recipient address — double-check the destination before retrying.";
+  }
+
+  // ── Mainnet configuration ───────────────────────────────────────────────────
+  if (err instanceof MainnetConfigError) {
+    return "Mainnet configuration is incomplete. Provide a valid RPC URL and wallet WASM hash.";
+  }
+
+  // ── Policy API ──────────────────────────────────────────────────────────────
+  if (err instanceof PolicyApiError) {
+    if (err.status === 0) {
+      return "Could not reach the policy service — check your internet connection and try again.";
+    }
+    if (err.status === 401 || err.status === 403) {
+      return "Access denied — you are not authorised to perform this policy action.";
+    }
+    if (err.status === 404) {
+      return "The requested policy was not found.";
+    }
+    if (err.status >= 500) {
+      return "The policy service is temporarily unavailable. Please try again shortly.";
+    }
+    return "A policy error occurred. Please review your policy settings and try again.";
+  }
+
+  // ── x402 — not configured ───────────────────────────────────────────────────
+  if (err instanceof X402NotConfiguredError) {
+    return "Agentic payments are not set up for this wallet. Configure x402 to enable them.";
+  }
+
+  // ── x402 — amount guard ─────────────────────────────────────────────────────
+  if (err instanceof MaxAmountExceededError) {
+    return `Payment refused — the server is asking for more than your set limit. Increase your maximum or contact the resource provider.`;
+  }
+
+  // ── x402 — disallowed asset ─────────────────────────────────────────────────
+  if (err instanceof DisallowedAssetError) {
+    return "Payment refused — the server requested a token that is not on your allowed list.";
+  }
+
+  // ── x402 — no matching option ───────────────────────────────────────────────
+  if (err instanceof NoUsablePaymentOptionError) {
+    return "No compatible payment option was found for this resource.";
+  }
+
+  // ── x402 — facilitator rejection ───────────────────────────────────────────
+  if (err instanceof PaymentRejectedError) {
+    return "Payment was declined — your spending limit may have been reached, or the payment was otherwise rejected.";
+  }
+
+  // ── x402 — bad server requirements ─────────────────────────────────────────
+  if (err instanceof InvalidRequirementsError) {
+    return "The server sent an invalid payment request. Please try again or contact the resource provider.";
+  }
+
+  // ── Generic fallback ────────────────────────────────────────────────────────
+  return "Something went wrong. Please try again or contact support if the issue persists.";
+}

--- a/contrib/examples/issue-58-amount-input-validator/README.md
+++ b/contrib/examples/issue-58-amount-input-validator/README.md
@@ -1,0 +1,127 @@
+# Amount Input Validator
+
+A self-contained example module that validates a raw string amount entered by
+a user before it is converted to base units for a Vellar payment.
+
+Contributed for [issue #58](https://github.com/Vellar-Wallet/vellar-sdk/issues/58).
+
+---
+
+## Overview
+
+`amount-input-validator.ts` exports a single function:
+
+```ts
+function validateAmount(input: string, token: TokenConfig): ValidationResult
+```
+
+It returns a discriminated union — `{ valid: true, value }` or
+`{ valid: false, code, message }` — so you can wire the result directly into a
+form field's error state without any try/catch.
+
+### Validation rules (in order)
+
+| Rule | Code | Example bad input |
+|---|---|---|
+| Must not be empty | `EMPTY` | `""`, `"  "` |
+| Must not be negative | `NEGATIVE` | `"-1"`, `"-0.5"` |
+| Must be a valid decimal number | `NOT_NUMERIC` | `"abc"`, `"1,5"`, `"1e5"`, `"10."` |
+| Must not exceed the token's decimal places | `TOO_MANY_DECIMALS` | `"1.00000001"` on a 7-decimal token |
+| Must be greater than zero | `ZERO` | `"0"`, `"0.0000000"` |
+
+The rules mirror `parseTokenAmount` in `src/payments.ts` so validation and
+parsing are always consistent.
+
+---
+
+## Usage
+
+### Basic form wiring
+
+```ts
+import { validateAmount } from "./amount-input-validator";
+
+function onAmountChange(rawInput: string) {
+  const result = validateAmount(rawInput, { decimals: 7, symbol: "XLM" });
+
+  if (!result.valid) {
+    setFieldError(result.message); // friendly string, safe to show in a <p>
+    return;
+  }
+
+  clearFieldError();
+  // result.value is the trimmed string — safe to pass to parseTokenAmount
+  setAmountValue(result.value);
+}
+```
+
+### Passing to `parseTokenAmount`
+
+```ts
+import { validateAmount } from "./amount-input-validator";
+import { parseTokenAmount } from "vellar-sdk"; // or src/payments.ts
+
+const result = validateAmount(rawInput, { decimals: 7 });
+if (!result.valid) throw new Error(result.message);
+
+// result.value is guaranteed valid — parseTokenAmount will not throw
+const baseUnits = parseTokenAmount(result.value, 7);
+```
+
+### Token configs for common assets
+
+```ts
+// XLM (7 decimal places, stroops)
+validateAmount(input, { decimals: 7, symbol: "XLM" });
+
+// USDC (6 decimal places)
+validateAmount(input, { decimals: 6, symbol: "USDC" });
+
+// A whole-unit-only token
+validateAmount(input, { decimals: 0, symbol: "POINTS" });
+```
+
+---
+
+## Running the tests
+
+The tests use [vitest](https://vitest.dev/), already a dev dependency of the repo.
+
+```bash
+# Run just this example's tests (from the repo root)
+npx vitest run contrib/examples/issue-58-amount-input-validator/amount-input-validator.test.ts
+```
+
+Or run the full suite:
+
+```bash
+npm test
+```
+
+Expected output:
+
+```
+ ✓ contrib/examples/issue-58-amount-input-validator/amount-input-validator.test.ts (45)
+   ✓ validateAmount — valid inputs (10)
+   ✓ validateAmount — empty input (3)
+   ✓ validateAmount — non-numeric input (9)
+   ✓ validateAmount — negative input (4)
+   ✓ validateAmount — zero input (5)
+   ✓ validateAmount — too many decimal places (6)
+   ✓ validateAmount — invalid token config (2)
+   ✓ validateAmount — symbol in error messages (3)
+
+ Test Files  1 passed (1)
+ Tests       42 passed (42)
+```
+
+---
+
+## File structure
+
+```
+contrib/examples/issue-58-amount-input-validator/
+├── README.md                        ← you are here
+├── amount-input-validator.ts        ← the module
+└── amount-input-validator.test.ts   ← vitest tests
+```

--- a/contrib/examples/issue-58-amount-input-validator/amount-input-validator.test.ts
+++ b/contrib/examples/issue-58-amount-input-validator/amount-input-validator.test.ts
@@ -1,0 +1,202 @@
+/**
+ * amount-input-validator.test.ts
+ *
+ * Tests for validateAmount.
+ *
+ * Run from the repo root:
+ *   npx vitest run contrib/examples/issue-58-amount-input-validator/amount-input-validator.test.ts
+ *
+ * Or run the full suite:
+ *   npm test
+ */
+
+import { describe, it, expect } from "vitest";
+import { validateAmount } from "./amount-input-validator";
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Helpers
+// ─────────────────────────────────────────────────────────────────────────────
+
+function valid(input: string, decimals: number, symbol?: string) {
+  return validateAmount(input, { decimals, symbol });
+}
+
+function expectValid(input: string, decimals: number) {
+  const result = validateAmount(input, { decimals });
+  expect(result.valid, `expected "${input}" to be valid with decimals=${decimals}`).toBe(true);
+  if (result.valid) {
+    expect(result.value).toBe(input.trim());
+  }
+}
+
+function expectInvalid(
+  input: string,
+  decimals: number,
+  expectedCode: string,
+) {
+  const result = validateAmount(input, { decimals });
+  expect(result.valid, `expected "${input}" to be invalid with decimals=${decimals}`).toBe(false);
+  if (!result.valid) {
+    expect(result.code).toBe(expectedCode);
+    expect(result.message.length).toBeGreaterThan(0);
+    // Message should never expose a raw stack trace or Error class prefix
+    expect(result.message).not.toMatch(/^[A-Z][a-zA-Z]+Error:/);
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Valid inputs
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("validateAmount — valid inputs", () => {
+  it("whole number with 7 decimals (XLM-style)", () => expectValid("10", 7));
+  it("decimal within precision (XLM-style)", () => expectValid("1.5", 7));
+  it("maximum precision (7 decimal places)", () => expectValid("1.0000001", 7));
+  it("large whole number", () => expectValid("999999999", 7));
+  it("leading zero on decimal", () => expectValid("0.1", 7));
+  it("6-decimal token (USDC-style)", () => expectValid("100.123456", 6));
+  it("zero-decimal token with whole number", () => expectValid("42", 0));
+  it("whitespace is trimmed and treated as valid", () => {
+    const result = validateAmount("  5.5  ", { decimals: 7 });
+    expect(result.valid).toBe(true);
+    if (result.valid) expect(result.value).toBe("5.5");
+  });
+  it("exact precision boundary — 6 of 6 places", () => expectValid("0.000001", 6));
+  it("returns the trimmed value in result.value", () => {
+    const result = valid("  3.14  ", 2);
+    expect(result.valid).toBe(true);
+    if (result.valid) expect(result.value).toBe("3.14");
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Empty / blank
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("validateAmount — empty input", () => {
+  it("empty string → EMPTY", () => expectInvalid("", 7, "EMPTY"));
+  it("spaces only → EMPTY", () => expectInvalid("   ", 7, "EMPTY"));
+  it("tab only → EMPTY", () => expectInvalid("\t", 7, "EMPTY"));
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Non-numeric
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("validateAmount — non-numeric input", () => {
+  it("alphabetic → NOT_NUMERIC", () => expectInvalid("abc", 7, "NOT_NUMERIC"));
+  it("alphanumeric mix → NOT_NUMERIC", () => expectInvalid("10abc", 7, "NOT_NUMERIC"));
+  it("comma as decimal separator → NOT_NUMERIC", () => expectInvalid("1,5", 7, "NOT_NUMERIC"));
+  it("multiple decimal points → NOT_NUMERIC", () => expectInvalid("1.2.3", 7, "NOT_NUMERIC"));
+  it("currency symbol prefix → NOT_NUMERIC", () => expectInvalid("$10", 7, "NOT_NUMERIC"));
+  it("e-notation → NOT_NUMERIC", () => expectInvalid("1e5", 7, "NOT_NUMERIC"));
+  it("bare decimal point → NOT_NUMERIC", () => expectInvalid(".", 7, "NOT_NUMERIC"));
+  it("trailing decimal point → NOT_NUMERIC", () => expectInvalid("10.", 7, "NOT_NUMERIC"));
+  it("whitespace inside number → NOT_NUMERIC", () => expectInvalid("1 0", 7, "NOT_NUMERIC"));
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Negative
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("validateAmount — negative input", () => {
+  it("negative integer → NEGATIVE", () => expectInvalid("-1", 7, "NEGATIVE"));
+  it("negative decimal → NEGATIVE", () => expectInvalid("-0.5", 7, "NEGATIVE"));
+  it("negative zero → NEGATIVE", () => expectInvalid("-0", 7, "NEGATIVE"));
+  it("message does not say NOT_NUMERIC for negatives", () => {
+    const result = validateAmount("-5", { decimals: 7 });
+    expect(result.valid).toBe(false);
+    if (!result.valid) {
+      expect(result.code).toBe("NEGATIVE");
+      expect(result.message.toLowerCase()).toContain("negative");
+    }
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Zero
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("validateAmount — zero input", () => {
+  it("literal zero → ZERO", () => expectInvalid("0", 7, "ZERO"));
+  it("0.0 → ZERO", () => expectInvalid("0.0", 7, "ZERO"));
+  it("all-zero fractional (max decimals) → ZERO", () => expectInvalid("0.0000000", 7, "ZERO"));
+  it("0.000000 for 6-decimal token → ZERO", () => expectInvalid("0.000000", 6, "ZERO"));
+  it("zero-decimal token with 0 → ZERO", () => expectInvalid("0", 0, "ZERO"));
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Too many decimal places
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("validateAmount — too many decimal places", () => {
+  it("8 decimal places on a 7-decimal token → TOO_MANY_DECIMALS", () =>
+    expectInvalid("1.00000001", 7, "TOO_MANY_DECIMALS"));
+
+  it("7 decimal places on a 6-decimal token → TOO_MANY_DECIMALS", () =>
+    expectInvalid("1.0000001", 6, "TOO_MANY_DECIMALS"));
+
+  it("any decimal on a 0-decimal token → TOO_MANY_DECIMALS", () =>
+    expectInvalid("1.1", 0, "TOO_MANY_DECIMALS"));
+
+  it("message mentions 'decimal' for 0-decimal token", () => {
+    const result = validateAmount("1.5", { decimals: 0, symbol: "NODEC" });
+    expect(result.valid).toBe(false);
+    if (!result.valid) {
+      expect(result.code).toBe("TOO_MANY_DECIMALS");
+      expect(result.message.toLowerCase()).toContain("decimal");
+    }
+  });
+
+  it("message mentions the symbol when provided", () => {
+    const result = validateAmount("1.00000001", { decimals: 7, symbol: "XLM" });
+    expect(result.valid).toBe(false);
+    if (!result.valid) {
+      expect(result.message).toContain("XLM");
+    }
+  });
+
+  it("exactly at precision boundary is valid (not TOO_MANY_DECIMALS)", () =>
+    expectValid("1.0000001", 7));
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Invalid token config
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("validateAmount — invalid token config", () => {
+  it("negative decimals → INVALID_DECIMALS_CONFIG", () =>
+    expectInvalid("1", -1, "INVALID_DECIMALS_CONFIG"));
+
+  it("fractional decimals → INVALID_DECIMALS_CONFIG", () => {
+    const result = validateAmount("1", { decimals: 2.5 });
+    expect(result.valid).toBe(false);
+    if (!result.valid) expect(result.code).toBe("INVALID_DECIMALS_CONFIG");
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Symbol in error messages
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("validateAmount — symbol in error messages", () => {
+  it("ZERO message includes symbol", () => {
+    const result = validateAmount("0", { decimals: 7, symbol: "XLM" });
+    expect(result.valid).toBe(false);
+    if (!result.valid) expect(result.message).toContain("XLM");
+  });
+
+  it("NOT_NUMERIC message includes symbol", () => {
+    const result = validateAmount("abc", { decimals: 7, symbol: "USDC" });
+    expect(result.valid).toBe(false);
+    if (!result.valid) expect(result.message).toContain("USDC");
+  });
+
+  it("no symbol → message still valid and non-empty", () => {
+    const result = validateAmount("0", { decimals: 7 });
+    expect(result.valid).toBe(false);
+    if (!result.valid) {
+      expect(result.message.length).toBeGreaterThan(0);
+    }
+  });
+});

--- a/contrib/examples/issue-58-amount-input-validator/amount-input-validator.ts
+++ b/contrib/examples/issue-58-amount-input-validator/amount-input-validator.ts
@@ -1,0 +1,153 @@
+/**
+ * amount-input-validator.ts
+ *
+ * Validates a raw string amount entered by a user before it is converted to
+ * base units for a Vellar payment. Returns a structured result with a clear
+ * per-rule message rather than throwing, making it easy to wire directly into
+ * a form field's error state.
+ *
+ * Validation rules (in order):
+ *  1. Non-empty after trimming
+ *  2. Numeric — only digits and an optional single decimal point
+ *  3. No more fractional digits than the token's `decimals` allows
+ *  4. Positive (greater than zero in base units)
+ *
+ * The rules mirror the behaviour of `parseTokenAmount` in the SDK's
+ * `src/payments.ts` so validation and parsing are always consistent.
+ */
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Types
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** Configuration for a specific token / asset. */
+export interface TokenConfig {
+  /**
+   * Number of decimal places the token supports.
+   * Must be a non-negative integer (e.g. 7 for XLM/stroops, 6 for USDC).
+   */
+  decimals: number;
+  /** Optional display symbol used in error messages (e.g. "XLM", "USDC"). */
+  symbol?: string;
+}
+
+/** A passing validation result. */
+export interface ValidResult {
+  valid: true;
+  /** The validated input, trimmed. Ready to pass to `parseTokenAmount`. */
+  value: string;
+}
+
+/** A failing validation result. */
+export interface InvalidResult {
+  valid: false;
+  /** Short, user-facing error message safe to display next to the input field. */
+  message: string;
+  /** Machine-readable reason code for programmatic handling (e.g. highlight
+   *  the decimal-places rule differently from an empty field). */
+  code:
+    | "EMPTY"
+    | "NOT_NUMERIC"
+    | "TOO_MANY_DECIMALS"
+    | "ZERO"
+    | "NEGATIVE"
+    | "INVALID_DECIMALS_CONFIG";
+}
+
+export type ValidationResult = ValidResult | InvalidResult;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Validator
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Validate a raw amount string against the rules for a specific token.
+ *
+ * @param input    - The raw string the user typed (e.g. "12.50", "0", "abc").
+ * @param token    - Token configuration: decimals (required) and optional symbol.
+ * @returns        A `ValidResult` or `InvalidResult`.
+ *
+ * @example
+ * const result = validateAmount("12.5", { decimals: 7, symbol: "XLM" });
+ * if (!result.valid) {
+ *   setFieldError(result.message);
+ * } else {
+ *   submitPayment(result.value); // safe to pass to parseTokenAmount
+ * }
+ */
+export function validateAmount(input: string, token: TokenConfig): ValidationResult {
+  // Guard: decimals must be a non-negative integer (matches parseTokenAmount's own guard)
+  if (!Number.isInteger(token.decimals) || token.decimals < 0) {
+    return {
+      valid: false,
+      code: "INVALID_DECIMALS_CONFIG",
+      message: `Token configuration error: decimals must be a non-negative integer (got ${token.decimals}).`,
+    };
+  }
+
+  const symbolSuffix = token.symbol ? ` for ${token.symbol}` : "";
+
+  // Rule 1 — non-empty
+  const trimmed = input.trim();
+  if (trimmed === "") {
+    return {
+      valid: false,
+      code: "EMPTY",
+      message: "Please enter an amount.",
+    };
+  }
+
+  // Rule 2 — reject explicit negatives before the numeric check so the message
+  // is specific ("cannot be negative") rather than generic ("not a valid number")
+  if (trimmed.startsWith("-")) {
+    return {
+      valid: false,
+      code: "NEGATIVE",
+      message: "Amount cannot be negative.",
+    };
+  }
+
+  // Rule 3 — numeric: digits only, with at most one decimal point
+  if (!/^\d+(\.\d+)?$/.test(trimmed)) {
+    return {
+      valid: false,
+      code: "NOT_NUMERIC",
+      message: `"${trimmed}" is not a valid number. Enter a positive number${symbolSuffix} (e.g. "10" or "0.5").`,
+    };
+  }
+
+  // Rule 4 — decimal places
+  const dotIndex = trimmed.indexOf(".");
+  if (dotIndex !== -1) {
+    const fractionLength = trimmed.length - dotIndex - 1;
+    if (fractionLength > token.decimals) {
+      const placesLabel = token.decimals === 1 ? "1 decimal place" : `${token.decimals} decimal places`;
+      return {
+        valid: false,
+        code: "TOO_MANY_DECIMALS",
+        message:
+          token.decimals === 0
+            ? `This token${symbolSuffix} does not support decimal amounts. Enter a whole number.`
+            : `Amount supports at most ${placesLabel}${symbolSuffix}.`,
+      };
+    }
+  }
+
+  // Rule 5 — greater than zero in base units
+  // Compute base-unit value using the same logic as parseTokenAmount so
+  // inputs like "0.0000000" (7 zeros after a point, decimals=7) are caught.
+  const [whole = "0", fraction = ""] = trimmed.split(".");
+  const baseUnits =
+    BigInt(whole) * 10n ** BigInt(token.decimals) +
+    BigInt(fraction.padEnd(token.decimals, "0") || "0");
+
+  if (baseUnits === 0n) {
+    return {
+      valid: false,
+      code: "ZERO",
+      message: `Amount must be greater than zero${symbolSuffix}.`,
+    };
+  }
+
+  return { valid: true, value: trimmed };
+}

--- a/contrib/examples/issue-64-session-change-emitter/README.md
+++ b/contrib/examples/issue-64-session-change-emitter/README.md
@@ -1,0 +1,100 @@
+# Session Change Emitter
+
+A self-contained example module implementing a simple event emitter that
+notifies subscribers whenever a wallet session value changes.
+
+Contributed for [issue #64](https://github.com/Vellar-Wallet/vellar-sdk/issues/64).
+
+---
+
+## Overview
+
+`session-change-emitter.ts` exposes a factory function `createSessionEmitter`
+that returns an object with three methods:
+
+| Method | Description |
+|---|---|
+| `subscribe(handler)` | Register a callback invoked on every session change. Returns an `unsubscribe` function. |
+| `setSession(newSession)` | Update the current session and notify all active subscribers. |
+| `getSession()` | Return the current session value without triggering notifications. |
+
+Multiple subscribers are supported; each receives the same `(newSession, prevSession)` tuple.
+
+---
+
+## Usage
+
+```ts
+import { createSessionEmitter } from "./session-change-emitter";
+
+const emitter = createSessionEmitter();
+
+// Subscribe — returns an unsubscribe function
+const unsubscribe = emitter.subscribe((newSession, prevSession) => {
+  console.log("Session changed");
+  console.log("  previous:", prevSession);
+  console.log("  current: ", newSession);
+});
+
+// Trigger a change
+emitter.setSession({ userId: "alice", token: "tok-xyz" });
+// → Session changed
+//     previous: null
+//     current:  { userId: 'alice', token: 'tok-xyz' }
+
+// Update again
+emitter.setSession({ userId: "alice", token: "tok-new" });
+// → Session changed
+//     previous: { userId: 'alice', token: 'tok-xyz' }
+//     current:  { userId: 'alice', token: 'tok-new' }
+
+// Stop receiving updates
+unsubscribe();
+
+emitter.setSession(null); // subscriber is silent now
+```
+
+---
+
+## Running the tests
+
+The tests use [vitest](https://vitest.dev/), which is already a dev dependency of the repo.
+
+```bash
+# Run just this example's tests (from the repo root)
+npx vitest run contrib/examples/issue-64-session-change-emitter/session-change-emitter.test.ts
+```
+
+Or run the entire project test suite (includes these tests automatically):
+
+```bash
+npm test
+```
+
+Expected output:
+
+```
+ ✓ contrib/examples/issue-64-session-change-emitter/session-change-emitter.test.ts (7)
+   ✓ createSessionEmitter > initial session is null
+   ✓ createSessionEmitter > subscriber receives the new session value
+   ✓ createSessionEmitter > subscriber receives the previous session as the second argument
+   ✓ createSessionEmitter > multiple subscribers all receive the same update
+   ✓ createSessionEmitter > unsubscribe stops the handler from receiving further updates
+   ✓ createSessionEmitter > unsubscribing one subscriber does not affect others
+   ✓ createSessionEmitter > setSession with null clears the session
+   ✓ createSessionEmitter > getSession reflects the latest value without triggering notifications
+
+ Test Files  1 passed (1)
+ Tests       8 passed (8)
+```
+
+---
+
+## File structure
+
+```
+contrib/examples/issue-64-session-change-emitter/
+├── README.md                        ← you are here
+├── session-change-emitter.ts        ← the module
+└── session-change-emitter.test.ts   ← tests / demo script
+```

--- a/contrib/examples/issue-64-session-change-emitter/session-change-emitter.test.ts
+++ b/contrib/examples/issue-64-session-change-emitter/session-change-emitter.test.ts
@@ -1,0 +1,122 @@
+/**
+ * session-change-emitter.test.ts
+ *
+ * Tests for the session change emitter.
+ *
+ * Run from the repo root:
+ *   npx vitest run contrib/examples/issue-64-session-change-emitter/session-change-emitter.test.ts
+ *
+ * Or run the whole suite:
+ *   npm test
+ */
+
+import { describe, it, expect, vi } from "vitest";
+import { createSessionEmitter } from "./session-change-emitter";
+
+describe("createSessionEmitter", () => {
+  it("initial session is null", () => {
+    const emitter = createSessionEmitter();
+    expect(emitter.getSession()).toBeNull();
+  });
+
+  it("subscriber receives the new session value", () => {
+    const emitter = createSessionEmitter();
+    const handler = vi.fn();
+
+    emitter.subscribe(handler);
+    emitter.setSession({ userId: "abc", token: "tok-1" });
+
+    expect(handler).toHaveBeenCalledOnce();
+    expect(handler).toHaveBeenCalledWith({ userId: "abc", token: "tok-1" }, null);
+  });
+
+  it("subscriber receives the previous session as the second argument", () => {
+    const emitter = createSessionEmitter();
+    const handler = vi.fn();
+
+    emitter.subscribe(handler);
+    emitter.setSession({ userId: "first" });
+    emitter.setSession({ userId: "second" });
+
+    expect(handler).toHaveBeenCalledTimes(2);
+    expect(handler).toHaveBeenNthCalledWith(1, { userId: "first" }, null);
+    expect(handler).toHaveBeenNthCalledWith(2, { userId: "second" }, { userId: "first" });
+  });
+
+  it("multiple subscribers all receive the same update", () => {
+    const emitter = createSessionEmitter();
+    const handlerA = vi.fn();
+    const handlerB = vi.fn();
+    const handlerC = vi.fn();
+
+    emitter.subscribe(handlerA);
+    emitter.subscribe(handlerB);
+    emitter.subscribe(handlerC);
+
+    const session = { userId: "multi" };
+    emitter.setSession(session);
+
+    expect(handlerA).toHaveBeenCalledOnce();
+    expect(handlerB).toHaveBeenCalledOnce();
+    expect(handlerC).toHaveBeenCalledOnce();
+
+    expect(handlerA).toHaveBeenCalledWith(session, null);
+    expect(handlerB).toHaveBeenCalledWith(session, null);
+    expect(handlerC).toHaveBeenCalledWith(session, null);
+  });
+
+  it("unsubscribe stops the handler from receiving further updates", () => {
+    const emitter = createSessionEmitter();
+    const handler = vi.fn();
+
+    const unsubscribe = emitter.subscribe(handler);
+
+    emitter.setSession({ userId: "before" });
+    expect(handler).toHaveBeenCalledOnce();
+
+    unsubscribe();
+
+    emitter.setSession({ userId: "after" });
+    // still only one call — the second update was not delivered
+    expect(handler).toHaveBeenCalledOnce();
+  });
+
+  it("unsubscribing one subscriber does not affect others", () => {
+    const emitter = createSessionEmitter();
+    const handlerA = vi.fn();
+    const handlerB = vi.fn();
+
+    const unsubA = emitter.subscribe(handlerA);
+    emitter.subscribe(handlerB);
+
+    unsubA();
+
+    emitter.setSession({ userId: "only-b" });
+
+    expect(handlerA).not.toHaveBeenCalled();
+    expect(handlerB).toHaveBeenCalledOnce();
+  });
+
+  it("setSession with null clears the session", () => {
+    const emitter = createSessionEmitter();
+
+    emitter.setSession({ userId: "temp" });
+    emitter.setSession(null);
+
+    expect(emitter.getSession()).toBeNull();
+  });
+
+  it("getSession reflects the latest value without triggering notifications", () => {
+    const emitter = createSessionEmitter();
+    const handler = vi.fn();
+
+    emitter.subscribe(handler);
+    emitter.setSession({ userId: "alice" });
+
+    // getSession should not fire handlers
+    const session = emitter.getSession();
+
+    expect(session).toEqual({ userId: "alice" });
+    expect(handler).toHaveBeenCalledOnce(); // only from setSession, not getSession
+  });
+});

--- a/contrib/examples/issue-64-session-change-emitter/session-change-emitter.ts
+++ b/contrib/examples/issue-64-session-change-emitter/session-change-emitter.ts
@@ -1,0 +1,59 @@
+/**
+ * session-change-emitter.ts
+ *
+ * A self-contained event emitter that notifies subscribers whenever
+ * the wallet session value changes.
+ */
+
+export type Session = Record<string, unknown> | null;
+
+export type SessionChangeHandler = (newSession: Session, prevSession: Session) => void;
+
+export type Unsubscribe = () => void;
+
+interface SessionEmitter {
+  subscribe: (handler: SessionChangeHandler) => Unsubscribe;
+  setSession: (newSession: Session) => void;
+  getSession: () => Session;
+}
+
+/**
+ * Creates a new session change emitter.
+ *
+ * @returns An object with `subscribe`, `setSession`, and `getSession`.
+ *
+ * @example
+ * const emitter = createSessionEmitter();
+ *
+ * const unsubscribe = emitter.subscribe((newSession, prevSession) => {
+ *   console.log('Session changed:', { newSession, prevSession });
+ * });
+ *
+ * emitter.setSession({ userId: '123', token: 'abc' });
+ * unsubscribe(); // stop receiving updates
+ */
+export function createSessionEmitter(): SessionEmitter {
+  let currentSession: Session = null;
+  const handlers = new Set<SessionChangeHandler>();
+
+  function subscribe(handler: SessionChangeHandler): Unsubscribe {
+    handlers.add(handler);
+    return () => {
+      handlers.delete(handler);
+    };
+  }
+
+  function setSession(newSession: Session): void {
+    const prevSession = currentSession;
+    currentSession = newSession;
+    for (const handler of handlers) {
+      handler(newSession, prevSession);
+    }
+  }
+
+  function getSession(): Session {
+    return currentSession;
+  }
+
+  return { subscribe, setSession, getSession };
+}

--- a/contrib/examples/issue-7-full-wallet-demo/README.md
+++ b/contrib/examples/issue-7-full-wallet-demo/README.md
@@ -1,0 +1,58 @@
+# issue-7-full-wallet-demo
+
+Reference example (issue #7) demonstrating the **full core flow** — create,
+connect, pay, and attach a spending-limit policy — through the real composed
+`createVellarWallet` handle, using the `TESTNET` network config.
+
+`full-create-connect`, `full-payment-flow`, and `full-policy-flow` each show
+one piece of this in isolation; this ties all four together in one session,
+the way an app actually uses the wallet.
+
+## Flow
+
+1. `vellar.create({ username })` — register a passkey and deploy the smart
+   account.
+2. Simulate a page reload (a fresh kit instance, same backend) and
+   `vellar.connect()` — reconnect the same wallet.
+3. `vellar.pay({ to, amount, token })` — build, simulate, sign, and submit a
+   payment.
+4. `policies.generate()` → `simulate()` → `deploy()` — attach a spending-limit
+   policy to the wallet.
+
+## Prerequisites this stands in for
+
+This example is fully mocked (no live network, no WebAuthn prompt), so it
+runs deterministically in CI and locally with nothing to configure. A real
+integration needs, in place of the mocks here:
+
+- **`kit`** — a real `PasskeyKit` instance. This is what actually runs the
+  WebAuthn ceremony (Face ID / Touch ID / a security key) — it only works in
+  a browser with a platform authenticator, which is why this reference can't
+  do it live.
+- **`backend`** — `createHttpWalletBackend(yourGatewayUrl)`, pointed at
+  **your backend gateway**. Submission is fee-sponsored (relayer/sponsor
+  secrets), so the SDK never submits directly — your server does, over the
+  `/wallet/create` / `/wallet/connect` / `/wallet/submit` routes described in
+  the root [README's "Your backend"](../../../README.md#your-backend)
+  section. Point it at a real gateway to run this against testnet for real.
+- **Policies** — `apiUrl` pointed at your policy gateway (`/policies/*`
+  routes, same doc), and a `policyAttach` runtime wired to
+  `kit.addPolicy(...)` (see the root README's
+  [Policies](../../../README.md#policies) section) instead of the fixed mock
+  hash used here.
+
+## Run it
+
+```sh
+npx tsx index.ts
+```
+
+## Tests
+
+```sh
+npx vitest run contrib/examples/issue-7-full-wallet-demo
+```
+
+Covers the full sequence logging each step in order, `create()` and
+`connect()` resolving to the same account, and the default `console.log`
+logger path.

--- a/contrib/examples/issue-7-full-wallet-demo/index.test.ts
+++ b/contrib/examples/issue-7-full-wallet-demo/index.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+import { runFullWalletDemo } from "./index";
+
+describe("runFullWalletDemo", () => {
+  it("runs create -> connect -> pay -> policy attach end to end, logging each step", async () => {
+    const logs: string[] = [];
+    await runFullWalletDemo((line) => logs.push(line));
+
+    expect(logs).toHaveLength(6);
+    expect(logs[0]).toMatch(/^1\. create\(\)\s+-> account C/);
+    expect(logs[1]).toMatch(/^2\. connect\(\)\s+-> account C/);
+    expect(logs[2]).toMatch(/^3\. pay\(\)\s+-> tx mockhash/);
+    expect(logs[3]).toMatch(/^4a\. policies\.generate\(\)\s+-> policy policy-/);
+    expect(logs[4]).toBe("4b. policies.simulate() -> ok=true");
+    expect(logs[5]).toMatch(/^4c\. policies\.deploy\(\)\s+-> attached, contract C/);
+
+    // create() and connect() resolve to the SAME account (fresh session, same wallet).
+    const createdAccount = logs[0]!.match(/account (C\S+)/)![1];
+    const connectedAccount = logs[1]!.match(/account (C\S+)/)![1];
+    expect(connectedAccount).toBe(createdAccount);
+  });
+
+  it("runs with the default console logger when none is given", async () => {
+    await expect(runFullWalletDemo()).resolves.toBeUndefined();
+  });
+});

--- a/contrib/examples/issue-7-full-wallet-demo/index.ts
+++ b/contrib/examples/issue-7-full-wallet-demo/index.ts
@@ -1,0 +1,234 @@
+/**
+ * Reference example (issue #7): the full core flow — create, connect, pay,
+ * and attach a spending-limit policy — through the real composed
+ * `createVellarWallet` handle, using the TESTNET network config. All
+ * dependencies (passkey kit, wallet backend, SAC client, policy API,
+ * policy-attach runtime) are in-memory mocks, so this runs deterministically
+ * with no live network call and no WebAuthn prompt.
+ *
+ * This ties together, in one script, what `full-create-connect`,
+ * `full-payment-flow`, and `full-policy-flow` each demonstrate separately —
+ * see those for a narrower look at each piece.
+ *
+ * A real integration replaces the mocks with:
+ * - `kit`: a real `PasskeyKit` instance (runs the actual WebAuthn ceremony)
+ * - `backend`: `createHttpWalletBackend(yourGatewayUrl)` — your server, which
+ *   holds the relayer/sponsor secrets (the SDK never does)
+ * - `sac`: a real `SACClient`
+ * - policies: pass `apiUrl` pointed at your policy gateway, and a
+ *   `policyAttach` runtime wired to `kit.addPolicy` (see the root README's
+ *   "Policies" section)
+ *
+ * Run with:
+ *   npx tsx index.ts
+ */
+
+import { createVellarWallet, type VellarWallet } from "../../../src/client";
+import { createPolicyFacade, type PolicyAttachRuntime } from "../../../src/policy-facade";
+import { TESTNET } from "../../../src/config";
+import type { PasskeyKitLike, WalletBackend } from "../../../src/passkeykit-connector";
+import type { SacClientLike, TokenContractClientLike } from "../../../src/payments-client";
+import type { PolicyDefinition } from "../../../src/types";
+import type { GeneratedPolicy, PolicyTemplateInfo, SimulateResult } from "../../../src/policy-types";
+
+// ── in-memory mocks (no network, no WebAuthn) ──────────────────────────────
+
+/** Shared "server" state so a second kit instance (simulating a fresh page
+ * load) can resolve the same wallet by keyId, like a real backend would. */
+function createMockBackend(): WalletBackend & {
+  submitTransaction(input: { signedXdr: string; network: string }): Promise<{ hash: string }>;
+} {
+  const wallets = new Map<string, { contractId: string; sessionId: string }>();
+  let nextHash = 1;
+  return {
+    async submitWalletCreation({ keyId, contractId }) {
+      const sessionId = `sess-${wallets.size + 1}`;
+      wallets.set(keyId, { contractId, sessionId });
+      return { sessionId };
+    },
+    async lookupContractId({ keyId }) {
+      return wallets.get(keyId);
+    },
+    async submitTransaction() {
+      return { hash: `mockhash${nextHash++}`.padEnd(16, "0") };
+    },
+  };
+}
+
+function createMockKit(): PasskeyKitLike {
+  return {
+    wallet: undefined,
+    async createWallet(_app, _user) {
+      return { keyIdBase64: "mock-key-id", contractId: "C" + "A".repeat(55), signedTx: "mock-create-tx" };
+    },
+    async connectWallet(opts) {
+      // Pretend the WebAuthn discovery ceremony resolved this credential (the
+      // real kit does this internally); the connector supplies getContractId
+      // to resolve it to a smart-account address via the backend.
+      const keyId = "mock-key-id";
+      const contractId = await opts?.getContractId?.(keyId);
+      if (!contractId) throw new Error("no wallet found for this keyId");
+      return { keyIdBase64: keyId, contractId };
+    },
+    async sign(tx) {
+      return typeof tx === "string" ? `signed:${tx}` : "signed:mock-tx";
+    },
+  };
+}
+
+function createMockSac(): SacClientLike {
+  return {
+    getSACClient(tokenContractId: string): TokenContractClientLike {
+      return {
+        async transfer() {
+          return `unsigned-transfer-tx:${tokenContractId}`;
+        },
+      };
+    },
+  };
+}
+
+const TEMPLATES: PolicyTemplateInfo[] = [
+  {
+    type: "spending_limit",
+    title: "Daily spending limit",
+    description: "Limits total outbound spend per rolling day.",
+    enforcement: { kind: "policy-contract", wasmHash: "a".repeat(64) },
+  },
+];
+
+/** A mock `fetch` implementing the policy gateway routes policy-client.ts
+ * calls, so `createPolicyFacade` (the same building block `vellar.policies`
+ * composes) can run its real request/response shapes with no network. */
+function createMockPolicyFetch(): typeof fetch {
+  const policies = new Map<string, GeneratedPolicy>();
+  return (async (input: RequestInfo | URL, init?: RequestInit) => {
+    const url = new URL(String(input));
+    const path = url.pathname;
+    const body = init?.body ? (JSON.parse(String(init.body)) as Record<string, unknown>) : {};
+    const json = (data: unknown, status = 200) =>
+      new Response(JSON.stringify(data), { status, headers: { "content-type": "application/json" } });
+
+    if (path === "/policies/templates") return json(TEMPLATES);
+
+    if (path === "/policies/generate") {
+      const definition = body.definition as PolicyDefinition;
+      const id = `policy-${Date.now()}`;
+      const policy: GeneratedPolicy = {
+        id,
+        createdAt: new Date().toISOString(),
+        status: "generated",
+        definition,
+        policyHash: "b".repeat(64),
+        manifest: { template: definition.type, enforcement: TEMPLATES[0]!.enforcement, network: "testnet" },
+      };
+      policies.set(id, policy);
+      return json({ policy });
+    }
+
+    const simulateMatch = path.match(/^\/policies\/([^/]+)\/simulate$/);
+    if (simulateMatch) {
+      const result: SimulateResult = { ok: true, minResourceFee: "100000" };
+      return json(result);
+    }
+
+    const deployInstanceMatch = path.match(/^\/policies\/([^/]+)\/deploy-instance$/);
+    if (deployInstanceMatch) {
+      return json({ contractId: `C${deployInstanceMatch[1]}`.padEnd(56, "X").slice(0, 56) });
+    }
+
+    if (path === "/policies/deploy") {
+      const { policyId, txHash, contractId } = body as { policyId: string; txHash: string; contractId?: string };
+      const existing = policies.get(policyId);
+      if (!existing) return json({ error: `policy ${policyId} not generated` }, 404);
+      const deployed: GeneratedPolicy = {
+        ...existing,
+        status: "deployed",
+        deployment: { contractId, txHash, deployedAt: new Date().toISOString() },
+      };
+      policies.set(policyId, deployed);
+      return json({ policy: deployed });
+    }
+
+    return json({ error: `no mock route for ${path}` }, 404);
+  }) as typeof fetch;
+}
+
+// ── the demo ────────────────────────────────────────────────────────────────
+
+export async function runFullWalletDemo(log: (line: string) => void = console.log): Promise<void> {
+  const backend = createMockBackend();
+  const sac = createMockSac();
+
+  // 1. Create a wallet (registers a passkey + submits the deployment).
+  const createKit = createMockKit();
+  const vellar: VellarWallet = createVellarWallet({
+    network: TESTNET.network,
+    appName: "issue-7-full-wallet-demo",
+    kit: createKit,
+    backend,
+    sac,
+    isValidAddress: (address) => address.length > 0,
+  });
+  const created = await vellar.create({ username: "demo-user" });
+  log(`1. create()  -> account ${created.accountId}`);
+
+  // 2. Simulate a page reload: a fresh kit instance, same backend, reconnect
+  //    by the persisted keyId (this is what `session.keyId` is for).
+  const reconnectKit = createMockKit();
+  const reconnected: VellarWallet = createVellarWallet({
+    network: TESTNET.network,
+    appName: "issue-7-full-wallet-demo",
+    kit: reconnectKit,
+    backend,
+    sac,
+    isValidAddress: (address) => address.length > 0,
+  });
+  const connected = await reconnected.connect();
+  log(`2. connect() -> account ${connected.accountId} (same wallet, fresh session)`);
+
+  // 3. Send a payment (builds + simulates, then signs and submits).
+  const { hash } = await reconnected.pay({
+    to: "C" + "B".repeat(55),
+    amount: 5_0000000n, // 5 XLM, in stroops
+    token: { contractId: TESTNET.nativeTokenContractId, symbol: "XLM", decimals: 7 },
+  });
+  log(`3. pay()     -> tx ${hash}`);
+
+  // 4. Attach a spending-limit policy. `createPolicyFacade` is the same
+  //    building block `vellar.policies` composes internally; used directly
+  //    here so a mock `fetch` can be injected (the top-level facade doesn't
+  //    expose that seam — see PolicyFacadeDeps).
+  const attach: PolicyAttachRuntime = {
+    async attachPolicy(policyContractId) {
+      return { hash: `attach-${policyContractId}`.slice(0, 16) };
+    },
+  };
+  const policies = createPolicyFacade({
+    apiUrl: "https://mock-policy-api.test",
+    network: TESTNET.network,
+    requireSession: () => ({ accountId: connected.accountId }),
+    attach,
+    fetch: createMockPolicyFetch(),
+  });
+
+  const definition: PolicyDefinition = {
+    version: "1",
+    type: "spending_limit",
+    owners: [connected.accountId],
+    spendingLimits: { dailyXlm: "100" },
+  };
+  const generated = await policies.generate(definition);
+  log(`4a. policies.generate() -> policy ${generated.id}`);
+  const simulated = await policies.simulate(generated.id);
+  log(`4b. policies.simulate() -> ok=${simulated.ok}`);
+  const deployed = await policies.deploy(generated.id);
+  log(`4c. policies.deploy()   -> attached, contract ${deployed.contractId}`);
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  runFullWalletDemo().catch((err) => {
+    console.error(`Error: ${(err as Error).message}`);
+    process.exitCode = 1;
+  });
+}

--- a/contrib/examples/issue-87-multi-wallet-switcher/README.md
+++ b/contrib/examples/issue-87-multi-wallet-switcher/README.md
@@ -1,0 +1,57 @@
+# Multi-Wallet Session Switcher
+
+A reference implementation demonstrating how to manage multiple wallet sessions and switch between them.
+
+## Overview
+
+This example shows how to:
+- Store multiple wallet sessions keyed by account labels
+- Switch the active session
+- Handle errors when switching to unknown labels
+- Retrieve the currently active session
+
+## Flow
+
+1. **Add sessions** - Register wallet sessions with unique labels
+2. **Switch sessions** - Change which session is currently active
+3. **Get active session** - Retrieve the current active session
+4. **Error handling** - Gracefully handle attempts to switch to non-existent sessions
+
+## Usage
+
+```typescript
+import { MultiWalletSwitcher } from './multi-wallet-switcher';
+
+const switcher = new MultiWalletSwitcher();
+
+// Add sessions
+switcher.addSession('alice', aliceSession);
+switcher.addSession('bob', bobSession);
+
+// Switch between sessions
+switcher.switchTo('alice');
+console.log(switcher.getActive()); // Returns alice's session
+
+switcher.switchTo('bob');
+console.log(switcher.getActive()); // Returns bob's session
+
+// Handle errors
+try {
+  switcher.switchTo('unknown');
+} catch (error) {
+  console.error(error.message); // "Session 'unknown' not found"
+}
+```
+
+## Running the Example
+
+```bash
+npx ts-node example.ts
+```
+
+## Implementation Details
+
+The switcher maintains:
+- A `Map` of label → session objects
+- A reference to the currently active session label
+- Clear error messages for missing sessions

--- a/contrib/examples/issue-87-multi-wallet-switcher/example.ts
+++ b/contrib/examples/issue-87-multi-wallet-switcher/example.ts
@@ -1,0 +1,62 @@
+/**
+ * Example usage of the Multi-Wallet Session Switcher
+ */
+
+import { MultiWalletSwitcher, WalletSession } from './multi-wallet-switcher';
+
+// Mock wallet sessions
+const aliceSession: WalletSession = {
+  accountId: 'CALICE123...',
+  username: 'alice',
+  createdAt: new Date('2024-01-01'),
+};
+
+const bobSession: WalletSession = {
+  accountId: 'CBOB456...',
+  username: 'bob',
+  createdAt: new Date('2024-01-02'),
+};
+
+function main() {
+  console.log('=== Multi-Wallet Session Switcher Example ===\n');
+
+  const switcher = new MultiWalletSwitcher();
+
+  // Add two sessions
+  console.log('Adding sessions for alice and bob...');
+  switcher.addSession('alice', aliceSession);
+  switcher.addSession('bob', bobSession);
+  console.log(`Available sessions: ${switcher.getLabels().join(', ')}\n`);
+
+  // Show initial active session
+  console.log('Initial active session:');
+  console.log(JSON.stringify(switcher.getActive(), null, 2));
+  console.log();
+
+  // Switch to bob
+  console.log('Switching to bob...');
+  switcher.switchTo('bob');
+  console.log('Active session after switch:');
+  console.log(JSON.stringify(switcher.getActive(), null, 2));
+  console.log();
+
+  // Switch back to alice
+  console.log('Switching back to alice...');
+  switcher.switchTo('alice');
+  console.log('Active session after switch:');
+  console.log(JSON.stringify(switcher.getActive(), null, 2));
+  console.log();
+
+  // Try switching to unknown session
+  console.log('Attempting to switch to unknown session...');
+  try {
+    switcher.switchTo('charlie');
+  } catch (error) {
+    console.error(`Error: ${(error as Error).message}`);
+  }
+  console.log();
+
+  console.log('=== Example Complete ===');
+}
+
+main();

--- a/contrib/examples/issue-87-multi-wallet-switcher/multi-wallet-switcher.ts
+++ b/contrib/examples/issue-87-multi-wallet-switcher/multi-wallet-switcher.ts
@@ -1,0 +1,68 @@
+/**
+ * Multi-Wallet Session Switcher
+ * Manages multiple wallet sessions and allows switching between them
+ */
+
+export interface WalletSession {
+  accountId: string;
+  username: string;
+  [key: string]: any;
+}
+
+export class MultiWalletSwitcher {
+  private sessions: Map<string, WalletSession> = new Map();
+  private activeLabel: string | null = null;
+
+  /**
+   * Add a new wallet session with a label
+   */
+  addSession(label: string, session: WalletSession): void {
+    this.sessions.set(label, session);
+    // If this is the first session, make it active
+    if (this.activeLabel === null) {
+      this.activeLabel = label;
+    }
+  }
+
+  /**
+   * Switch to a different wallet session
+   * @throws Error if the label doesn't exist
+   */
+  switchTo(label: string): void {
+    if (!this.sessions.has(label)) {
+      throw new Error(`Session '${label}' not found`);
+    }
+    this.activeLabel = label;
+  }
+
+  /**
+   * Get the currently active wallet session
+   * @returns The active session or null if no sessions exist
+   */
+  getActive(): WalletSession | null {
+    if (this.activeLabel === null) {
+      return null;
+    }
+    return this.sessions.get(this.activeLabel) || null;
+  }
+
+  /**
+   * Get all registered session labels
+   */
+  getLabels(): string[] {
+    return Array.from(this.sessions.keys());
+  }
+
+  /**
+   * Remove a session by label
+   */
+  removeSession(label: string): boolean {
+    const removed = this.sessions.delete(label);
+    if (removed && this.activeLabel === label) {
+      // If we removed the active session, switch to another or null
+      const labels = this.getLabels();
+      this.activeLabel = labels.length > 0 ? labels[0] : null;
+    }
+    return removed;
+  }
+}

--- a/contrib/examples/issue-88-balance-change-watcher/README.md
+++ b/contrib/examples/issue-88-balance-change-watcher/README.md
@@ -1,0 +1,36 @@
+# Balance Change Watcher
+
+A self-contained reference example that polls a balance source on an interval
+and emits a change event **only** when the returned value differs from the last
+observed value.
+
+## Flow
+
+1. `createBalanceWatcher(source, intervalMs)` starts an interval loop and
+   records the first balance silently (no event on the initial read).
+2. On every subsequent poll, if the new balance differs from the previous one,
+   all registered `ChangeHandler` callbacks are invoked with
+   `(newBalance, previousBalance)`.
+3. Call `watcher.subscribe(handler)` to register a listener.
+4. Call `watcher.stop()` to cancel the interval and end polling.
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| `balance-change-watcher.ts` | Core `createBalanceWatcher` implementation |
+| `demo.ts` | Script with a mock source whose value changes mid-run |
+
+## Running the demo
+
+```bash
+npx ts-node demo.ts
+```
+
+Expected output (values change at polls 4 and 6):
+
+```
+[change] 100.00 → 175.50
+[change] 175.50 → 200.00
+Watcher stopped.
+```

--- a/contrib/examples/issue-88-balance-change-watcher/balance-change-watcher.ts
+++ b/contrib/examples/issue-88-balance-change-watcher/balance-change-watcher.ts
@@ -1,0 +1,53 @@
+/**
+ * Balance change watcher (issue #88)
+ *
+ * Polls a balance source on a fixed interval and emits a "change" event only
+ * when the returned value differs from the previously observed value.
+ */
+
+export type BalanceSource = () => Promise<string>;
+export type ChangeHandler = (newBalance: string, previousBalance: string) => void;
+
+export interface BalanceWatcher {
+  subscribe: (handler: ChangeHandler) => void;
+  stop: () => void;
+}
+
+/**
+ * Create a watcher that polls `source` every `intervalMs` milliseconds.
+ * Call `subscribe` to register a handler; call `stop` to end polling.
+ */
+export function createBalanceWatcher(
+  source: BalanceSource,
+  intervalMs: number = 2000,
+): BalanceWatcher {
+  let lastBalance: string | null = null;
+  const handlers: ChangeHandler[] = [];
+  let timer: ReturnType<typeof setInterval> | null = null;
+
+  async function poll() {
+    const balance = await source();
+    if (lastBalance !== null && balance !== lastBalance) {
+      for (const handler of handlers) {
+        handler(balance, lastBalance);
+      }
+    }
+    lastBalance = balance;
+  }
+
+  // Run an initial poll immediately, then on the interval.
+  poll();
+  timer = setInterval(poll, intervalMs);
+
+  return {
+    subscribe(handler: ChangeHandler) {
+      handlers.push(handler);
+    },
+    stop() {
+      if (timer !== null) {
+        clearInterval(timer);
+        timer = null;
+      }
+    },
+  };
+}

--- a/contrib/examples/issue-88-balance-change-watcher/demo.ts
+++ b/contrib/examples/issue-88-balance-change-watcher/demo.ts
@@ -1,0 +1,31 @@
+/**
+ * Demo script for the balance change watcher (issue #88).
+ *
+ * A mock balance source returns a fixed value for the first few polls, then
+ * changes — showing that the watcher only fires when the value actually differs.
+ *
+ * Run: npx ts-node demo.ts
+ */
+
+import { createBalanceWatcher } from './balance-change-watcher';
+
+const VALUES = ['100.00', '100.00', '100.00', '175.50', '175.50', '200.00'];
+let callCount = 0;
+
+const mockSource = async (): Promise<string> => {
+  const value = VALUES[Math.min(callCount, VALUES.length - 1)];
+  callCount += 1;
+  return value;
+};
+
+const watcher = createBalanceWatcher(mockSource, 500);
+
+watcher.subscribe((newBalance, previousBalance) => {
+  console.log(`[change] ${previousBalance} → ${newBalance}`);
+});
+
+// Let the watcher run through all mock values then stop.
+setTimeout(() => {
+  watcher.stop();
+  console.log('Watcher stopped.');
+}, 3500);

--- a/contrib/examples/issue-89-policy-comparison-tool/README.md
+++ b/contrib/examples/issue-89-policy-comparison-tool/README.md
@@ -1,0 +1,50 @@
+# Policy Comparison Tool
+
+A reference implementation demonstrating how to compare policy configurations between two accounts.
+
+## Overview
+
+This example shows how to:
+- Fetch policy configurations from mock sources
+- Compare policies between two accounts
+- Report differences in a readable format
+- Display side-by-side values for differing fields
+
+## Flow
+
+1. **Fetch policies** - Retrieve policy configurations for two accounts
+2. **Compare** - Identify which fields differ between the accounts
+3. **Report** - Display differences with values from both accounts side by side
+
+## Usage
+
+```typescript
+import { PolicyComparisonTool } from './policy-comparison-tool';
+import { mockPolicySource } from './mock-policy-source';
+
+const tool = new PolicyComparisonTool(mockPolicySource);
+
+// Compare two accounts
+const diff = await tool.compare('account1', 'account2');
+
+if (diff.hasDifferences) {
+  console.log('Differences found:');
+  diff.differences.forEach(d => {
+    console.log(`${d.field}: ${d.account1Value} vs ${d.account2Value}`);
+  });
+}
+```
+
+## Running the Example
+
+```bash
+npx ts-node example.ts
+```
+
+## Implementation Details
+
+The tool:
+- Uses a pluggable policy source (mock implementation provided)
+- Deep compares policy objects field by field
+- Returns structured difference objects with field paths and values
+- Handles nested policy configurations

--- a/contrib/examples/issue-89-policy-comparison-tool/example.ts
+++ b/contrib/examples/issue-89-policy-comparison-tool/example.ts
@@ -1,0 +1,29 @@
+/**
+ * Example usage of the Policy Comparison Tool
+ */
+
+import { PolicyComparisonTool } from './policy-comparison-tool';
+import { mockPolicySource } from './mock-policy-source';
+
+async function main() {
+  console.log('=== Policy Comparison Tool Example ===\n');
+
+  const tool = new PolicyComparisonTool(mockPolicySource);
+
+  console.log('Comparing policies for account1 and account2...\n');
+
+  const result = await tool.compare('account1', 'account2');
+
+  // Display the formatted comparison
+  console.log(tool.formatComparison(result));
+
+  // Also show the structured differences
+  if (result.hasDifferences) {
+    console.log('\nStructured Differences:');
+    console.log(JSON.stringify(result.differences, null, 2));
+  }
+
+  console.log('\n=== Example Complete ===');
+}
+
+main().catch(console.error);

--- a/contrib/examples/issue-89-policy-comparison-tool/mock-policy-source.ts
+++ b/contrib/examples/issue-89-policy-comparison-tool/mock-policy-source.ts
@@ -1,0 +1,44 @@
+/**
+ * Mock policy source for testing
+ */
+
+import { PolicySource, PolicyConfig } from './policy-comparison-tool';
+
+const mockPolicies: Record<string, PolicyConfig> = {
+  account1: {
+    spendingLimit: {
+      daily: 1000,
+      monthly: 25000,
+      currency: 'USD',
+    },
+    allowedRecipients: ['GALICE...', 'GBOB...'],
+    requiresApproval: false,
+    multiSig: {
+      enabled: false,
+      threshold: 1,
+    },
+  },
+  account2: {
+    spendingLimit: {
+      daily: 500,
+      monthly: 25000,
+      currency: 'USD',
+    },
+    allowedRecipients: ['GALICE...', 'GCHARLIE...'],
+    requiresApproval: true,
+    multiSig: {
+      enabled: true,
+      threshold: 2,
+    },
+  },
+};
+
+export const mockPolicySource: PolicySource = {
+  async getPolicy(accountId: string): Promise<PolicyConfig> {
+    const policy = mockPolicies[accountId];
+    if (!policy) {
+      throw new Error(`Policy not found for account: ${accountId}`);
+    }
+    return policy;
+  },
+};

--- a/contrib/examples/issue-89-policy-comparison-tool/policy-comparison-tool.ts
+++ b/contrib/examples/issue-89-policy-comparison-tool/policy-comparison-tool.ts
@@ -1,0 +1,114 @@
+/**
+ * Policy Comparison Tool
+ * Compares policy configurations between two accounts
+ */
+
+export interface PolicyConfig {
+  [key: string]: any;
+}
+
+export interface PolicySource {
+  getPolicy(accountId: string): Promise<PolicyConfig>;
+}
+
+export interface PolicyDifference {
+  field: string;
+  account1Value: any;
+  account2Value: any;
+}
+
+export interface ComparisonResult {
+  account1: string;
+  account2: string;
+  hasDifferences: boolean;
+  differences: PolicyDifference[];
+}
+
+export class PolicyComparisonTool {
+  constructor(private policySource: PolicySource) {}
+
+  /**
+   * Compare policies between two accounts
+   */
+  async compare(account1Id: string, account2Id: string): Promise<ComparisonResult> {
+    const policy1 = await this.policySource.getPolicy(account1Id);
+    const policy2 = await this.policySource.getPolicy(account2Id);
+
+    const differences = this.findDifferences(policy1, policy2);
+
+    return {
+      account1: account1Id,
+      account2: account2Id,
+      hasDifferences: differences.length > 0,
+      differences,
+    };
+  }
+
+  /**
+   * Recursively find differences between two policy objects
+   */
+  private findDifferences(
+    obj1: any,
+    obj2: any,
+    prefix = ''
+  ): PolicyDifference[] {
+    const differences: PolicyDifference[] = [];
+
+    // Get all unique keys from both objects
+    const allKeys = new Set([
+      ...Object.keys(obj1 || {}),
+      ...Object.keys(obj2 || {}),
+    ]);
+
+    for (const key of allKeys) {
+      const fieldPath = prefix ? `${prefix}.${key}` : key;
+      const val1 = obj1?.[key];
+      const val2 = obj2?.[key];
+
+      // If both are objects, recurse
+      if (
+        typeof val1 === 'object' &&
+        val1 !== null &&
+        !Array.isArray(val1) &&
+        typeof val2 === 'object' &&
+        val2 !== null &&
+        !Array.isArray(val2)
+      ) {
+        differences.push(...this.findDifferences(val1, val2, fieldPath));
+      } else if (JSON.stringify(val1) !== JSON.stringify(val2)) {
+        // Values differ
+        differences.push({
+          field: fieldPath,
+          account1Value: val1,
+          account2Value: val2,
+        });
+      }
+    }
+
+    return differences;
+  }
+
+  /**
+   * Format comparison result as readable text
+   */
+  formatComparison(result: ComparisonResult): string {
+    if (!result.hasDifferences) {
+      return `No differences found between ${result.account1} and ${result.account2}`;
+    }
+
+    const lines = [
+      `Policy Comparison: ${result.account1} vs ${result.account2}`,
+      '='.repeat(60),
+      '',
+    ];
+
+    for (const diff of result.differences) {
+      lines.push(`Field: ${diff.field}`);
+      lines.push(`  ${result.account1}: ${JSON.stringify(diff.account1Value)}`);
+      lines.push(`  ${result.account2}: ${JSON.stringify(diff.account2Value)}`);
+      lines.push('');
+    }
+
+    return lines.join('\n');
+  }
+}

--- a/contrib/examples/issue-90-retrying-submitter/README.md
+++ b/contrib/examples/issue-90-retrying-submitter/README.md
@@ -1,0 +1,69 @@
+# Retrying Transaction Submitter
+
+A reference implementation demonstrating retry logic with exponential backoff for transaction submission.
+
+## Overview
+
+This example shows how to:
+- Wrap a submission function with automatic retry logic
+- Implement exponential backoff between retry attempts
+- Set maximum retry attempts
+- Provide clear error messages when all attempts are exhausted
+
+## Flow
+
+1. **Submit** - Attempt to submit a transaction
+2. **Retry on failure** - If submission fails, wait with exponential backoff
+3. **Succeed or exhaust** - Either succeed before max attempts or fail with a clear error
+
+## Backoff Calculation
+
+The exponential backoff formula used:
+```
+delay = baseDelay * (2 ^ attemptNumber)
+```
+
+Example with baseDelay=100ms:
+- Attempt 1: immediate
+- Attempt 2: wait 100ms
+- Attempt 3: wait 200ms
+- Attempt 4: wait 400ms
+- Attempt 5: wait 800ms
+
+## Usage
+
+```typescript
+import { RetryingSubmitter } from './retrying-submitter';
+
+const submitter = new RetryingSubmitter({
+  maxAttempts: 5,
+  baseDelayMs: 100,
+});
+
+try {
+  const result = await submitter.submit(async () => {
+    // Your submission logic here
+    return await submitTransaction(tx);
+  });
+  console.log('Success:', result);
+} catch (error) {
+  console.error('All attempts exhausted:', error.message);
+}
+```
+
+## Running the Examples
+
+```bash
+# Example with eventual success
+npx ts-node example-success.ts
+
+# Example with all attempts exhausted
+npx ts-node example-failure.ts
+```
+
+## Implementation Details
+
+- Configurable maximum attempts and base delay
+- Exponential backoff prevents overwhelming the service
+- Clear error messages distinguish temporary failures from exhaustion
+- Logs each attempt for debugging

--- a/contrib/examples/issue-90-retrying-submitter/example-failure.ts
+++ b/contrib/examples/issue-90-retrying-submitter/example-failure.ts
@@ -1,0 +1,30 @@
+/**
+ * Example: Submission that exhausts all attempts and fails
+ */
+
+import { RetryingSubmitter } from './retrying-submitter';
+
+// Mock submission that always fails
+async function mockSubmitThatAlwaysFails(): Promise<string> {
+  throw new Error('Service unavailable');
+}
+
+async function main() {
+  console.log('=== Retrying Submitter - Failure Example ===\n');
+
+  const submitter = new RetryingSubmitter({
+    maxAttempts: 4,
+    baseDelayMs: 50,
+  });
+
+  try {
+    await submitter.submit(mockSubmitThatAlwaysFails);
+  } catch (error) {
+    console.error('\nAll attempts exhausted!');
+    console.error('Error:', (error as Error).message);
+  }
+
+  console.log('\n=== Example Complete ===');
+}
+
+main().catch(console.error);

--- a/contrib/examples/issue-90-retrying-submitter/example-success.ts
+++ b/contrib/examples/issue-90-retrying-submitter/example-success.ts
@@ -1,0 +1,36 @@
+/**
+ * Example: Submission that fails a few times before succeeding
+ */
+
+import { RetryingSubmitter } from './retrying-submitter';
+
+// Mock submission that fails first 2 attempts, then succeeds
+let attemptCount = 0;
+async function mockSubmitWithEventualSuccess(): Promise<string> {
+  attemptCount++;
+  if (attemptCount < 3) {
+    throw new Error('Network timeout');
+  }
+  return 'tx_hash_12345';
+}
+
+async function main() {
+  console.log('=== Retrying Submitter - Success Example ===\n');
+
+  const submitter = new RetryingSubmitter({
+    maxAttempts: 5,
+    baseDelayMs: 100,
+  });
+
+  try {
+    const result = await submitter.submit(mockSubmitWithEventualSuccess);
+    console.log('\nTransaction submitted successfully!');
+    console.log('Result:', result);
+  } catch (error) {
+    console.error('\nFailed:', (error as Error).message);
+  }
+
+  console.log('\n=== Example Complete ===');
+}
+
+main().catch(console.error);

--- a/contrib/examples/issue-90-retrying-submitter/retrying-submitter.ts
+++ b/contrib/examples/issue-90-retrying-submitter/retrying-submitter.ts
@@ -1,0 +1,64 @@
+/**
+ * Retrying Transaction Submitter
+ * Wraps a submission function with retry logic and exponential backoff
+ */
+
+export interface RetryConfig {
+  maxAttempts: number;
+  baseDelayMs: number;
+}
+
+export class RetryingSubmitter {
+  private config: RetryConfig;
+
+  constructor(config: RetryConfig) {
+    this.config = config;
+  }
+
+  /**
+   * Submit with retry logic
+   * @param submitFn The function to retry
+   * @returns The result from submitFn
+   * @throws Error if all attempts are exhausted
+   */
+  async submit<T>(submitFn: () => Promise<T>): Promise<T> {
+    let lastError: Error | null = null;
+
+    for (let attempt = 1; attempt <= this.config.maxAttempts; attempt++) {
+      try {
+        console.log(`Attempt ${attempt}/${this.config.maxAttempts}...`);
+        const result = await submitFn();
+        console.log(`Success on attempt ${attempt}`);
+        return result;
+      } catch (error) {
+        lastError = error as Error;
+        console.log(`Attempt ${attempt} failed: ${lastError.message}`);
+
+        if (attempt < this.config.maxAttempts) {
+          const delay = this.calculateBackoff(attempt);
+          console.log(`Waiting ${delay}ms before retry...`);
+          await this.sleep(delay);
+        }
+      }
+    }
+
+    throw new Error(
+      `All ${this.config.maxAttempts} attempts exhausted. Last error: ${lastError?.message}`
+    );
+  }
+
+  /**
+   * Calculate exponential backoff delay
+   * Formula: baseDelay * (2 ^ (attempt - 1))
+   */
+  private calculateBackoff(attempt: number): number {
+    return this.config.baseDelayMs * Math.pow(2, attempt - 1);
+  }
+
+  /**
+   * Sleep for a given duration
+   */
+  private sleep(ms: number): Promise<void> {
+    return new Promise((resolve) => setTimeout(resolve, ms));
+  }
+}

--- a/contrib/examples/issue-91-relayer-fallback-example/README.md
+++ b/contrib/examples/issue-91-relayer-fallback-example/README.md
@@ -1,0 +1,54 @@
+# Relayer Fallback Example
+
+A reference implementation demonstrating a submission path that tries a primary relayer and falls back to direct submission on failure.
+
+## Overview
+
+This example shows how to:
+- Attempt submission through a primary relayer function
+- Automatically fall back to a secondary direct submission on failure
+- Demonstrate both success and fallback scenarios
+- Provide clear logging of which path was used
+
+## Flow
+
+1. **Primary attempt** - Try to submit via the primary relayer
+2. **Fallback on failure** - If primary fails, automatically use the fallback path
+3. **Success path** - When primary succeeds, never invoke the fallback
+
+## Usage
+
+```typescript
+import { RelayerFallbackSubmitter } from './relayer-fallback-submitter';
+
+const submitter = new RelayerFallbackSubmitter({
+  primarySubmit: async (tx) => {
+    // Primary relayer logic
+    return await relayer.submit(tx);
+  },
+  fallbackSubmit: async (tx) => {
+    // Direct submission logic
+    return await directSubmit(tx);
+  },
+});
+
+const result = await submitter.submit(transaction);
+console.log('Submitted via:', result.path); // 'primary' or 'fallback'
+```
+
+## Running the Examples
+
+```bash
+# Example with primary succeeding (fallback never called)
+npx ts-node example-primary-success.ts
+
+# Example with primary failing, fallback succeeds
+npx ts-node example-fallback.ts
+```
+
+## Implementation Details
+
+- Both primary and fallback functions are simple mocks
+- Clear logging shows which path was taken
+- Fallback is only invoked if primary fails
+- Returns metadata about which submission path succeeded

--- a/contrib/examples/issue-91-relayer-fallback-example/example-fallback.ts
+++ b/contrib/examples/issue-91-relayer-fallback-example/example-fallback.ts
@@ -1,0 +1,51 @@
+/**
+ * Example: Primary fails, fallback succeeds
+ */
+
+import { RelayerFallbackSubmitter } from './relayer-fallback-submitter';
+
+interface MockTransaction {
+  from: string;
+  to: string;
+  amount: number;
+}
+
+// Mock primary relayer that fails
+async function mockPrimaryRelayerFailure(tx: MockTransaction): Promise<string> {
+  await new Promise((resolve) => setTimeout(resolve, 50));
+  throw new Error('Relayer service unavailable');
+}
+
+// Mock fallback that succeeds
+async function mockFallbackSuccess(tx: MockTransaction): Promise<string> {
+  await new Promise((resolve) => setTimeout(resolve, 50));
+  return `direct_tx_${Date.now()}`;
+}
+
+async function main() {
+  console.log('=== Relayer Fallback - Fallback Path Example ===\n');
+
+  const submitter = new RelayerFallbackSubmitter({
+    primarySubmit: mockPrimaryRelayerFailure,
+    fallbackSubmit: mockFallbackSuccess,
+  });
+
+  const transaction: MockTransaction = {
+    from: 'GALICE...',
+    to: 'GBOB...',
+    amount: 100,
+  };
+
+  console.log('Transaction:', JSON.stringify(transaction, null, 2));
+  console.log();
+
+  const result = await submitter.submit(transaction);
+
+  console.log('\n✓ Submission completed via fallback path');
+  console.log('Path used:', result.path);
+  console.log('Transaction hash:', result.result);
+
+  console.log('\n=== Example Complete ===');
+}
+
+main().catch(console.error);

--- a/contrib/examples/issue-91-relayer-fallback-example/example-primary-success.ts
+++ b/contrib/examples/issue-91-relayer-fallback-example/example-primary-success.ts
@@ -1,0 +1,52 @@
+/**
+ * Example: Primary submission succeeds, fallback is never invoked
+ */
+
+import { RelayerFallbackSubmitter } from './relayer-fallback-submitter';
+
+interface MockTransaction {
+  from: string;
+  to: string;
+  amount: number;
+}
+
+// Mock primary relayer that succeeds
+async function mockPrimaryRelayerSuccess(tx: MockTransaction): Promise<string> {
+  // Simulate some processing time
+  await new Promise((resolve) => setTimeout(resolve, 50));
+  return `relayer_tx_${Date.now()}`;
+}
+
+// Mock fallback that should never be called
+async function mockFallbackSubmit(tx: MockTransaction): Promise<string> {
+  console.log('⚠️  Fallback was called (should not happen in this example)');
+  return `direct_tx_${Date.now()}`;
+}
+
+async function main() {
+  console.log('=== Relayer Fallback - Primary Success Example ===\n');
+
+  const submitter = new RelayerFallbackSubmitter({
+    primarySubmit: mockPrimaryRelayerSuccess,
+    fallbackSubmit: mockFallbackSubmit,
+  });
+
+  const transaction: MockTransaction = {
+    from: 'GALICE...',
+    to: 'GBOB...',
+    amount: 100,
+  };
+
+  console.log('Transaction:', JSON.stringify(transaction, null, 2));
+  console.log();
+
+  const result = await submitter.submit(transaction);
+
+  console.log('\n✓ Submission completed');
+  console.log('Path used:', result.path);
+  console.log('Transaction hash:', result.result);
+
+  console.log('\n=== Example Complete ===');
+}
+
+main().catch(console.error);

--- a/contrib/examples/issue-91-relayer-fallback-example/relayer-fallback-submitter.ts
+++ b/contrib/examples/issue-91-relayer-fallback-example/relayer-fallback-submitter.ts
@@ -1,0 +1,65 @@
+/**
+ * Relayer Fallback Submitter
+ * Attempts primary relayer submission, falls back to direct submission on failure
+ */
+
+export interface SubmitFunction<T, R> {
+  (transaction: T): Promise<R>;
+}
+
+export interface FallbackConfig<T, R> {
+  primarySubmit: SubmitFunction<T, R>;
+  fallbackSubmit: SubmitFunction<T, R>;
+}
+
+export interface SubmitResult<R> {
+  path: 'primary' | 'fallback';
+  result: R;
+}
+
+export class RelayerFallbackSubmitter<T = any, R = any> {
+  private config: FallbackConfig<T, R>;
+
+  constructor(config: FallbackConfig<T, R>) {
+    this.config = config;
+  }
+
+  /**
+   * Submit a transaction, trying primary first, then fallback
+   */
+  async submit(transaction: T): Promise<SubmitResult<R>> {
+    console.log('Attempting primary submission...');
+    
+    try {
+      const result = await this.config.primarySubmit(transaction);
+      console.log('Primary submission succeeded');
+      return {
+        path: 'primary',
+        result,
+      };
+    } catch (primaryError) {
+      console.log(
+        `Primary submission failed: ${(primaryError as Error).message}`
+      );
+      console.log('Attempting fallback submission...');
+
+      try {
+        const result = await this.config.fallbackSubmit(transaction);
+        console.log('Fallback submission succeeded');
+        return {
+          path: 'fallback',
+          result,
+        };
+      } catch (fallbackError) {
+        console.log(
+          `Fallback submission failed: ${(fallbackError as Error).message}`
+        );
+        throw new Error(
+          `Both submission paths failed. Primary: ${
+            (primaryError as Error).message
+          }, Fallback: ${(fallbackError as Error).message}`
+        );
+      }
+    }
+  }
+}

--- a/contrib/examples/issue-93-session-key-rotation/README.md
+++ b/contrib/examples/issue-93-session-key-rotation/README.md
@@ -1,0 +1,49 @@
+# Session Key Rotation Helper
+
+A self-contained reference example that manages an in-memory registry of
+session keys where only one key is active at a time.
+
+## Flow
+
+1. `createSessionKeyRegistry()` returns a registry with no keys.
+2. `registry.rotate()` generates a new 32-byte hex key, marks the current
+   active key (if any) as `'retired'`, and returns the new key.
+3. `registry.activeKey()` returns the currently active key, or `null`.
+4. `registry.history()` returns all entries in chronological order, each with
+   `key`, `status`, `createdAt`, and (if retired) `retiredAt`.
+
+## Constraints
+
+- Only one key may be `'active'` at any time.
+- Retired keys remain in history and are never removed.
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| `session-key-rotation.ts` | Core `createSessionKeyRegistry` implementation |
+| `demo.ts` | Script that generates, rotates, and inspects keys |
+
+## Running the demo
+
+```bash
+npx ts-node demo.ts
+```
+
+Expected output:
+
+```
+--- Initial rotation ---
+Active key: <hex>
+
+--- Rotating to a new key ---
+Active key: <different hex>
+
+--- Key history ---
+  [retired] <key1 prefix>...  created=...  retired=...
+  [active ] <key2 prefix>...  created=...
+
+--- Confirming old key is retired ---
+key1 status: retired
+key2 is active: true
+```

--- a/contrib/examples/issue-93-session-key-rotation/demo.ts
+++ b/contrib/examples/issue-93-session-key-rotation/demo.ts
@@ -1,0 +1,29 @@
+/**
+ * Demo script for session key rotation (issue #93).
+ *
+ * Run: npx ts-node demo.ts
+ */
+
+import { createSessionKeyRegistry } from './session-key-rotation';
+
+const registry = createSessionKeyRegistry();
+
+console.log('--- Initial rotation ---');
+const key1 = registry.rotate();
+console.log('Active key:', key1);
+
+console.log('\n--- Rotating to a new key ---');
+const key2 = registry.rotate();
+console.log('Active key:', key2);
+
+console.log('\n--- Key history ---');
+for (const entry of registry.history()) {
+  const line = `  [${entry.status.padEnd(7)}] ${entry.key.slice(0, 16)}...  created=${entry.createdAt.toISOString()}`;
+  console.log(entry.retiredAt ? `${line}  retired=${entry.retiredAt.toISOString()}` : line);
+}
+
+console.log('\n--- Confirming old key is retired ---');
+const h = registry.history();
+const old = h.find(e => e.key === key1)!;
+console.log(`key1 status: ${old.status}`); // retired
+console.log(`key2 is active: ${registry.activeKey() === key2}`); // true

--- a/contrib/examples/issue-93-session-key-rotation/session-key-rotation.ts
+++ b/contrib/examples/issue-93-session-key-rotation/session-key-rotation.ts
@@ -1,0 +1,57 @@
+/**
+ * Session key rotation helper (issue #93)
+ *
+ * Maintains an in-memory registry of session keys. At most one key is active
+ * at a time; rotating to a new key marks the previous key as retired.
+ */
+
+import { randomBytes } from 'crypto';
+
+export type KeyStatus = 'active' | 'retired';
+
+export interface KeyEntry {
+  key: string;
+  status: KeyStatus;
+  createdAt: Date;
+  retiredAt?: Date;
+}
+
+export interface SessionKeyRegistry {
+  /** Generate and activate a new session key, retiring the current one. */
+  rotate: () => string;
+  /** Return the currently active key, or null if none exists yet. */
+  activeKey: () => string | null;
+  /** Return the full history of all keys in chronological order. */
+  history: () => KeyEntry[];
+}
+
+function generateKey(): string {
+  return randomBytes(32).toString('hex');
+}
+
+export function createSessionKeyRegistry(): SessionKeyRegistry {
+  const entries: KeyEntry[] = [];
+
+  return {
+    rotate() {
+      // Retire the current active key if one exists.
+      const current = entries.find(e => e.status === 'active');
+      if (current) {
+        current.status = 'retired';
+        current.retiredAt = new Date();
+      }
+
+      const newKey = generateKey();
+      entries.push({ key: newKey, status: 'active', createdAt: new Date() });
+      return newKey;
+    },
+
+    activeKey() {
+      return entries.find(e => e.status === 'active')?.key ?? null;
+    },
+
+    history() {
+      return [...entries];
+    },
+  };
+}

--- a/contrib/examples/issue-94-activity-feed-aggregator/README.md
+++ b/contrib/examples/issue-94-activity-feed-aggregator/README.md
@@ -1,0 +1,47 @@
+# Wallet Activity Feed Aggregator
+
+A self-contained reference example that merges payment history and policy change
+history into a single chronologically ordered activity feed where every item has
+a consistent shape.
+
+## Flow
+
+1. `aggregateFeed(payments, policyChanges)` accepts two arrays of raw records.
+2. Each record is normalised into an `ActivityItem` with `id`, `kind`,
+   `timestamp`, `summary`, and `meta`.
+3. The combined list is sorted **newest first** by `timestamp`.
+
+## Consistent item shape
+
+```ts
+interface ActivityItem {
+  id: string;
+  kind: 'payment' | 'policy_change';
+  timestamp: Date;
+  summary: string;         // human-readable one-liner
+  meta: Record<string, unknown>; // source-specific fields
+}
+```
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| `activity-feed-aggregator.ts` | Core `aggregateFeed` implementation |
+| `demo.ts` | Script with sample payments and policy changes |
+
+## Running the demo
+
+```bash
+npx ts-node demo.ts
+```
+
+Expected output (newest first):
+
+```
+[2026-07-05T08:15:00.000Z] (payment) Sent 9.99 USDC to GDEF...
+[2026-07-04T11:45:00.000Z] (policy_change) Policy pol-42: limit_updated
+[2026-07-03T14:30:00.000Z] (payment) Sent 120.00 USDC to GABC...
+[2026-07-02T09:00:00.000Z] (policy_change) Policy pol-42: activated
+[2026-07-01T10:00:00.000Z] (payment) Sent 50.00 USDC to GBXYZ...
+```

--- a/contrib/examples/issue-94-activity-feed-aggregator/activity-feed-aggregator.ts
+++ b/contrib/examples/issue-94-activity-feed-aggregator/activity-feed-aggregator.ts
@@ -1,0 +1,69 @@
+/**
+ * Wallet activity feed aggregator (issue #94)
+ *
+ * Merges payment history and policy change history into a single
+ * chronologically ordered feed where every item has a consistent shape.
+ */
+
+export type ActivityKind = 'payment' | 'policy_change';
+
+export interface ActivityItem {
+  id: string;
+  kind: ActivityKind;
+  timestamp: Date;
+  summary: string;
+  meta: Record<string, unknown>;
+}
+
+export interface PaymentRecord {
+  id: string;
+  amount: string;
+  currency: string;
+  to: string;
+  at: Date;
+}
+
+export interface PolicyChangeRecord {
+  id: string;
+  policyId: string;
+  changeType: string;
+  at: Date;
+}
+
+function fromPayment(p: PaymentRecord): ActivityItem {
+  return {
+    id: p.id,
+    kind: 'payment',
+    timestamp: p.at,
+    summary: `Sent ${p.amount} ${p.currency} to ${p.to}`,
+    meta: { amount: p.amount, currency: p.currency, to: p.to },
+  };
+}
+
+function fromPolicyChange(c: PolicyChangeRecord): ActivityItem {
+  return {
+    id: c.id,
+    kind: 'policy_change',
+    timestamp: c.at,
+    summary: `Policy ${c.policyId}: ${c.changeType}`,
+    meta: { policyId: c.policyId, changeType: c.changeType },
+  };
+}
+
+/**
+ * Merge payment records and policy change records into a single feed sorted
+ * newest-first.
+ */
+export function aggregateFeed(
+  payments: PaymentRecord[],
+  policyChanges: PolicyChangeRecord[],
+): ActivityItem[] {
+  const items: ActivityItem[] = [
+    ...payments.map(fromPayment),
+    ...policyChanges.map(fromPolicyChange),
+  ];
+
+  items.sort((a, b) => b.timestamp.getTime() - a.timestamp.getTime());
+
+  return items;
+}

--- a/contrib/examples/issue-94-activity-feed-aggregator/demo.ts
+++ b/contrib/examples/issue-94-activity-feed-aggregator/demo.ts
@@ -1,0 +1,25 @@
+/**
+ * Demo script for the activity feed aggregator (issue #94).
+ *
+ * Run: npx ts-node demo.ts
+ */
+
+import { aggregateFeed, PaymentRecord, PolicyChangeRecord } from './activity-feed-aggregator';
+
+const payments: PaymentRecord[] = [
+  { id: 'pay-1', amount: '50.00', currency: 'USDC', to: 'GBXYZ...', at: new Date('2026-07-01T10:00:00Z') },
+  { id: 'pay-2', amount: '120.00', currency: 'USDC', to: 'GABC...', at: new Date('2026-07-03T14:30:00Z') },
+  { id: 'pay-3', amount: '9.99', currency: 'USDC', to: 'GDEF...', at: new Date('2026-07-05T08:15:00Z') },
+];
+
+const policyChanges: PolicyChangeRecord[] = [
+  { id: 'pc-1', policyId: 'pol-42', changeType: 'activated', at: new Date('2026-07-02T09:00:00Z') },
+  { id: 'pc-2', policyId: 'pol-42', changeType: 'limit_updated', at: new Date('2026-07-04T11:45:00Z') },
+];
+
+const feed = aggregateFeed(payments, policyChanges);
+
+console.log('Activity feed (newest first):\n');
+for (const item of feed) {
+  console.log(`[${item.timestamp.toISOString()}] (${item.kind}) ${item.summary}`);
+}

--- a/contrib/examples/issue-95-policy-template-picker/README.md
+++ b/contrib/examples/issue-95-policy-template-picker/README.md
@@ -1,0 +1,61 @@
+# Policy Template Picker CLI
+
+A self-contained reference example that lists mock Vellar policy templates and prints the parameter schema for a caller-selected template.
+
+## How to run
+
+```bash
+# From the repo root — list all templates
+npx ts-node contrib/examples/issue-95-policy-template-picker/picker.ts
+
+# Pick a specific template by zero-based index
+npx ts-node contrib/examples/issue-95-policy-template-picker/picker.ts 0
+npx ts-node contrib/examples/issue-95-policy-template-picker/picker.ts 2
+
+# Run the bundled sample (list + two valid picks + one out-of-range)
+npx ts-node contrib/examples/issue-95-policy-template-picker/run-sample.ts
+```
+
+## Sample output — listing
+
+```
+Available policy templates:
+
+  [0] Daily Spending Limit (spending-limit-daily)
+      Caps total spend per rolling 24-hour window; enforced on-chain by a deployed policy contract.
+  [1] Session-Key Signer Limits (session-key-only)
+      Restricts a session key to a fixed set of contract calls; enforced by the wallet's signer limits.
+  [2] Multi-Signer Approval (multi-signer-approval)
+      Requires M-of-N signers to approve a transaction before it is submitted.
+  [3] No Policy (unrestricted)
+      No spending restriction is attached; the wallet's normal signer thresholds apply.
+
+Run with an index (0–3) to view that template's parameter schema.
+```
+
+## Sample output — valid index (`picker.ts 0`)
+
+```
+Template [0]: Daily Spending Limit
+Type        : spending-limit-daily
+Description : Caps total spend per rolling 24-hour window; enforced on-chain by a deployed policy contract.
+Enforcement : {"kind":"policy-contract","wasmHash":"mock-wasm-hash-spending-limit","constructorArgs":{"dailyLimitStroops":"10000000","windowSeconds":86400}}
+
+Parameter schema:
+  dailyLimitStroops
+    type     : string (stroops)
+    required : required
+    desc     : Maximum spend in stroops per rolling 24-hour window (1 XLM = 10,000,000 stroops).
+  windowSeconds
+    type     : number
+    required : optional
+    desc     : Length of the rolling window in seconds. Defaults to 86400 (24 hours).
+```
+
+## Sample output — out-of-range index (`picker.ts 9`)
+
+```
+Error: index "9" is out of range. Valid range is 0–3.
+```
+
+The process exits with code 1 on an out-of-range index.

--- a/contrib/examples/issue-95-policy-template-picker/picker.ts
+++ b/contrib/examples/issue-95-policy-template-picker/picker.ts
@@ -1,0 +1,138 @@
+// Policy Template Picker CLI
+//
+// Usage: npx ts-node picker.ts <index>
+//
+// Lists available mock policy templates (index 0-based).
+// Provide an index to print that template's parameter schema.
+
+import type { PolicyTemplateInfo, Enforcement } from "../../../src/policy-types";
+
+interface TemplateWithParams extends PolicyTemplateInfo {
+  params: Record<string, { type: string; required: boolean; description: string }>;
+}
+
+export const POLICY_TEMPLATES: TemplateWithParams[] = [
+  {
+    type: "spending-limit-daily",
+    title: "Daily Spending Limit",
+    description:
+      "Caps total spend per rolling 24-hour window; enforced on-chain by a deployed policy contract.",
+    enforcement: {
+      kind: "policy-contract",
+      wasmHash: "mock-wasm-hash-spending-limit",
+      constructorArgs: { dailyLimitStroops: "10000000", windowSeconds: 86400 },
+    },
+    params: {
+      dailyLimitStroops: {
+        type: "string (stroops)",
+        required: true,
+        description: "Maximum spend in stroops per rolling 24-hour window (1 XLM = 10,000,000 stroops).",
+      },
+      windowSeconds: {
+        type: "number",
+        required: false,
+        description: "Length of the rolling window in seconds. Defaults to 86400 (24 hours).",
+      },
+    },
+  },
+  {
+    type: "session-key-only",
+    title: "Session-Key Signer Limits",
+    description:
+      "Restricts a session key to a fixed set of contract calls; enforced by the wallet's signer limits.",
+    enforcement: { kind: "signer-limits" },
+    params: {
+      allowedContractIds: {
+        type: "string[]",
+        required: true,
+        description: "List of contract IDs the session key is permitted to invoke.",
+      },
+      allowedFunctionNames: {
+        type: "string[]",
+        required: false,
+        description: "Optional allowlist of function names. Omit to permit all functions on the allowed contracts.",
+      },
+      expiresAt: {
+        type: "number (unix timestamp)",
+        required: false,
+        description: "Unix timestamp after which the session key is considered expired.",
+      },
+    },
+  },
+  {
+    type: "multi-signer-approval",
+    title: "Multi-Signer Approval",
+    description:
+      "Requires M-of-N signers to approve a transaction before it is submitted.",
+    enforcement: { kind: "policy-contract", wasmHash: "mock-wasm-hash-multisig" },
+    params: {
+      threshold: {
+        type: "number",
+        required: true,
+        description: "Minimum number of signers whose approval is required (M).",
+      },
+      signers: {
+        type: "string[] (Stellar public keys)",
+        required: true,
+        description: "Complete list of authorised signer public keys (N).",
+      },
+    },
+  },
+  {
+    type: "unrestricted",
+    title: "No Policy",
+    description:
+      "No spending restriction is attached; the wallet's normal signer thresholds apply.",
+    enforcement: { kind: "none" },
+    params: {},
+  },
+];
+
+export function listTemplates(): void {
+  console.log("Available policy templates:\n");
+  POLICY_TEMPLATES.forEach((t, i) => {
+    console.log(`  [${i}] ${t.title} (${t.type})`);
+    console.log(`      ${t.description}`);
+  });
+  console.log(`\nRun with an index (0–${POLICY_TEMPLATES.length - 1}) to view that template's parameter schema.`);
+}
+
+export function printTemplateSchema(indexStr: string): void {
+  const index = Number(indexStr);
+  if (!Number.isInteger(index) || index < 0 || index >= POLICY_TEMPLATES.length) {
+    console.error(
+      `Error: index "${indexStr}" is out of range. Valid range is 0–${POLICY_TEMPLATES.length - 1}.`
+    );
+    process.exitCode = 1;
+    return;
+  }
+
+  const template = POLICY_TEMPLATES[index];
+  console.log(`\nTemplate [${index}]: ${template.title}`);
+  console.log(`Type        : ${template.type}`);
+  console.log(`Description : ${template.description}`);
+  console.log(`Enforcement : ${JSON.stringify(template.enforcement)}`);
+
+  const paramEntries = Object.entries(template.params);
+  if (paramEntries.length === 0) {
+    console.log("\nParameter schema: (none — this template takes no parameters)");
+  } else {
+    console.log("\nParameter schema:");
+    for (const [name, meta] of paramEntries) {
+      const req = meta.required ? "required" : "optional";
+      console.log(`  ${name}`);
+      console.log(`    type     : ${meta.type}`);
+      console.log(`    required : ${req}`);
+      console.log(`    desc     : ${meta.description}`);
+    }
+  }
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  const arg = process.argv[2];
+  if (arg === undefined) {
+    listTemplates();
+  } else {
+    printTemplateSchema(arg);
+  }
+}

--- a/contrib/examples/issue-95-policy-template-picker/run-sample.ts
+++ b/contrib/examples/issue-95-policy-template-picker/run-sample.ts
@@ -1,0 +1,16 @@
+// Sample runner: demonstrates listing templates and picking a valid index,
+// then shows the error path for an out-of-range index.
+
+import { listTemplates, printTemplateSchema, POLICY_TEMPLATES } from "./picker";
+
+console.log("=== Listing all templates ===\n");
+listTemplates();
+
+console.log("\n=== Selecting template at index 0 ===");
+printTemplateSchema("0");
+
+console.log("\n=== Selecting template at index 2 ===");
+printTemplateSchema("2");
+
+console.log(`\n=== Out-of-range index (${POLICY_TEMPLATES.length}) ===`);
+printTemplateSchema(String(POLICY_TEMPLATES.length));

--- a/contrib/examples/issue-96-verification-status-poller/README.md
+++ b/contrib/examples/issue-96-verification-status-poller/README.md
@@ -1,0 +1,44 @@
+# Verification Status Poller
+
+A self-contained reference example that polls a mock verification job until it
+reaches a terminal state (`verified` or `failed`), with a configurable maximum
+wait time.
+
+## Flow
+
+1. `pollVerificationStatus(jobId, fetcher, options)` starts an interval loop.
+2. On each tick it calls `fetcher(jobId)` to retrieve the current job.
+3. If the job status is `'verified'` or `'failed'` the promise resolves with
+   the final `VerificationJob`.
+4. If `maxWaitMs` elapses before a terminal status is reached, the promise
+   rejects with a descriptive timeout error.
+
+## Options
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `intervalMs` | `1000` | Polling interval in milliseconds |
+| `maxWaitMs` | `30000` | Maximum total wait before rejection |
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| `verification-status-poller.ts` | Core `pollVerificationStatus` implementation |
+| `demo.ts` | Script showing both success and timeout paths |
+
+## Running the demo
+
+```bash
+npx ts-node demo.ts
+```
+
+Expected output:
+
+```
+--- Success path ---
+Job resolved: status=verified
+
+--- Timeout path ---
+Correctly rejected: Verification job job-002 timed out after 1000ms
+```

--- a/contrib/examples/issue-96-verification-status-poller/demo.ts
+++ b/contrib/examples/issue-96-verification-status-poller/demo.ts
@@ -1,0 +1,49 @@
+/**
+ * Demo script for the verification status poller (issue #96).
+ *
+ * Demonstrates both the success path (job resolves in time) and the timeout
+ * path (job never reaches a terminal state within maxWaitMs).
+ *
+ * Run: npx ts-node demo.ts
+ */
+
+import { pollVerificationStatus, VerificationJob, JobStatus } from './verification-status-poller';
+
+// --- Success path: job transitions to 'verified' after a few polls ---
+
+function makeMockFetcher(transitions: JobStatus[], delayMs: number) {
+  let call = 0;
+  return async (_jobId: string): Promise<VerificationJob> => {
+    await new Promise(r => setTimeout(r, delayMs));
+    const status = transitions[Math.min(call, transitions.length - 1)];
+    call += 1;
+    return { id: _jobId, status };
+  };
+}
+
+async function main() {
+  console.log('--- Success path ---');
+  const successFetcher = makeMockFetcher(['pending', 'processing', 'verified'], 300);
+  try {
+    const result = await pollVerificationStatus('job-001', successFetcher, {
+      intervalMs: 400,
+      maxWaitMs: 5000,
+    });
+    console.log(`Job resolved: status=${result.status}`);
+  } catch (err) {
+    console.error('Unexpected error:', err);
+  }
+
+  console.log('\n--- Timeout path ---');
+  const stalledFetcher = makeMockFetcher(['pending', 'pending', 'pending'], 200);
+  try {
+    await pollVerificationStatus('job-002', stalledFetcher, {
+      intervalMs: 300,
+      maxWaitMs: 1000,
+    });
+  } catch (err) {
+    console.log(`Correctly rejected: ${(err as Error).message}`);
+  }
+}
+
+main();

--- a/contrib/examples/issue-96-verification-status-poller/verification-status-poller.ts
+++ b/contrib/examples/issue-96-verification-status-poller/verification-status-poller.ts
@@ -1,0 +1,61 @@
+/**
+ * Verification status poller (issue #96)
+ *
+ * Polls a mock verification job on an interval and resolves once the job
+ * reaches a terminal state. Rejects if the maximum wait time is exceeded.
+ */
+
+export type JobStatus = 'pending' | 'processing' | 'verified' | 'failed';
+
+export interface VerificationJob {
+  id: string;
+  status: JobStatus;
+}
+
+export type StatusFetcher = (jobId: string) => Promise<VerificationJob>;
+
+const TERMINAL_STATUSES: JobStatus[] = ['verified', 'failed'];
+
+export interface PollOptions {
+  /** How often to check, in milliseconds. Default: 1000 */
+  intervalMs?: number;
+  /** Maximum total wait time before rejecting, in milliseconds. Default: 30000 */
+  maxWaitMs?: number;
+}
+
+/**
+ * Poll `fetcher` for `jobId` until it reaches a terminal status or
+ * `maxWaitMs` elapses. Returns the final `VerificationJob` on success,
+ * or rejects with a timeout error.
+ */
+export function pollVerificationStatus(
+  jobId: string,
+  fetcher: StatusFetcher,
+  options: PollOptions = {},
+): Promise<VerificationJob> {
+  const intervalMs = options.intervalMs ?? 1000;
+  const maxWaitMs = options.maxWaitMs ?? 30000;
+
+  return new Promise((resolve, reject) => {
+    const start = Date.now();
+    let timer: ReturnType<typeof setInterval> | null = null;
+
+    async function check() {
+      if (Date.now() - start >= maxWaitMs) {
+        if (timer) clearInterval(timer);
+        reject(new Error(`Verification job ${jobId} timed out after ${maxWaitMs}ms`));
+        return;
+      }
+
+      const job = await fetcher(jobId);
+      if (TERMINAL_STATUSES.includes(job.status)) {
+        if (timer) clearInterval(timer);
+        resolve(job);
+      }
+    }
+
+    // First check immediately, then on interval.
+    check();
+    timer = setInterval(check, intervalMs);
+  });
+}

--- a/contrib/examples/lightweight-logger/README.md
+++ b/contrib/examples/lightweight-logger/README.md
@@ -1,0 +1,43 @@
+# Lightweight logging wrapper
+
+A minimal `info`/`warn`/`error` logger with a global `setSilent` switch —
+useful for keeping test output clean without stripping log calls out of the
+code under test, or for a CLI's `--quiet` flag.
+
+## Usage
+
+```ts
+import { info, warn, error, setSilent } from "./lightweight-logger";
+
+info("Starting up");        // [INFO] Starting up
+warn("Cache miss");         // [WARN] Cache miss
+error("Request failed");    // [ERROR] Request failed
+
+setSilent(true);
+info("This produces no output at all");
+setSilent(false);
+```
+
+## Run it
+
+```sh
+npx tsx lightweight-logger.ts
+```
+
+Expected output:
+
+```
+[INFO] Starting up
+[WARN] Cache miss, falling back to network
+[ERROR] Request failed after 3 retries
+--- now silenced ---
+[INFO] Logging resumed
+```
+
+(Nothing prints between the `--- now silenced ---` line and `Logging resumed`.)
+
+## Tests
+
+```sh
+npx vitest run contrib/examples/lightweight-logger
+```

--- a/contrib/examples/lightweight-logger/lightweight-logger.test.ts
+++ b/contrib/examples/lightweight-logger/lightweight-logger.test.ts
@@ -1,0 +1,47 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { error, info, setSilent, warn } from "./lightweight-logger";
+
+describe("lightweight-logger", () => {
+  beforeEach(() => {
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    setSilent(false); // reset module-level state so tests don't leak into each other
+    vi.restoreAllMocks();
+  });
+
+  it("prefixes each level with a clear label", () => {
+    info("hello");
+    warn("careful");
+    error("broken");
+
+    expect(console.log).toHaveBeenCalledWith("[INFO] hello");
+    expect(console.warn).toHaveBeenCalledWith("[WARN] careful");
+    expect(console.error).toHaveBeenCalledWith("[ERROR] broken");
+  });
+
+  it("produces no output at all once silenced", () => {
+    setSilent(true);
+
+    info("hello");
+    warn("careful");
+    error("broken");
+
+    expect(console.log).not.toHaveBeenCalled();
+    expect(console.warn).not.toHaveBeenCalled();
+    expect(console.error).not.toHaveBeenCalled();
+  });
+
+  it("resumes logging after silence is turned back off", () => {
+    setSilent(true);
+    info("swallowed");
+    setSilent(false);
+    info("heard");
+
+    expect(console.log).toHaveBeenCalledTimes(1);
+    expect(console.log).toHaveBeenCalledWith("[INFO] heard");
+  });
+});

--- a/contrib/examples/lightweight-logger/lightweight-logger.ts
+++ b/contrib/examples/lightweight-logger/lightweight-logger.ts
@@ -1,0 +1,43 @@
+// Example: a minimal logging wrapper with info/warn/error levels that can
+// be silenced entirely — handy for keeping test output clean without
+// deleting the log calls from the code under test.
+//
+// Run with: npx tsx lightweight-logger.ts
+
+let silent = false;
+
+/** Suppresses all output from info/warn/error until called again with false. */
+export function setSilent(value: boolean): void {
+  silent = value;
+}
+
+export function info(message: string): void {
+  if (!silent) console.log(`[INFO] ${message}`);
+}
+
+export function warn(message: string): void {
+  if (!silent) console.warn(`[WARN] ${message}`);
+}
+
+export function error(message: string): void {
+  if (!silent) console.error(`[ERROR] ${message}`);
+}
+
+function main() {
+  info("Starting up");
+  warn("Cache miss, falling back to network");
+  error("Request failed after 3 retries");
+
+  console.log("--- now silenced ---");
+  setSilent(true);
+  info("This should not print");
+  warn("Neither should this");
+  error("Nor this");
+  setSilent(false);
+
+  info("Logging resumed");
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main();
+}

--- a/contrib/examples/list-caip2-ids/README.md
+++ b/contrib/examples/list-caip2-ids/README.md
@@ -1,0 +1,30 @@
+# CAIP-2 Network Identifiers Example (#111)
+
+Lists the CAIP-2 (Chain Agnostic Improvement Proposal 2) network identifiers used throughout the Vellar SDK ecosystem. Purely a static constant lookup with zero network overhead.
+
+## Supported Identifiers
+
+| CAIP-2 Identifier | Network Name | Environment | Description |
+| --- | --- | --- | --- |
+| `stellar:pubnet` | Stellar Public Mainnet | Production | Live network for asset settlements & Soroban contracts |
+| `stellar:testnet` | Stellar Testnet | Testnet | Public test environment for dApps & x402 payment flows |
+| `stellar:futurenet` | Stellar Futurenet | Devnet | Developer network for previewing protocol features |
+
+## SDK Usage Note
+
+CAIP-2 identifiers are standardized `<namespace>:<reference>` strings used in the SDK for:
+- **x402 Payment Headers**: Specifying target payment chain in `X-PAYMENT-REQUIRED` headers (e.g. `network: "stellar:testnet"`).
+- **Wallet Session Binding**: Distinguishing wallet sessions and session key permissions across multi-chain environments.
+- **RPC & Explorer Routing**: Mapping network requests to appropriate Horizon and Soroban RPC nodes.
+
+## Run it
+
+```sh
+npx tsx contrib/examples/list-caip2-ids/list-caip2-ids.ts
+```
+
+## Tests
+
+```sh
+npx vitest run contrib/examples/list-caip2-ids
+```

--- a/contrib/examples/list-caip2-ids/list-caip2-ids.test.ts
+++ b/contrib/examples/list-caip2-ids/list-caip2-ids.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest';
+import {
+  STELLAR_CAIP2_IDENTIFIERS,
+  getCaip2Identifiers,
+} from './list-caip2-ids';
+
+describe('list-caip2-ids (#111)', () => {
+  it('returns both testnet and mainnet CAIP-2 network identifiers', () => {
+    const ids = getCaip2Identifiers();
+    expect(ids.length).toBeGreaterThanOrEqual(2);
+
+    const caip2Strings = ids.map((item) => item.identifier);
+    expect(caip2Strings).toContain('stellar:pubnet');
+    expect(caip2Strings).toContain('stellar:testnet');
+  });
+
+  it('contains proper labels and environment descriptions', () => {
+    const testnet = STELLAR_CAIP2_IDENTIFIERS.find(
+      (item) => item.identifier === 'stellar:testnet',
+    );
+    expect(testnet).toBeDefined();
+    expect(testnet?.networkName).toBe('Stellar Testnet');
+    expect(testnet?.environment).toBe('testnet');
+  });
+});

--- a/contrib/examples/list-caip2-ids/list-caip2-ids.ts
+++ b/contrib/examples/list-caip2-ids/list-caip2-ids.ts
@@ -1,0 +1,56 @@
+// Example: List the CAIP-2 network identifiers used across the Vellar SDK.
+//
+// Run with: npx tsx contrib/examples/list-caip2-ids/list-caip2-ids.ts
+
+export interface Caip2NetworkIdentifier {
+  identifier: string;
+  networkName: string;
+  environment: 'production' | 'testnet' | 'devnet';
+  description: string;
+}
+
+/**
+ * CAIP-2 (Chain Agnostic Improvement Proposal 2) network identifiers
+ * supported across the Vellar SDK ecosystem.
+ */
+export const STELLAR_CAIP2_IDENTIFIERS: Caip2NetworkIdentifier[] = [
+  {
+    identifier: 'stellar:pubnet',
+    networkName: 'Stellar Public Mainnet',
+    environment: 'production',
+    description: 'Production network for live Stellar asset settlements and smart contracts.',
+  },
+  {
+    identifier: 'stellar:testnet',
+    networkName: 'Stellar Testnet',
+    environment: 'testnet',
+    description: 'Public test network for developing and testing Soroban contracts and x402 payments.',
+  },
+  {
+    identifier: 'stellar:futurenet',
+    networkName: 'Stellar Futurenet',
+    environment: 'devnet',
+    description: 'Experimental developer network for early preview of upcoming protocol upgrades.',
+  },
+];
+
+export function getCaip2Identifiers(): Caip2NetworkIdentifier[] {
+  return STELLAR_CAIP2_IDENTIFIERS;
+}
+
+function main() {
+  console.log('=== CAIP-2 Network Identifiers in Vellar SDK ===\n');
+
+  console.log('Identifier        | Network Name            | Environment  | Description');
+  console.log('------------------|-------------------------|--------------|---------------------------------------------------------');
+
+  for (const net of STELLAR_CAIP2_IDENTIFIERS) {
+    console.log(
+      `${net.identifier.padEnd(17)} | ${net.networkName.padEnd(23)} | ${net.environment.padEnd(12)} | ${net.description}`,
+    );
+  }
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main();
+}

--- a/contrib/examples/list-error-classes/README.md
+++ b/contrib/examples/list-error-classes/README.md
@@ -1,0 +1,37 @@
+# List the SDK's typed error classes
+
+Prints the SDK's typed error class names with a one-line description of when
+each is thrown — a quick reference for `try`/`catch` handling without
+digging through the source.
+
+> **This list is hardcoded and must be kept in sync with the SDK source
+> manually.** It is not generated or validated against `src/` — if a new
+> error class is added, or an existing one renamed, this list will drift
+> until someone updates it by hand.
+
+## Run it
+
+```sh
+npx tsx list-error-classes.ts
+```
+
+Expected output (10 entries):
+
+```
+WalletNotReadyError: wallet.pay()/wallet.policies used before create() or connect()
+WalletNetworkMismatchError: the connector is configured for one network but asked to operate on another
+InvalidRecipientError: a payment recipient is invalid or equals the sender
+InvalidAmountError: a payment/token amount string is malformed, zero, or negative
+WalletApiError: an HTTP call to the wallet gateway (create/connect/submit) returned a non-2xx response
+PolicyApiError: an HTTP call to the policy API gateway returned a non-2xx response
+TransactionTimeoutError: waitForTransaction() polled past its timeout without a final status
+MaxAmountExceededError: an x402 server requested more than the caller's maxAmount
+DisallowedAssetError: an x402 server requested an asset not in the caller's allowedAssets
+X402NotConfiguredError: wallet.x402 was used without x402 config in createVellarWallet
+```
+
+## Tests
+
+```sh
+npx vitest run contrib/examples/list-error-classes
+```

--- a/contrib/examples/list-error-classes/list-error-classes.test.ts
+++ b/contrib/examples/list-error-classes/list-error-classes.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+import { SDK_ERROR_CLASSES } from "./list-error-classes";
+
+describe("SDK_ERROR_CLASSES", () => {
+  it("lists at least 6 error classes", () => {
+    expect(SDK_ERROR_CLASSES.length).toBeGreaterThanOrEqual(6);
+  });
+
+  it("gives every entry a non-empty name and description", () => {
+    for (const entry of SDK_ERROR_CLASSES) {
+      expect(entry.name.length).toBeGreaterThan(0);
+      expect(entry.description.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("every name ends in Error, matching the SDK's class naming convention", () => {
+    for (const entry of SDK_ERROR_CLASSES) {
+      expect(entry.name.endsWith("Error")).toBe(true);
+    }
+  });
+
+  it("has no duplicate class names", () => {
+    const names = SDK_ERROR_CLASSES.map((e) => e.name);
+    expect(new Set(names).size).toBe(names.length);
+  });
+});

--- a/contrib/examples/list-error-classes/list-error-classes.ts
+++ b/contrib/examples/list-error-classes/list-error-classes.ts
@@ -1,0 +1,33 @@
+// Example: list the SDK's typed error classes with a one-line description
+// of when each is thrown. Hardcoded — kept in sync with the SDK source
+// manually (see the README note).
+//
+// Run with: npx tsx list-error-classes.ts
+
+export interface ErrorClassInfo {
+  name: string;
+  description: string;
+}
+
+export const SDK_ERROR_CLASSES: ErrorClassInfo[] = [
+  { name: "WalletNotReadyError", description: "wallet.pay()/wallet.policies used before create() or connect()" },
+  { name: "WalletNetworkMismatchError", description: "the connector is configured for one network but asked to operate on another" },
+  { name: "InvalidRecipientError", description: "a payment recipient is invalid or equals the sender" },
+  { name: "InvalidAmountError", description: "a payment/token amount string is malformed, zero, or negative" },
+  { name: "WalletApiError", description: "an HTTP call to the wallet gateway (create/connect/submit) returned a non-2xx response" },
+  { name: "PolicyApiError", description: "an HTTP call to the policy API gateway returned a non-2xx response" },
+  { name: "TransactionTimeoutError", description: "waitForTransaction() polled past its timeout without a final status" },
+  { name: "MaxAmountExceededError", description: "an x402 server requested more than the caller's maxAmount" },
+  { name: "DisallowedAssetError", description: "an x402 server requested an asset not in the caller's allowedAssets" },
+  { name: "X402NotConfiguredError", description: "wallet.x402 was used without x402 config in createVellarWallet" },
+];
+
+function main() {
+  for (const { name, description } of SDK_ERROR_CLASSES) {
+    console.log(`${name}: ${description}`);
+  }
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main();
+}

--- a/contrib/examples/list-policy-templates/README.md
+++ b/contrib/examples/list-policy-templates/README.md
@@ -1,0 +1,39 @@
+# List policy templates (mock backend)
+
+A standalone example that calls a mocked `policies.listTemplates()`-style
+function and prints the returned templates.
+
+## What it does
+
+`list-templates.ts` builds a `PolicyClient` (from `createPolicyClient` in
+`src/policy-client.ts`) with an injected `fetch` that serves three hardcoded
+`PolicyTemplateInfo` entries for `GET /policies/templates` instead of calling
+a real gateway. `main()` calls `listTemplates()` and prints each template's
+`type` (its id) and `description`.
+
+## Run it
+
+```sh
+npx tsx contrib/examples/list-policy-templates/list-templates.ts
+```
+
+## Test it
+
+```sh
+npm test -- contrib/examples/list-policy-templates
+```
+
+## Mapping to the real policies API
+
+In a real integration you'd construct the client the same way but point it at
+your gateway and skip the `fetch` override:
+
+```ts
+const client = createPolicyClient({ apiUrl: "https://api.myapp.com", network: "mainnet" });
+const templates = await client.listTemplates();
+```
+
+That issues `GET {apiUrl}/policies/templates` against your deployed
+policy-service and returns the live `PolicyTemplateInfo[]` — the same shape
+this example fabricates locally, so code written against the mock output
+here works unchanged against the real backend.

--- a/contrib/examples/list-policy-templates/list-templates.test.ts
+++ b/contrib/examples/list-policy-templates/list-templates.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it, vi } from "vitest";
+import { listPolicyTemplates, main } from "./list-templates";
+
+describe("listPolicyTemplates", () => {
+  it("returns at least 3 templates from the mock backend", async () => {
+    const templates = await listPolicyTemplates();
+    expect(templates.length).toBeGreaterThanOrEqual(3);
+    for (const template of templates) {
+      expect(typeof template.type).toBe("string");
+      expect(typeof template.description).toBe("string");
+      expect(template.description.length).toBeGreaterThan(0);
+    }
+  });
+});
+
+describe("main", () => {
+  it("prints each template's id and description", async () => {
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    await main();
+    const templates = await listPolicyTemplates();
+    expect(logSpy).toHaveBeenCalledTimes(templates.length);
+    for (const template of templates) {
+      expect(logSpy).toHaveBeenCalledWith(`${template.type}: ${template.description}`);
+    }
+    logSpy.mockRestore();
+  });
+});

--- a/contrib/examples/list-policy-templates/list-templates.ts
+++ b/contrib/examples/list-policy-templates/list-templates.ts
@@ -1,0 +1,64 @@
+// Standalone example: call a mocked policies.listTemplates() and print the
+// results. See ./README.md for how this maps to the real policies API.
+
+import { createPolicyClient } from "../../../src/policy-client";
+import type { PolicyTemplateInfo } from "../../../src/policy-types";
+
+const MOCK_TEMPLATES: PolicyTemplateInfo[] = [
+  {
+    type: "spending-limit-daily",
+    title: "Daily spending limit",
+    description:
+      "Caps total spend per rolling 24h window; enforced on-chain by a deployed policy contract.",
+    enforcement: { kind: "policy-contract", wasmHash: "mock-wasm-hash-spending-limit" },
+  },
+  {
+    type: "session-key-only",
+    title: "Session-key signer limits",
+    description:
+      "Restricts a session key to a fixed set of contract calls; enforced by the wallet's signer limits, no separate contract deployed.",
+    enforcement: { kind: "signer-limits" },
+  },
+  {
+    type: "unrestricted",
+    title: "No policy",
+    description: "No spending restriction is attached; the wallet's normal signer thresholds apply.",
+    enforcement: { kind: "none" },
+  },
+];
+
+/** A `fetch` stand-in that serves `MOCK_TEMPLATES` for GET /policies/templates
+ * and 404s everything else — enough to drive `createPolicyClient` without a
+ * real gateway. */
+function mockPoliciesFetch(): typeof fetch {
+  return (async (input: RequestInfo | URL) => {
+    const url = typeof input === "string" ? input : input.toString();
+    if (url.endsWith("/policies/templates")) {
+      return new Response(JSON.stringify(MOCK_TEMPLATES), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    }
+    return new Response(JSON.stringify({ error: "not found" }), { status: 404 });
+  }) as typeof fetch;
+}
+
+export async function listPolicyTemplates(): Promise<PolicyTemplateInfo[]> {
+  const client = createPolicyClient({
+    apiUrl: "https://example-gateway.invalid",
+    network: "testnet",
+    fetch: mockPoliciesFetch(),
+  });
+  return client.listTemplates();
+}
+
+export async function main(): Promise<void> {
+  const templates = await listPolicyTemplates();
+  for (const template of templates) {
+    console.log(`${template.type}: ${template.description}`);
+  }
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main();
+}

--- a/contrib/examples/list-testnet-assets/README.md
+++ b/contrib/examples/list-testnet-assets/README.md
@@ -1,0 +1,36 @@
+# List testnet asset codes
+
+Prints a fixed list of common testnet asset codes useful for manual testing,
+as a simple formatted table.
+
+> **This is a static reference list, not a live query.** The SDK has no
+> "list assets" endpoint, and testnet issuers/liquidity change over time —
+> verify an asset (and its issuer) still exists on testnet before relying on
+> it in a real test.
+
+## Run it
+
+```sh
+npx tsx list-testnet-assets.ts
+```
+
+Expected output:
+
+```
+CODE   DESCRIPTION
+------------------
+XLM    Native Stellar Lumens — no issuer, always available
+USDC   Circle's testnet USD Coin, widely used for payment demos
+yUSDC  Yield-bearing wrapped testnet USDC used in some DeFi demos
+SRT    Common StellarX testnet reward/test token
+TEST   Generic placeholder code many sample issuers mint for demos
+BTC    Testnet-issued synthetic Bitcoin-pegged asset used in anchor demos
+
+Static reference list — not a live query. Verify an asset/issuer still exists on testnet before use.
+```
+
+## Tests
+
+```sh
+npx vitest run contrib/examples/list-testnet-assets
+```

--- a/contrib/examples/list-testnet-assets/list-testnet-assets.test.ts
+++ b/contrib/examples/list-testnet-assets/list-testnet-assets.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+import { TESTNET_ASSETS } from "./list-testnet-assets";
+
+describe("TESTNET_ASSETS", () => {
+  it("lists at least 5 sample asset codes", () => {
+    expect(TESTNET_ASSETS.length).toBeGreaterThanOrEqual(5);
+  });
+
+  it("gives every asset a non-empty code and description", () => {
+    for (const asset of TESTNET_ASSETS) {
+      expect(asset.code.length).toBeGreaterThan(0);
+      expect(asset.description.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("includes the native XLM asset", () => {
+    expect(TESTNET_ASSETS.some((a) => a.code === "XLM")).toBe(true);
+  });
+
+  it("has no duplicate asset codes", () => {
+    const codes = TESTNET_ASSETS.map((a) => a.code);
+    expect(new Set(codes).size).toBe(codes.length);
+  });
+});

--- a/contrib/examples/list-testnet-assets/list-testnet-assets.ts
+++ b/contrib/examples/list-testnet-assets/list-testnet-assets.ts
@@ -1,0 +1,40 @@
+// Example: print a fixed list of common testnet asset codes useful for
+// manual testing. This is a static reference list, NOT a live query — the
+// SDK has no "list assets" endpoint, and testnet issuers/liquidity change
+// over time, so verify an asset still exists before relying on it.
+//
+// Run with: npx tsx list-testnet-assets.ts
+
+export interface TestnetAsset {
+  code: string;
+  description: string;
+}
+
+export const TESTNET_ASSETS: TestnetAsset[] = [
+  { code: "XLM", description: "Native Stellar Lumens — no issuer, always available" },
+  { code: "USDC", description: "Circle's testnet USD Coin, widely used for payment demos" },
+  { code: "yUSDC", description: "Yield-bearing wrapped testnet USDC used in some DeFi demos" },
+  { code: "SRT", description: "Common StellarX testnet reward/test token" },
+  { code: "TEST", description: "Generic placeholder code many sample issuers mint for demos" },
+  { code: "BTC", description: "Testnet-issued synthetic Bitcoin-pegged asset used in anchor demos" },
+];
+
+function printTable(assets: TestnetAsset[]): void {
+  const codeWidth = Math.max(...assets.map((a) => a.code.length), "CODE".length);
+  const header = `${"CODE".padEnd(codeWidth)}  DESCRIPTION`;
+  console.log(header);
+  console.log("-".repeat(header.length));
+  for (const asset of assets) {
+    console.log(`${asset.code.padEnd(codeWidth)}  ${asset.description}`);
+  }
+}
+
+function main() {
+  printTable(TESTNET_ASSETS);
+  console.log();
+  console.log("Static reference list — not a live query. Verify an asset/issuer still exists on testnet before use.");
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main();
+}

--- a/contrib/examples/local-balance-cache/README.md
+++ b/contrib/examples/local-balance-cache/README.md
@@ -1,0 +1,22 @@
+# local-balance-cache
+
+Small in-memory balance cache keyed by account and token with a configurable expiry.
+
+## Usage
+
+```ts
+import { LocalBalanceCache } from "./index";
+
+const cache = new LocalBalanceCache({ ttlMs: 5000 });
+
+cache.set("GACC", "USDC", 1000000n);
+const balance = cache.get("GACC", "USDC");
+console.log(balance); // 1000000n
+```
+
+## API
+
+- `set(account, token, value)` — store a balance with expiry.
+- `get(account, token)` — returns `bigint | undefined` (undefined when missing or expired).
+- `invalidate(account, token)` — removes a cached entry immediately.
+- `clear()` — removes all entries.

--- a/contrib/examples/local-balance-cache/index.ts
+++ b/contrib/examples/local-balance-cache/index.ts
@@ -1,0 +1,49 @@
+/**
+ * Small balance cache keyed by account + token, with a configurable expiry.
+ */
+
+export interface CacheEntry<T> {
+  value: T;
+  expiresAt: number; // epoch ms
+}
+
+export interface BalanceCacheOptions {
+  /** Expiry in milliseconds. Default: 5,000. */
+  ttlMs?: number;
+}
+
+export class LocalBalanceCache {
+  private store = new Map<string, CacheEntry<bigint>>();
+  private ttlMs: number;
+
+  constructor(opts?: BalanceCacheOptions) {
+    this.ttlMs = opts?.ttlMs ?? 5000;
+  }
+
+  key(account: string, token: string): string {
+    return `${account}\u0001${token}`;
+  }
+
+  set(account: string, token: string, value: bigint): void {
+    const expiresAt = Date.now() + this.ttlMs;
+    this.store.set(this.key(account, token), { value, expiresAt });
+  }
+
+  get(account: string, token: string): bigint | undefined {
+    const entry = this.store.get(this.key(account, token));
+    if (!entry) return undefined;
+    if (Date.now() > entry.expiresAt) {
+      this.store.delete(this.key(account, token));
+      return undefined;
+    }
+    return entry.value;
+  }
+
+  invalidate(account: string, token: string): void {
+    this.store.delete(this.key(account, token));
+  }
+
+  clear(): void {
+    this.store.clear();
+  }
+}

--- a/contrib/examples/local-balance-cache/test.ts
+++ b/contrib/examples/local-balance-cache/test.ts
@@ -1,0 +1,24 @@
+import { LocalBalanceCache } from "./index";
+
+console.log("local-balance-cache tests:");
+
+{
+  const cache = new LocalBalanceCache({ ttlMs: 1000 });
+
+  cache.set("GACC", "USDC", 12345n);
+  const hit = cache.get("GACC", "USDC");
+  console.assert(hit === 12345n, "expected fresh hit");
+  console.log("ok: fresh hit for GACC/USDC");
+}
+
+{
+  const cache = new LocalBalanceCache({ ttlMs: 50 });
+
+  cache.set("GACC", "USDC", 12345n);
+  await new Promise((resolve) => setTimeout(resolve, 100));
+  const miss = cache.get("GACC", "USDC");
+  console.assert(miss === undefined, "expected expired miss");
+  console.log("ok: expired entry treated as miss");
+}
+
+console.log("local-balance-cache tests passed");

--- a/contrib/examples/mainnet-network-info/README.md
+++ b/contrib/examples/mainnet-network-info/README.md
@@ -1,0 +1,33 @@
+# Mainnet network info
+
+Prints the canonical Stellar mainnet network passphrase and its CAIP-2
+identifier. Pure constant lookup — no network calls.
+
+## Where this is used in the SDK
+
+- `MAINNET.networkPassphrase` (`src/config.ts`) is one of the SDK-verified
+  fields in the `MAINNET` / `mainnetConfig()` `NetworkConfig` — used to
+  construct `PasskeyKit`/`SACClient` and to sign/submit transactions on the
+  correct network.
+- The `stellar:pubnet` CAIP-2 identifier is how the SDK's x402 client
+  (`src/x402-client.ts`) tags mainnet payment requirements per the x402 v2
+  spec (`PaymentRequirements.network`, `src/x402-types.ts`).
+
+## Run it
+
+```sh
+npx tsx mainnet-network-info.ts
+```
+
+Expected output:
+
+```
+Network passphrase: Public Global Stellar Network ; September 2015
+CAIP-2 identifier:  stellar:pubnet
+```
+
+## Tests
+
+```sh
+npx vitest run contrib/examples/mainnet-network-info
+```

--- a/contrib/examples/mainnet-network-info/mainnet-network-info.test.ts
+++ b/contrib/examples/mainnet-network-info/mainnet-network-info.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from "vitest";
+import { MAINNET } from "../../../src/config";
+import { MAINNET_CAIP2 } from "./mainnet-network-info";
+
+describe("mainnet network info", () => {
+  it("exposes the canonical mainnet passphrase from src/config", () => {
+    expect(MAINNET.networkPassphrase).toBe("Public Global Stellar Network ; September 2015");
+  });
+
+  it("exposes the stellar:pubnet CAIP-2 identifier", () => {
+    expect(MAINNET_CAIP2).toBe("stellar:pubnet");
+  });
+});

--- a/contrib/examples/mainnet-network-info/mainnet-network-info.ts
+++ b/contrib/examples/mainnet-network-info/mainnet-network-info.ts
@@ -1,0 +1,21 @@
+// Example: print the canonical Stellar mainnet network passphrase and its
+// CAIP-2 identifier. Pure constant lookup — no network calls.
+//
+// Run with: npx tsx mainnet-network-info.ts
+
+import { MAINNET } from "../../../src/config";
+
+// The CAIP-2 identifier vellar-sdk's x402 client maps mainnet to internally
+// (src/x402-client.ts's CAIP2_BY_NETWORK / src/x402-types.ts's
+// PaymentRequirements.network doc) — not exported as a named constant, so
+// it's reproduced here as the same literal.
+export const MAINNET_CAIP2 = "stellar:pubnet";
+
+function main() {
+  console.log("Network passphrase:", MAINNET.networkPassphrase);
+  console.log("CAIP-2 identifier: ", MAINNET_CAIP2);
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main();
+}

--- a/contrib/examples/mask-secret/README.md
+++ b/contrib/examples/mask-secret/README.md
@@ -1,0 +1,24 @@
+# Mask Secret Key Example (#113)
+
+Provides a lightweight, safe utility `maskSecret` that masks all but the first few characters of a secret key string (such as a Stellar secret seed starting with `S`). Suitable for safe logging without exposing sensitive key material in stdout or telemetry.
+
+## Examples & Expected Outputs
+
+| Input Secret Key | Visible Chars | Masked Output for Safe Logging |
+| --- | --- | --- |
+| `SD4V5Q7Z3X8K9L0M1N2O3P4Q5R6S7T8U9V0W1X2Y3Z4A5B6C7D8E9F0G` | 4 (Default) | `SD4V****************************************************` |
+| `SBXZ9876543210FEDCBA9876543210FEDCBA9876543210FEDCBA9876` | 4 (Default) | `SBXZ****************************************************` |
+| `SBXZ9876543210` | 2 | `SB****************` |
+| `S123` | 4 | `****` (Fully masked to prevent leaks) |
+
+## Run it
+
+```sh
+npx tsx contrib/examples/mask-secret/mask-secret.ts
+```
+
+## Tests
+
+```sh
+npx vitest run contrib/examples/mask-secret
+```

--- a/contrib/examples/mask-secret/mask-secret.test.ts
+++ b/contrib/examples/mask-secret/mask-secret.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest';
+import { maskSecret } from './mask-secret';
+
+describe('mask-secret (#113)', () => {
+  it('masks secret key showing only first 4 characters by default', () => {
+    const secret =
+      'SD4V5Q7Z3X8K9L0M1N2O3P4Q5R6S7T8U9V0W1X2Y3Z4A5B6C7D8E9F0G';
+    const masked = maskSecret(secret);
+    expect(masked.startsWith('SD4V')).toBe(true);
+    expect(masked.slice(4)).toBe('*'.repeat(secret.length - 4));
+    expect(masked.length).toBe(secret.length);
+  });
+
+  it('customizes visible length and mask character', () => {
+    const secret = 'SBXZ9876543210';
+    const masked = maskSecret(secret, 2, '#');
+    expect(masked.startsWith('SB')).toBe(true);
+    expect(masked.slice(2)).toBe('#'.repeat(secret.length - 2));
+  });
+
+  it('masks short strings entirely to avoid leaking secrets', () => {
+    expect(maskSecret('S123')).toBe('****');
+    expect(maskSecret('AB')).toBe('**');
+  });
+
+  it('handles empty or null inputs gracefully', () => {
+    expect(maskSecret('')).toBe('');
+    expect(maskSecret(null as any)).toBe('');
+  });
+});

--- a/contrib/examples/mask-secret/mask-secret.ts
+++ b/contrib/examples/mask-secret/mask-secret.ts
@@ -1,0 +1,55 @@
+// Example: Mask secret keys for safe logging without exposing full unmasked secrets.
+//
+// Run with: npx tsx contrib/examples/mask-secret/mask-secret.ts
+
+/**
+ * Masks a secret key string, showing only the first `visibleChars` characters
+ * followed by `*` mask characters.
+ *
+ * Safe Logging Guarantee:
+ * - If the input is empty or invalid, returns an empty string or fixed mask.
+ * - If the secret is shorter than or equal to `visibleChars`, masks all characters.
+ * - Never returns or leaks the unmasked secret.
+ */
+export function maskSecret(
+  secret: string,
+  visibleChars = 4,
+  maskChar = '*',
+): string {
+  if (!secret || typeof secret !== 'string') {
+    return '';
+  }
+
+  const str = secret.trim();
+  if (str.length <= visibleChars) {
+    return maskChar.repeat(str.length);
+  }
+
+  const visiblePart = str.slice(0, visibleChars);
+  const maskedPart = maskChar.repeat(str.length - visibleChars);
+  return `${visiblePart}${maskedPart}`;
+}
+
+function main() {
+  console.log('=== Mask Secret Key Example ===\n');
+
+  // Example secret keys (Sample/Testnet values)
+  // IMPORTANT: The script only prints the result of maskSecret(), never unmasked secrets!
+  const sampleSecretKeys = [
+    'SD4V5Q7Z3X8K9L0M1N2O3P4Q5R6S7T8U9V0W1X2Y3Z4A5B6C7D8E9F0G',
+    'SBXZ9876543210FEDCBA9876543210FEDCBA9876543210FEDCBA9876',
+    'S123',
+    'SECRET_API_KEY_LIVE_99887766554433221100',
+  ];
+
+  console.log('Safe Masked Outputs for Logging:');
+  console.log('-----------------------------------');
+  for (const secretKey of sampleSecretKeys) {
+    const masked = maskSecret(secretKey);
+    console.log(`Masked Output : ${masked}  (Length: ${masked.length})`);
+  }
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main();
+}

--- a/contrib/examples/memory-session-store/README.md
+++ b/contrib/examples/memory-session-store/README.md
@@ -1,0 +1,36 @@
+# In-memory session store
+
+A minimal in-memory store for a `WalletSession`, exposing `getSession()` and
+`setSession()` operating on a module-level variable.
+
+**For examples and tests only — not production.** A real app should persist
+sessions with `createWebStorageAdapter` (or a custom `SessionStorageAdapter`)
+from `vellar-sdk`'s `src/session.ts`. A plain module-level variable is lost on
+reload/restart and is shared globally across everything that imports this
+module — there is no per-user or per-tab isolation.
+
+## Run it
+
+```sh
+npx tsx memory-session-store.ts
+```
+
+Expected output:
+
+```
+Before setSession: null
+After setSession:  {
+  accountId: 'CABC123SAMPLEWALLETCONTRACTADDRESSXXXXXXXXXXXXXXXXXXXXXX',
+  network: 'testnet',
+  connected: true,
+  authMethod: 'passkey',
+  createdAt: '2026-01-15T09:30:00.000Z',
+  lastActiveAt: '2026-01-15T09:30:00.000Z'
+}
+```
+
+## Tests
+
+```sh
+npx vitest run contrib/examples/memory-session-store
+```

--- a/contrib/examples/memory-session-store/memory-session-store.test.ts
+++ b/contrib/examples/memory-session-store/memory-session-store.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+import { getSession, setSession, type WalletSession } from "./memory-session-store";
+
+const sample: WalletSession = {
+  accountId: "CTEST",
+  network: "testnet",
+  connected: true,
+  authMethod: "passkey",
+  createdAt: "2026-01-01T00:00:00.000Z",
+  lastActiveAt: "2026-01-01T00:00:00.000Z",
+};
+
+describe("memory session store", () => {
+  it("returns null before any session is set", () => {
+    expect(getSession()).toBeNull();
+  });
+
+  it("returns the session that was set", () => {
+    setSession(sample);
+    expect(getSession()).toEqual(sample);
+  });
+
+  it("overwrites the previous session on a second setSession call", () => {
+    setSession(sample);
+    const updated = { ...sample, accountId: "CTEST2" };
+    setSession(updated);
+    expect(getSession()).toEqual(updated);
+  });
+});

--- a/contrib/examples/memory-session-store/memory-session-store.ts
+++ b/contrib/examples/memory-session-store/memory-session-store.ts
@@ -1,0 +1,47 @@
+// Example: a minimal in-memory store for a wallet session, with getSession
+// and setSession operating on a module-level variable.
+//
+// NOTE: for examples and tests only — not production. A real app persists
+// sessions with createWebStorageAdapter (or similar) from vellar-sdk's
+// src/session.ts, not a plain module variable, which is lost on reload and
+// shared across everything that imports this module.
+//
+// Run with: npx tsx memory-session-store.ts
+
+export interface WalletSession {
+  accountId: string;
+  network: "testnet" | "mainnet";
+  connected: boolean;
+  authMethod: "passkey";
+  createdAt: string;
+  lastActiveAt: string;
+}
+
+let currentSession: WalletSession | null = null;
+
+export function setSession(session: WalletSession): void {
+  currentSession = session;
+}
+
+export function getSession(): WalletSession | null {
+  return currentSession;
+}
+
+function main() {
+  console.log("Before setSession:", getSession());
+
+  setSession({
+    accountId: "CABC123SAMPLEWALLETCONTRACTADDRESSXXXXXXXXXXXXXXXXXXXXXX",
+    network: "testnet",
+    connected: true,
+    authMethod: "passkey",
+    createdAt: "2026-01-15T09:30:00.000Z",
+    lastActiveAt: "2026-01-15T09:30:00.000Z",
+  });
+
+  console.log("After setSession: ", getSession());
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main();
+}

--- a/contrib/examples/mock-device-pairing/README.md
+++ b/contrib/examples/mock-device-pairing/README.md
@@ -1,0 +1,60 @@
+# Mock device pairing flow for tests
+
+A mock version of the extension device pairing flow — **request**,
+**approve**, then **issue-session** — useful for wiring into a test suite
+that needs a "device is paired" scenario without a real browser extension.
+State is a plain in-memory `Map`; there's no network or WebAuthn involved.
+
+## Flow
+
+`createMockPairingFlow()` returns three functions sharing in-memory state:
+
+1. **`request(deviceLabel)`** — a device asks to be paired. Returns a
+   `PairingRequest` with `status: "pending"`.
+2. **`approve(requestId)`** — approves a pending request (in a real flow,
+   confirmed from an already-paired device). Throws for an unknown
+   `requestId`.
+3. **`issueSession(requestId)`** — issues a session for an **approved**
+   request only. Calling it on a request that is still `"pending"` (or
+   doesn't exist) **throws a clear error instead of returning a session** —
+   a real backend must never hand out a session before the paired device
+   confirms.
+
+## Usage
+
+```ts
+import { createMockPairingFlow } from "./mock-device-pairing";
+
+const flow = createMockPairingFlow();
+
+const req = flow.request("Chrome extension on laptop"); // status: "pending"
+flow.issueSession(req.requestId); // throws: not approved yet
+
+flow.approve(req.requestId); // status: "approved"
+const session = flow.issueSession(req.requestId); // { sessionId, requestId, deviceLabel, issuedAt }
+```
+
+## Run it
+
+```sh
+npx tsx mock-device-pairing.ts
+```
+
+Expected output:
+
+```
+Step 1: request pairing for 'Chrome extension on laptop'
+  requestId=req_1 status=pending
+Step 2: issue a session before approval (should fail)
+  error: Pairing request "req_1" is not approved yet (status: "pending")
+Step 3: approve the request
+  requestId=req_1 status=approved
+Step 4: issue the session now that it's approved
+  sessionId=sess_1 deviceLabel=Chrome extension on laptop
+```
+
+## Tests
+
+```sh
+npx vitest run contrib/examples/mock-device-pairing
+```

--- a/contrib/examples/mock-device-pairing/mock-device-pairing.test.ts
+++ b/contrib/examples/mock-device-pairing/mock-device-pairing.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "vitest";
+import { createMockPairingFlow } from "./mock-device-pairing";
+
+describe("createMockPairingFlow", () => {
+  it("starts a request as pending", () => {
+    const flow = createMockPairingFlow();
+    const req = flow.request("Test device");
+    expect(req.status).toBe("pending");
+    expect(req.deviceLabel).toBe("Test device");
+  });
+
+  it("issuing a session before approval throws instead of returning a session", () => {
+    const flow = createMockPairingFlow();
+    const req = flow.request("Test device");
+    expect(() => flow.issueSession(req.requestId)).toThrow(/not approved yet/);
+  });
+
+  it("approve marks a pending request as approved", () => {
+    const flow = createMockPairingFlow();
+    const req = flow.request("Test device");
+    const approved = flow.approve(req.requestId);
+    expect(approved.status).toBe("approved");
+  });
+
+  it("issues a session for an approved request", () => {
+    const flow = createMockPairingFlow();
+    const req = flow.request("Test device");
+    flow.approve(req.requestId);
+    const session = flow.issueSession(req.requestId);
+    expect(session.requestId).toBe(req.requestId);
+    expect(session.deviceLabel).toBe("Test device");
+    expect(session.sessionId).toBeTruthy();
+  });
+
+  it("approve throws for an unknown request id", () => {
+    const flow = createMockPairingFlow();
+    expect(() => flow.approve("does-not-exist")).toThrow(/No pairing request/);
+  });
+
+  it("issueSession throws for an unknown request id", () => {
+    const flow = createMockPairingFlow();
+    expect(() => flow.issueSession("does-not-exist")).toThrow(/No pairing request/);
+  });
+
+  it("issues distinct session ids for separate approved requests", () => {
+    const flow = createMockPairingFlow();
+    const reqA = flow.request("Device A");
+    const reqB = flow.request("Device B");
+    flow.approve(reqA.requestId);
+    flow.approve(reqB.requestId);
+    const sessionA = flow.issueSession(reqA.requestId);
+    const sessionB = flow.issueSession(reqB.requestId);
+    expect(sessionA.sessionId).not.toBe(sessionB.sessionId);
+  });
+
+  it("keeps requests from separate flow instances independent", () => {
+    const flowA = createMockPairingFlow();
+    const flowB = createMockPairingFlow();
+    const req = flowA.request("Device A");
+    expect(() => flowB.approve(req.requestId)).toThrow(/No pairing request/);
+  });
+});

--- a/contrib/examples/mock-device-pairing/mock-device-pairing.ts
+++ b/contrib/examples/mock-device-pairing/mock-device-pairing.ts
@@ -1,0 +1,104 @@
+// Example: a mock version of the extension device pairing flow — request,
+// approve, then issue a session — for use in tests without a real
+// extension. In-memory state only; no network or WebAuthn involved.
+//
+// Issuing a session for a pairing request that hasn't been approved yet
+// returns a clear error rather than a session, the same way a real backend
+// would refuse to hand out a session before the paired device confirms.
+//
+// Run with: npx tsx mock-device-pairing.ts
+
+export type PairingStatus = "pending" | "approved";
+
+export interface PairingRequest {
+  requestId: string;
+  deviceLabel: string;
+  status: PairingStatus;
+  requestedAt: string;
+}
+
+export interface PairedSession {
+  requestId: string;
+  sessionId: string;
+  deviceLabel: string;
+  issuedAt: string;
+}
+
+/** In-memory pairing authority: tracks requests by id and only issues a
+ * session once the matching request has been approved. */
+export function createMockPairingFlow() {
+  const requests = new Map<string, PairingRequest>();
+  let nextRequestSeq = 1;
+  let nextSessionSeq = 1;
+
+  return {
+    /** Step 1: a device asks to be paired. Starts out "pending". */
+    request(deviceLabel: string): PairingRequest {
+      const pairingRequest: PairingRequest = {
+        requestId: `req_${nextRequestSeq++}`,
+        deviceLabel,
+        status: "pending",
+        requestedAt: new Date().toISOString(),
+      };
+      requests.set(pairingRequest.requestId, pairingRequest);
+      return pairingRequest;
+    },
+
+    /** Step 2: approve a pending request (e.g. confirmed from an already
+     * paired device). Throws for an unknown request id. */
+    approve(requestId: string): PairingRequest {
+      const pairingRequest = requests.get(requestId);
+      if (!pairingRequest) {
+        throw new Error(`No pairing request with id "${requestId}"`);
+      }
+      pairingRequest.status = "approved";
+      return pairingRequest;
+    },
+
+    /** Step 3: issue a session for an approved request. Throws — rather
+     * than returning a session — if the request is unknown or still
+     * pending approval. */
+    issueSession(requestId: string): PairedSession {
+      const pairingRequest = requests.get(requestId);
+      if (!pairingRequest) {
+        throw new Error(`No pairing request with id "${requestId}"`);
+      }
+      if (pairingRequest.status !== "approved") {
+        throw new Error(`Pairing request "${requestId}" is not approved yet (status: "${pairingRequest.status}")`);
+      }
+      return {
+        requestId,
+        sessionId: `sess_${nextSessionSeq++}`,
+        deviceLabel: pairingRequest.deviceLabel,
+        issuedAt: new Date().toISOString(),
+      };
+    },
+  };
+}
+
+function main() {
+  const pairingFlow = createMockPairingFlow();
+
+  console.log("Step 1: request pairing for 'Chrome extension on laptop'");
+  const req = pairingFlow.request("Chrome extension on laptop");
+  console.log(`  requestId=${req.requestId} status=${req.status}`);
+
+  console.log("Step 2: issue a session before approval (should fail)");
+  try {
+    pairingFlow.issueSession(req.requestId);
+  } catch (err) {
+    console.log(`  error: ${(err as Error).message}`);
+  }
+
+  console.log("Step 3: approve the request");
+  const approved = pairingFlow.approve(req.requestId);
+  console.log(`  requestId=${approved.requestId} status=${approved.status}`);
+
+  console.log("Step 4: issue the session now that it's approved");
+  const session = pairingFlow.issueSession(req.requestId);
+  console.log(`  sessionId=${session.sessionId} deviceLabel=${session.deviceLabel}`);
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main();
+}

--- a/contrib/examples/mock-docs-lookup/README.md
+++ b/contrib/examples/mock-docs-lookup/README.md
@@ -1,0 +1,35 @@
+# Mock docs page lookup
+
+`getDocPage(slug)` is a small in-memory stand-in for the docs site's page
+registry — same shape (`{ slug, title }`), no dependency on the real
+website content. Useful in tests of tooling that consumes a doc-page lookup
+(e.g. a link checker or a "related docs" widget) without needing the real
+site built.
+
+## Usage
+
+```ts
+import { getDocPage } from "./mock-docs-lookup";
+
+getDocPage("passkeys"); // { slug: "passkeys", title: "Passkeys & Smart Accounts" }
+getDocPage("does-not-exist"); // undefined — never throws
+```
+
+## Run it
+
+```sh
+npx tsx mock-docs-lookup.ts
+```
+
+Expected output:
+
+```
+Known page: { slug: 'passkeys', title: 'Passkeys & Smart Accounts' }
+Unknown page: undefined
+```
+
+## Tests
+
+```sh
+npx vitest run contrib/examples/mock-docs-lookup
+```

--- a/contrib/examples/mock-docs-lookup/mock-docs-lookup.test.ts
+++ b/contrib/examples/mock-docs-lookup/mock-docs-lookup.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "vitest";
+import { getDocPage } from "./mock-docs-lookup";
+
+describe("getDocPage", () => {
+  it("returns the page for a known slug", () => {
+    expect(getDocPage("passkeys")).toEqual({ slug: "passkeys", title: "Passkeys & Smart Accounts" });
+  });
+
+  it("returns undefined for an unknown slug rather than throwing", () => {
+    expect(getDocPage("does-not-exist")).toBeUndefined();
+  });
+
+  it("has at least three sample pages", () => {
+    expect(getDocPage("getting-started")).toBeDefined();
+    expect(getDocPage("passkeys")).toBeDefined();
+    expect(getDocPage("x402-payments")).toBeDefined();
+  });
+});

--- a/contrib/examples/mock-docs-lookup/mock-docs-lookup.ts
+++ b/contrib/examples/mock-docs-lookup/mock-docs-lookup.ts
@@ -1,0 +1,35 @@
+// Example: a small mock docs registry lookup, similar in shape to the docs
+// site's getDocPage, for use in tests of tooling that consumes such a
+// lookup without depending on the real website content.
+//
+// Run with: npx tsx mock-docs-lookup.ts
+
+export interface DocPage {
+  slug: string;
+  title: string;
+}
+
+const PAGES: DocPage[] = [
+  { slug: "getting-started", title: "Getting Started" },
+  { slug: "passkeys", title: "Passkeys & Smart Accounts" },
+  { slug: "x402-payments", title: "x402 Agentic Payments" },
+  { slug: "policies", title: "Programmable Account Policies" },
+];
+
+/**
+ * Returns the DocPage for `slug`, or `undefined` for an unknown slug —
+ * never throws, so a caller can treat a miss as "no such page" rather than
+ * handling an exception.
+ */
+export function getDocPage(slug: string): DocPage | undefined {
+  return PAGES.find((page) => page.slug === slug);
+}
+
+function main() {
+  console.log("Known page:", getDocPage("passkeys"));
+  console.log("Unknown page:", getDocPage("does-not-exist"));
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main();
+}

--- a/contrib/examples/mock-fee-service/README.md
+++ b/contrib/examples/mock-fee-service/README.md
@@ -1,0 +1,28 @@
+# Mock fee estimation service
+
+A self-contained mock fee estimation function returning fixed sample fee
+values (in stroops) for `low`, `medium`, and `high` priority levels. Throws
+`UnknownFeePriorityError` for anything else.
+
+## Run it
+
+```sh
+npx tsx mock-fee-service.ts
+```
+
+Expected output:
+
+```
+low: 100 stroops
+medium: 10000 stroops
+high: 1000000 stroops
+invalid priority rejected: Unknown fee priority "urgent" — expected one of: low, medium, high
+```
+
+## Tests
+
+Covers all three valid priority levels plus an invalid one:
+
+```sh
+npx vitest run contrib/examples/mock-fee-service
+```

--- a/contrib/examples/mock-fee-service/mock-fee-service.test.ts
+++ b/contrib/examples/mock-fee-service/mock-fee-service.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from "vitest";
+import { estimateFee, UnknownFeePriorityError, type FeePriority } from "./mock-fee-service";
+
+describe("estimateFee", () => {
+  it.each([
+    ["low", 100n],
+    ["medium", 10_000n],
+    ["high", 1_000_000n],
+  ] as const)("returns a fixed fee for %s priority", (priority, expected) => {
+    expect(estimateFee(priority)).toBe(expected);
+  });
+
+  it("throws UnknownFeePriorityError for an unrecognized priority", () => {
+    expect(() => estimateFee("urgent" as FeePriority)).toThrow(UnknownFeePriorityError);
+    expect(() => estimateFee("urgent" as FeePriority)).toThrow(/Unknown fee priority "urgent"/);
+  });
+});

--- a/contrib/examples/mock-fee-service/mock-fee-service.ts
+++ b/contrib/examples/mock-fee-service/mock-fee-service.ts
@@ -1,0 +1,50 @@
+// Example: a mock fee estimation service returning fixed sample fee values
+// (in stroops) for low, medium, and high priority levels.
+//
+// Run with: npx tsx mock-fee-service.ts
+
+export type FeePriority = "low" | "medium" | "high";
+
+const FEES_BY_PRIORITY: Record<FeePriority, bigint> = {
+  low: 100n,
+  medium: 10_000n,
+  high: 1_000_000n,
+};
+
+export class UnknownFeePriorityError extends Error {
+  constructor(priority: string) {
+    super(
+      `Unknown fee priority "${priority}" — expected one of: ${Object.keys(FEES_BY_PRIORITY).join(", ")}`,
+    );
+    this.name = "UnknownFeePriorityError";
+  }
+}
+
+/** Returns a fixed sample fee (in stroops) for the given priority level. */
+export function estimateFee(priority: FeePriority): bigint {
+  const fee = FEES_BY_PRIORITY[priority];
+  if (fee === undefined) {
+    throw new UnknownFeePriorityError(priority);
+  }
+  return fee;
+}
+
+function main() {
+  for (const priority of ["low", "medium", "high"] as const) {
+    console.log(`${priority}: ${estimateFee(priority)} stroops`);
+  }
+
+  try {
+    // Deliberately an invalid priority (cast past the type system, since a
+    // real caller's input isn't statically known to be a FeePriority) to
+    // demonstrate the error path.
+    estimateFee("urgent" as FeePriority);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    console.log(`invalid priority rejected: ${message}`);
+  }
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main();
+}

--- a/contrib/examples/mock-full-backend/README.md
+++ b/contrib/examples/mock-full-backend/README.md
@@ -1,0 +1,51 @@
+# Mock end-to-end wallet backend
+
+A fully in-memory `WalletBackend` — `submitWalletCreation`, `lookupContractId`,
+and `submitTransaction` — backed by an append-only ledger of submitted
+transactions queryable by hash. Wired into a real `createVellarWallet` handle
+(with equally minimal mock `kit`/`sac`) to demonstrate a complete
+create-then-pay sequence with no WebAuthn prompt, RPC call, or relayer.
+
+## Usage
+
+```ts
+import { createMockVellarWallet } from "./mock-full-backend";
+
+const { wallet, backend } = createMockVellarWallet("testnet");
+const session = await wallet.create();
+const { hash } = await wallet.pay({ to: "G...", amount: 100_0000000n, token });
+
+backend.getTransaction(hash); // { hash, signedXdr, network, submittedAt }
+backend.listTransactions();   // every submission so far, oldest first
+```
+
+`createMockWalletBackend()` on its own gives you just the backend, if you
+want to wire it into your own kit/sac instead of the ones this example
+provides.
+
+## Run it
+
+```sh
+npx tsx mock-full-backend.ts
+```
+
+Expected output (hashes vary only in their counter suffix):
+
+```
+Step 1: create the wallet
+  session.accountId = CMOCKSMARTACCOUNTXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+Step 2: send a payment
+  submitted, hash = mocktxhash100000
+Step 3: send a second payment
+  submitted, hash = mocktxhash200000
+Step 4: query the ledger by hash
+  getTransaction(first.hash) -> {"hash":"mocktxhash100000","signedXdr":"signed:unsigned-transfer-tx:CUSDCMOCK","network":"testnet","submittedAt":"..."}
+Step 5: list every submitted transaction
+  listTransactions() has 2 entries
+```
+
+## Tests
+
+```sh
+npx vitest run contrib/examples/mock-full-backend
+```

--- a/contrib/examples/mock-full-backend/mock-full-backend.test.ts
+++ b/contrib/examples/mock-full-backend/mock-full-backend.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "vitest";
+import { createMockVellarWallet, createMockWalletBackend } from "./mock-full-backend";
+
+const token = { symbol: "USDC", contractId: "CUSDCMOCK", decimals: 7 };
+
+describe("createMockWalletBackend", () => {
+  it("returns undefined for a hash that was never submitted", () => {
+    const backend = createMockWalletBackend();
+    expect(backend.getTransaction("nope")).toBeUndefined();
+  });
+
+  it("records a submitted transaction, queryable by its returned hash", async () => {
+    const backend = createMockWalletBackend();
+    const { hash } = await backend.submitTransaction({ signedXdr: "xdr-1", network: "testnet" });
+
+    const entry = backend.getTransaction(hash);
+    expect(entry).toBeDefined();
+    expect(entry?.signedXdr).toBe("xdr-1");
+    expect(entry?.network).toBe("testnet");
+  });
+
+  it("gives every submission a distinct hash", async () => {
+    const backend = createMockWalletBackend();
+    const a = await backend.submitTransaction({ signedXdr: "xdr-a", network: "testnet" });
+    const b = await backend.submitTransaction({ signedXdr: "xdr-b", network: "testnet" });
+    expect(a.hash).not.toBe(b.hash);
+  });
+
+  it("lists transactions oldest first", async () => {
+    const backend = createMockWalletBackend();
+    await backend.submitTransaction({ signedXdr: "xdr-1", network: "testnet" });
+    await backend.submitTransaction({ signedXdr: "xdr-2", network: "testnet" });
+
+    const list = backend.listTransactions();
+    expect(list).toHaveLength(2);
+    expect(list[0]?.signedXdr).toBe("xdr-1");
+    expect(list[1]?.signedXdr).toBe("xdr-2");
+  });
+});
+
+describe("createMockVellarWallet — full create then pay sequence", () => {
+  it("creates a wallet and completes a payment, recorded in the backend's ledger", async () => {
+    const { wallet, backend } = createMockVellarWallet("testnet");
+
+    const session = await wallet.create({ username: "demo-user" });
+    expect(session.accountId).toBeTruthy();
+    expect(session.connected).toBe(true);
+
+    const result = await wallet.pay({ to: "GRECIPIENTXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX", amount: 1_0000000n, token });
+
+    expect(backend.getTransaction(result.hash)).toBeDefined();
+    expect(backend.listTransactions()).toHaveLength(1);
+  });
+
+  it("accumulates multiple payments in the ledger across the same session", async () => {
+    const { wallet, backend } = createMockVellarWallet("testnet");
+    await wallet.create();
+
+    await wallet.pay({ to: "GRECIPIENT1XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX", amount: 1_0000000n, token });
+    await wallet.pay({ to: "GRECIPIENT2XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX", amount: 2_0000000n, token });
+
+    expect(backend.listTransactions()).toHaveLength(2);
+  });
+});

--- a/contrib/examples/mock-full-backend/mock-full-backend.ts
+++ b/contrib/examples/mock-full-backend/mock-full-backend.ts
@@ -1,0 +1,137 @@
+// Example: a mock end-to-end WalletBackend — create, connect, and
+// submitTransaction — backed by an in-memory ledger of submitted
+// transactions queryable by hash, wired into a real createVellarWallet for
+// a full create-then-pay sequence with no live network call.
+//
+// Run with: npx tsx mock-full-backend.ts
+
+import { createVellarWallet, type VellarWallet } from "../../../src/client";
+import type { PasskeyKitLike, WalletBackend } from "../../../src/passkeykit-connector";
+import type { SacClientLike, TokenContractClientLike } from "../../../src/payments-client";
+import type { Network } from "../../../src/types";
+import type { TokenInfo } from "../../../src/balances";
+
+export interface LedgerEntry {
+  hash: string;
+  signedXdr: string;
+  network: Network;
+  submittedAt: string;
+}
+
+export interface MockWalletBackend extends WalletBackend {
+  submitTransaction(input: { signedXdr: string; network: Network }): Promise<{ hash: string }>;
+  /** Looks up a previously submitted transaction by the hash returned from
+   * submitTransaction. Undefined if no such hash was ever submitted. */
+  getTransaction(hash: string): LedgerEntry | undefined;
+  /** Every transaction submitted so far, oldest first. */
+  listTransactions(): LedgerEntry[];
+}
+
+/**
+ * Builds a fully in-memory WalletBackend: wallet creation always succeeds
+ * with a fresh session id, and every submitted transaction is recorded in
+ * an append-only ledger, queryable by its hash. No network I/O.
+ */
+export function createMockWalletBackend(): MockWalletBackend {
+  const ledger: LedgerEntry[] = [];
+  let nextHash = 1;
+
+  return {
+    async submitWalletCreation(input) {
+      return { sessionId: `session-${input.keyId}` };
+    },
+    async lookupContractId() {
+      // This example only exercises the create flow, not reconnect; a
+      // reconnect-focused example would populate a keyId->contractId map here.
+      return undefined;
+    },
+    async submitTransaction(input) {
+      const hash = `mocktxhash${nextHash++}`.padEnd(16, "0");
+      ledger.push({ hash, signedXdr: input.signedXdr, network: input.network, submittedAt: new Date().toISOString() });
+      return { hash };
+    },
+    getTransaction(hash) {
+      return ledger.find((entry) => entry.hash === hash);
+    },
+    listTransactions() {
+      return [...ledger];
+    },
+  };
+}
+
+/** A minimal mock PasskeyKitLike + SacClientLike, just enough to complete a
+ * create-then-pay sequence against the mock backend above. */
+function createMockKitAndSac(): { kit: PasskeyKitLike; sac: SacClientLike } {
+  const kit: PasskeyKitLike = {
+    async createWallet(_app, _user) {
+      return {
+        keyIdBase64: "mock-key-id",
+        contractId: "CMOCKSMARTACCOUNTXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+        signedTx: "mock-create-tx",
+      };
+    },
+    async connectWallet() {
+      return { keyIdBase64: "mock-key-id", contractId: "CMOCKSMARTACCOUNTXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX" };
+    },
+    async sign(tx: unknown) {
+      return typeof tx === "string" ? `signed:${tx}` : "signed:mock-payment-tx";
+    },
+  };
+
+  const sac: SacClientLike = {
+    getSACClient(tokenContractId: string): TokenContractClientLike {
+      return {
+        async transfer() {
+          return `unsigned-transfer-tx:${tokenContractId}`;
+        },
+      };
+    },
+  };
+
+  return { kit, sac };
+}
+
+export function createMockVellarWallet(network: Network): { wallet: VellarWallet; backend: MockWalletBackend } {
+  const backend = createMockWalletBackend();
+  const { kit, sac } = createMockKitAndSac();
+
+  const wallet = createVellarWallet({
+    network,
+    appName: "mock-full-backend example",
+    kit,
+    backend,
+    sac,
+    isValidAddress: (address: string) => address.length > 0,
+  });
+
+  return { wallet, backend };
+}
+
+async function main() {
+  const log = (line: string) => console.log(line);
+  const { wallet, backend } = createMockVellarWallet("testnet");
+
+  log("Step 1: create the wallet");
+  const session = await wallet.create({ username: "demo-user" });
+  log(`  session.accountId = ${session.accountId}`);
+
+  const token: TokenInfo = { symbol: "USDC", contractId: "CUSDCMOCK", decimals: 7 };
+
+  log("Step 2: send a payment");
+  const first = await wallet.pay({ to: "GRECIPIENT1XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX", amount: 10_0000000n, token });
+  log(`  submitted, hash = ${first.hash}`);
+
+  log("Step 3: send a second payment");
+  const second = await wallet.pay({ to: "GRECIPIENT2XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX", amount: 5_0000000n, token });
+  log(`  submitted, hash = ${second.hash}`);
+
+  log("Step 4: query the ledger by hash");
+  log(`  getTransaction(first.hash) -> ${JSON.stringify(backend.getTransaction(first.hash))}`);
+
+  log("Step 5: list every submitted transaction");
+  log(`  listTransactions() has ${backend.listTransactions().length} entries`);
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main();
+}

--- a/contrib/examples/mock-passkey-ceremony/README.md
+++ b/contrib/examples/mock-passkey-ceremony/README.md
@@ -1,0 +1,56 @@
+# Mock passkey ceremony for CI
+
+A deterministic mock passkey registration + authentication ceremony —
+useful for wiring into a CI test suite that needs a stable "user has a
+passkey" scenario without a real browser or WebAuthn/authenticator support.
+
+## Flow
+
+1. `generateMockCredential(seed)` derives a `{ credentialId, publicKey }`
+   pair from `seed` using a small seeded PRNG (mulberry32). **The same seed
+   always produces the same credential** — no hidden randomness, no global
+   state, reproducible across processes and CI runs.
+2. `createMockAuthenticator()` wraps that generator with an in-memory
+   "authenticator": `register(seed)` derives and remembers a credential;
+   `authenticate(credentialId)` looks it up, throwing for an id that was
+   never registered — the same refusal a real authenticator gives for an
+   unknown credential.
+
+## Usage
+
+```ts
+import { createMockAuthenticator } from "./mock-passkey-ceremony";
+
+const authenticator = createMockAuthenticator();
+const { credential } = authenticator.register("alice-device");
+const { credential: authed } = authenticator.authenticate(credential.credentialId);
+// authed.credentialId === credential.credentialId
+```
+
+## Run it
+
+```sh
+npx tsx mock-passkey-ceremony.ts
+```
+
+Expected output (the two determinism-check lines are always identical to
+each other, though the exact hex values are fixed by the PRNG):
+
+```
+Determinism check: generateMockCredential('alice-device') called twice...
+  call 1: a638baa8f7332b207ac6e86a8bcb454c
+  call 2: a638baa8f7332b207ac6e86a8bcb454c
+  same credentialId both times: true
+
+Full register-then-authenticate sequence:
+  Step 1: register with seed 'alice-device'
+    registered credentialId = a638baa8f7332b207ac6e86a8bcb454c
+  Step 2: authenticate with that credentialId
+    authenticated at 2026-...-...T...Z, publicKey = ...
+```
+
+## Tests
+
+```sh
+npx vitest run contrib/examples/mock-passkey-ceremony
+```

--- a/contrib/examples/mock-passkey-ceremony/mock-passkey-ceremony.test.ts
+++ b/contrib/examples/mock-passkey-ceremony/mock-passkey-ceremony.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+import { createMockAuthenticator, generateMockCredential } from "./mock-passkey-ceremony";
+
+describe("generateMockCredential", () => {
+  it("produces the same credential for the same seed across two calls", () => {
+    const first = generateMockCredential("alice-device");
+    const second = generateMockCredential("alice-device");
+    expect(first).toEqual(second);
+  });
+
+  it("produces different credentials for different seeds", () => {
+    const alice = generateMockCredential("alice-device");
+    const bob = generateMockCredential("bob-device");
+    expect(alice.credentialId).not.toBe(bob.credentialId);
+  });
+
+  it("returns hex strings of the expected length", () => {
+    const credential = generateMockCredential("seed");
+    expect(credential.credentialId).toMatch(/^[0-9a-f]{32}$/); // 16 bytes
+    expect(credential.publicKey).toMatch(/^[0-9a-f]{64}$/); // 32 bytes
+  });
+});
+
+describe("createMockAuthenticator", () => {
+  it("authenticates a credential it registered", () => {
+    const authenticator = createMockAuthenticator();
+    const { credential } = authenticator.register("alice-device");
+
+    const result = authenticator.authenticate(credential.credentialId);
+    expect(result.credential).toEqual(credential);
+  });
+
+  it("throws for a credential id it never registered", () => {
+    const authenticator = createMockAuthenticator();
+    expect(() => authenticator.authenticate("unknown-id")).toThrow(/No credential registered/);
+  });
+
+  it("keeps registrations independent across separate authenticator instances", () => {
+    const a = createMockAuthenticator();
+    const b = createMockAuthenticator();
+    const { credential } = a.register("alice-device");
+
+    expect(() => b.authenticate(credential.credentialId)).toThrow(/No credential registered/);
+  });
+
+  it("supports registering and authenticating multiple credentials", () => {
+    const authenticator = createMockAuthenticator();
+    const alice = authenticator.register("alice-device").credential;
+    const bob = authenticator.register("bob-device").credential;
+
+    expect(authenticator.authenticate(alice.credentialId).credential).toEqual(alice);
+    expect(authenticator.authenticate(bob.credentialId).credential).toEqual(bob);
+  });
+});

--- a/contrib/examples/mock-passkey-ceremony/mock-passkey-ceremony.ts
+++ b/contrib/examples/mock-passkey-ceremony/mock-passkey-ceremony.ts
@@ -1,0 +1,114 @@
+// Example: a deterministic mock passkey registration + authentication
+// ceremony, for wiring into a CI test suite with no real browser or
+// WebAuthn support. The same seed always produces the same mock
+// credential, so tests stay reproducible.
+//
+// Run with: npx tsx mock-passkey-ceremony.ts
+
+export interface MockCredential {
+  credentialId: string;
+  publicKey: string;
+}
+
+// A small seeded PRNG (mulberry32) so credential generation is
+// deterministic from a string seed without pulling in a crypto dependency
+// — this is a test double, not a real key generator.
+function hashSeed(seed: string): number {
+  let h = 0;
+  for (let i = 0; i < seed.length; i++) {
+    h = (Math.imul(31, h) + seed.charCodeAt(i)) | 0;
+  }
+  return h >>> 0;
+}
+
+function mulberry32(seed: number): () => number {
+  let state = seed;
+  return () => {
+    state = (state + 0x6d2b79f5) | 0;
+    let t = Math.imul(state ^ (state >>> 15), 1 | state);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+function randomHex(rand: () => number, byteLength: number): string {
+  let out = "";
+  for (let i = 0; i < byteLength; i++) {
+    out += Math.floor(rand() * 256).toString(16).padStart(2, "0");
+  }
+  return out;
+}
+
+/**
+ * Deterministically derives a mock WebAuthn-shaped credential from `seed`:
+ * the same seed always produces the same credentialId and publicKey across
+ * calls (and across process restarts — there's no hidden global state).
+ */
+export function generateMockCredential(seed: string): MockCredential {
+  const rand = mulberry32(hashSeed(seed));
+  return {
+    credentialId: randomHex(rand, 16),
+    publicKey: randomHex(rand, 32),
+  };
+}
+
+export interface RegisterResult {
+  credential: MockCredential;
+  registeredAt: string;
+}
+
+export interface AuthenticateResult {
+  credential: MockCredential;
+  authenticatedAt: string;
+}
+
+/** In-memory "authenticator": remembers registered credentials by id, the
+ * same way a real platform authenticator would, so authenticate() can only
+ * succeed for a credential this instance actually registered. */
+export function createMockAuthenticator() {
+  const registered = new Map<string, MockCredential>();
+
+  return {
+    /** Registration ceremony: derives a credential from `seed` and stores it. */
+    register(seed: string): RegisterResult {
+      const credential = generateMockCredential(seed);
+      registered.set(credential.credentialId, credential);
+      return { credential, registeredAt: new Date().toISOString() };
+    },
+
+    /** Authentication ceremony: looks up a previously registered credential
+     * by id. Throws for an id this authenticator never registered — a real
+     * authenticator refuses an unknown credential too. */
+    authenticate(credentialId: string): AuthenticateResult {
+      const credential = registered.get(credentialId);
+      if (!credential) {
+        throw new Error(`No credential registered with id "${credentialId}"`);
+      }
+      return { credential, authenticatedAt: new Date().toISOString() };
+    },
+  };
+}
+
+function main() {
+  console.log("Determinism check: generateMockCredential('alice-device') called twice...");
+  const first = generateMockCredential("alice-device");
+  const second = generateMockCredential("alice-device");
+  console.log(`  call 1: ${first.credentialId}`);
+  console.log(`  call 2: ${second.credentialId}`);
+  console.log(`  same credentialId both times: ${first.credentialId === second.credentialId}`);
+
+  console.log("\nFull register-then-authenticate sequence:");
+  const authenticator = createMockAuthenticator();
+
+  console.log("  Step 1: register with seed 'alice-device'");
+  const { credential } = authenticator.register("alice-device");
+  console.log(`    registered credentialId = ${credential.credentialId}`);
+
+  console.log("  Step 2: authenticate with that credentialId");
+  const authResult = authenticator.authenticate(credential.credentialId);
+  console.log(`    authenticated at ${authResult.authenticatedAt}, publicKey = ${authResult.credential.publicKey}`);
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main();
+}

--- a/contrib/examples/mock-passkey-kit/README.md
+++ b/contrib/examples/mock-passkey-kit/README.md
@@ -1,0 +1,29 @@
+# Mock passkey kit for headless testing
+
+A mock `PasskeyKitLike` implementing `createWallet`, `connectWallet`, and
+`sign`, each returning a fixed, documented canned response — never a real
+WebAuthn ceremony or browser feature. Useful for headless tests that need to
+wire a kit into `createVellarWallet()`.
+
+## Canned responses
+
+| Method | Returns |
+| --- | --- |
+| `createWallet` | `{ keyIdBase64: CANNED_KEY_ID, contractId: CANNED_CONTRACT_ID, signedTx: "mock-signed-deployment-tx" }` |
+| `connectWallet` | `{ keyIdBase64: CANNED_KEY_ID, contractId: CANNED_CONTRACT_ID }` |
+| `sign` | the input transaction, unchanged (a no-op "signature") |
+
+## Run it
+
+```sh
+npx tsx mock-passkey-kit.ts
+```
+
+Wires the mock kit (plus a minimal mock backend) into the real
+`createVellarWallet()` and calls `create()`, printing the resulting session.
+
+## Tests
+
+```sh
+npx vitest run contrib/examples/mock-passkey-kit
+```

--- a/contrib/examples/mock-passkey-kit/mock-passkey-kit.test.ts
+++ b/contrib/examples/mock-passkey-kit/mock-passkey-kit.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+import { CANNED_CONTRACT_ID, CANNED_KEY_ID, createMockPasskeyKit } from "./mock-passkey-kit";
+
+describe("createMockPasskeyKit", () => {
+  it("createWallet returns the canned keyId, contractId, and a signed tx", async () => {
+    const kit = createMockPasskeyKit();
+    await expect(kit.createWallet("app", "user")).resolves.toEqual({
+      keyIdBase64: CANNED_KEY_ID,
+      contractId: CANNED_CONTRACT_ID,
+      signedTx: "mock-signed-deployment-tx",
+    });
+  });
+
+  it("connectWallet returns the same canned keyId and contractId", async () => {
+    const kit = createMockPasskeyKit();
+    await expect(kit.connectWallet()).resolves.toEqual({
+      keyIdBase64: CANNED_KEY_ID,
+      contractId: CANNED_CONTRACT_ID,
+    });
+  });
+
+  it("sign returns the input transaction unchanged", async () => {
+    const kit = createMockPasskeyKit();
+    const tx = { some: "transaction" };
+    await expect(kit.sign(tx)).resolves.toBe(tx);
+  });
+});

--- a/contrib/examples/mock-passkey-kit/mock-passkey-kit.ts
+++ b/contrib/examples/mock-passkey-kit/mock-passkey-kit.ts
@@ -1,0 +1,66 @@
+// Example: a mock PasskeyKitLike returning fixed, documented canned
+// responses for createWallet, connectWallet, and sign — for headless tests
+// that need a createVellarWallet() kit without a real WebAuthn ceremony or
+// browser feature.
+//
+// Run with: npx tsx mock-passkey-kit.ts
+
+import { createVellarWallet, type PasskeyKitLike } from "../../../src/index";
+
+export const CANNED_KEY_ID = "mock-keyid-canned";
+export const CANNED_CONTRACT_ID = "CMOCKPASSKEYKITCONTRACTADDRESSXXXXXXXXXXXXXXXXXXXXXXXXXX";
+
+/**
+ * A mock PasskeyKitLike for headless tests: every call resolves immediately
+ * with a fixed, documented response — never a real WebAuthn prompt or
+ * browser API.
+ *
+ *   - createWallet  → { keyIdBase64: CANNED_KEY_ID, contractId: CANNED_CONTRACT_ID, signedTx: "mock-signed-deployment-tx" }
+ *   - connectWallet → { keyIdBase64: CANNED_KEY_ID, contractId: CANNED_CONTRACT_ID }
+ *   - sign          → returns the input transaction unchanged (a no-op "signature")
+ */
+export function createMockPasskeyKit(): PasskeyKitLike {
+  return {
+    async createWallet() {
+      return {
+        keyIdBase64: CANNED_KEY_ID,
+        contractId: CANNED_CONTRACT_ID,
+        signedTx: "mock-signed-deployment-tx",
+      };
+    },
+    async connectWallet() {
+      return { keyIdBase64: CANNED_KEY_ID, contractId: CANNED_CONTRACT_ID };
+    },
+    async sign(tx: unknown) {
+      return tx;
+    },
+  };
+}
+
+async function main() {
+  const wallet = createVellarWallet({
+    network: "testnet",
+    appName: "vellar-example",
+    kit: createMockPasskeyKit(),
+    backend: {
+      async submitWalletCreation() {
+        return { sessionId: "mock-session-id" };
+      },
+      async lookupContractId() {
+        return undefined;
+      },
+      async submitTransaction() {
+        return { hash: "mock-tx-hash" };
+      },
+    },
+    sac: { getSACClient: () => ({ transfer: async () => "mock-tx" }) },
+    isValidAddress: () => true,
+  });
+
+  const session = await wallet.create({ username: "Headless Test User" });
+  console.log("Wired mock passkey kit into createVellarWallet(); session:", session);
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main();
+}

--- a/contrib/examples/mock-policy-attach/README.md
+++ b/contrib/examples/mock-policy-attach/README.md
@@ -1,0 +1,23 @@
+# mock-policy-attach
+
+Mock `PolicyAttachRuntime` suitable for unit tests.
+
+- `attachPolicy(...)` always returns a fixed sample transaction hash.
+- `resume(...)` is a no-op and resolves immediately.
+
+This deliberately does not perform any passkey prompt or network I/O.
+
+## Usage
+
+```ts
+import { createMockPolicyAttachRuntime } from "./index";
+
+const attach = createMockPolicyAttachRuntime();
+
+const result = await attach.attachPolicy("CPOLICY");
+console.log(result.hash); // fixed sample hash
+
+await attach.resume("key-id"); // no-op
+```
+
+Ref: `PolicyAttachRuntime`.

--- a/contrib/examples/mock-policy-attach/index.ts
+++ b/contrib/examples/mock-policy-attach/index.ts
@@ -1,0 +1,23 @@
+import type { PolicyAttachRuntime } from "../../../src/policy-facade";
+
+/**
+ * Mock PolicyAttachRuntime for unit tests.
+ *
+ * - attachPolicy returns a fixed sample transaction hash.
+ * - resume is a no-op documented in the README.
+ */
+const FIXED_HASH = "aaa111bbb222ccc333ddd444eee555fff666777888";
+
+export function createMockPolicyAttachRuntime(opts?: { hash?: string }): PolicyAttachRuntime {
+  const hash = opts?.hash ?? FIXED_HASH;
+
+  return {
+    resume() {
+      // no-op: mock does not prompt or manipulate passkey state.
+      return Promise.resolve();
+    },
+    async attachPolicy() {
+      return { hash };
+    },
+  };
+}

--- a/contrib/examples/mock-policy-attach/test.ts
+++ b/contrib/examples/mock-policy-attach/test.ts
@@ -1,0 +1,28 @@
+import { createMockPolicyAttachRuntime } from "./index";
+
+console.log("mock-policy-attach tests:");
+
+{
+  const attach = createMockPolicyAttachRuntime();
+
+  const hash = await attach.attachPolicy("CINSTANCE");
+  console.assert(hash.hash.length > 0, "expected non-empty hash");
+  console.log("ok: attachPolicy returns a fixed hash:", hash.hash);
+}
+
+{
+  const attach = createMockPolicyAttachRuntime({ hash: "custom-tx-123" });
+
+  const hash = await attach.attachPolicy("CINSTANCE");
+  console.assert(hash.hash === "custom-tx-123", "expected custom hash");
+  console.log("ok: custom hash returned");
+}
+
+{
+  const attach = createMockPolicyAttachRuntime();
+  const resume = await attach.resume!("some-key-id");
+  console.assert(resume === undefined, "resume should resolve void");
+  console.log("ok: resume is a no-op");
+}
+
+console.log("mock-policy-attach tests passed");

--- a/contrib/examples/mock-policy-gateway/README.md
+++ b/contrib/examples/mock-policy-gateway/README.md
@@ -1,0 +1,31 @@
+# Mock policy API gateway
+
+A mock `fetch` implementation covering the policy API gateway's
+list-templates, generate, and simulate routes — wired into the SDK's real
+`createPolicyClient()` (`src/policy-client.ts`) via its injectable `fetch`
+option, for offline tests that don't need a live gateway.
+
+## Covered routes
+
+| Route | Response shape |
+| --- | --- |
+| `GET /policies/templates` | `PolicyTemplateInfo[]` |
+| `POST /policies/generate` | `{ policy: GeneratedPolicy }` |
+| `POST /policies/:id/simulate` | `SimulateResult` |
+
+Any other route returns a 404 with an explanatory error body.
+
+## Run it
+
+```sh
+npx tsx mock-policy-gateway.ts
+```
+
+Exercises all three covered routes through the real `PolicyClient` and
+prints each response.
+
+## Tests
+
+```sh
+npx vitest run contrib/examples/mock-policy-gateway
+```

--- a/contrib/examples/mock-policy-gateway/mock-policy-gateway.test.ts
+++ b/contrib/examples/mock-policy-gateway/mock-policy-gateway.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+import { createPolicyClient } from "../../../src/policy-client";
+import { mockPolicyGatewayFetch } from "./mock-policy-gateway";
+
+describe("mockPolicyGatewayFetch wired into createPolicyClient", () => {
+  const client = createPolicyClient({
+    apiUrl: "https://mock-gateway.example.com",
+    network: "testnet",
+    fetch: mockPolicyGatewayFetch,
+  });
+
+  it("listTemplates returns at least one template", async () => {
+    const templates = await client.listTemplates();
+    expect(templates.length).toBeGreaterThan(0);
+    expect(templates[0]).toHaveProperty("type");
+    expect(templates[0]).toHaveProperty("enforcement");
+  });
+
+  it("generate returns a GeneratedPolicy", async () => {
+    const policy = await client.generate({ version: "1", type: "spending-limit", owners: ["GOWNER"] });
+    expect(policy.id).toBeTruthy();
+    expect(policy.status).toBe("generated");
+  });
+
+  it("simulate returns a SimulateResult", async () => {
+    const result = await client.simulate("policy_mock123", "CWALLET");
+    expect(result.ok).toBe(true);
+  });
+
+  it("404s an unmocked route", async () => {
+    const res = await mockPolicyGatewayFetch("https://mock-gateway.example.com/policies/unknown-route");
+    expect(res.status).toBe(404);
+  });
+});

--- a/contrib/examples/mock-policy-gateway/mock-policy-gateway.ts
+++ b/contrib/examples/mock-policy-gateway/mock-policy-gateway.ts
@@ -1,0 +1,81 @@
+// Example: a mock fetch handler returning canned responses for the policy
+// API gateway's list-templates, generate, and simulate routes — for
+// offline tests that need to wire the real createPolicyClient() to
+// something other than a live gateway.
+//
+// Run with: npx tsx mock-policy-gateway.ts
+
+import { createPolicyClient } from "../../../src/policy-client";
+import type { GeneratedPolicy, PolicyTemplateInfo, SimulateResult } from "../../../src/policy-types";
+
+const MOCK_TEMPLATES: PolicyTemplateInfo[] = [
+  {
+    type: "spending-limit",
+    title: "Spending limit",
+    description: "A rolling-window daily spending cap enforced by a dedicated policy contract.",
+    enforcement: { kind: "policy-contract", wasmHash: "mock-wasm-hash" },
+  },
+  {
+    type: "none",
+    title: "No extra policy",
+    description: "Default single-owner behaviour.",
+    enforcement: { kind: "none" },
+  },
+];
+
+const MOCK_GENERATED_POLICY: GeneratedPolicy = {
+  id: "policy_mock123",
+  createdAt: "2026-01-01T00:00:00.000Z",
+  status: "generated",
+  definition: { version: "1", type: "spending-limit", owners: ["GOWNER"] },
+  policyHash: "mock-policy-hash",
+  manifest: {
+    template: "spending-limit",
+    enforcement: { kind: "policy-contract", wasmHash: "mock-wasm-hash" },
+    network: "testnet",
+  },
+};
+
+const MOCK_SIMULATE_RESULT: SimulateResult = { ok: true, minResourceFee: "100000" };
+
+/** A mock fetch implementation covering the policy gateway's
+ * templates/generate/simulate routes. Any other route 404s. */
+export const mockPolicyGatewayFetch: typeof fetch = (async (url: string | URL, init?: RequestInit) => {
+  const { pathname } = new URL(url);
+  const method = init?.method ?? "GET";
+
+  if (pathname === "/policies/templates" && method === "GET") {
+    return new Response(JSON.stringify(MOCK_TEMPLATES), { status: 200 });
+  }
+  if (pathname === "/policies/generate" && method === "POST") {
+    return new Response(JSON.stringify({ policy: MOCK_GENERATED_POLICY }), { status: 200 });
+  }
+  if (pathname.endsWith("/simulate") && method === "POST") {
+    return new Response(JSON.stringify(MOCK_SIMULATE_RESULT), { status: 200 });
+  }
+
+  return new Response(JSON.stringify({ error: `mock gateway: no route for ${method} ${pathname}` }), {
+    status: 404,
+  });
+}) as typeof fetch;
+
+async function main() {
+  const client = createPolicyClient({
+    apiUrl: "https://mock-gateway.example.com",
+    network: "testnet",
+    fetch: mockPolicyGatewayFetch,
+  });
+
+  console.log("listTemplates():", await client.listTemplates());
+  console.log();
+  console.log(
+    "generate():",
+    await client.generate({ version: "1", type: "spending-limit", owners: ["GOWNER"] }),
+  );
+  console.log();
+  console.log("simulate():", await client.simulate("policy_mock123", "CWALLET"));
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main();
+}

--- a/contrib/examples/mock-sac-client/README.md
+++ b/contrib/examples/mock-sac-client/README.md
@@ -1,0 +1,29 @@
+# Mock SAC client for balance reads
+
+A mock `BalanceReader` (`src/balances.ts`) — the interface the SDK's real
+RPC-backed SAC balance reads (`createRpcBalanceReader`, `vellar-sdk/rpc`)
+implement — returning a fixed, configurable balance for any token/account
+pair. Useful for offline tests that need a balance reader without a real RPC
+call.
+
+## Run it
+
+```sh
+npx tsx mock-sac-client.ts
+```
+
+Expected output (all three accounts get the same fixed balance):
+
+```
+GALICE: 500000000 (fixed, regardless of token or account)
+GBOB: 500000000 (fixed, regardless of token or account)
+CCONTRACTHOLDERXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX: 500000000 (fixed, regardless of token or account)
+```
+
+## Tests
+
+Also demonstrates wiring the mock into the real `createBalanceService`:
+
+```sh
+npx vitest run contrib/examples/mock-sac-client
+```

--- a/contrib/examples/mock-sac-client/mock-sac-client.test.ts
+++ b/contrib/examples/mock-sac-client/mock-sac-client.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+import { createBalanceService } from "../../../src/balances";
+import { createMockBalanceReader } from "./mock-sac-client";
+
+describe("createMockBalanceReader", () => {
+  it("returns the configured fixed balance for any account", async () => {
+    const reader = createMockBalanceReader(1_000n);
+    await expect(reader.getTokenBalance("CTOKEN", "GALICE")).resolves.toBe(1_000n);
+    await expect(reader.getTokenBalance("CTOKEN", "GBOB")).resolves.toBe(1_000n);
+  });
+
+  it("returns the same fixed balance regardless of the token contract queried", async () => {
+    const reader = createMockBalanceReader(42n);
+    await expect(reader.getTokenBalance("CTOKEN_A", "GALICE")).resolves.toBe(42n);
+    await expect(reader.getTokenBalance("CTOKEN_B", "GALICE")).resolves.toBe(42n);
+  });
+
+  it("wires cleanly into the real createBalanceService", async () => {
+    const reader = createMockBalanceReader(250n);
+    const xlm = { symbol: "XLM", contractId: "CNATIVE", decimals: 7 };
+    const service = createBalanceService(reader, [xlm]);
+
+    await expect(service.getBalances("GALICE")).resolves.toEqual([{ ...xlm, amount: 250n }]);
+  });
+});

--- a/contrib/examples/mock-sac-client/mock-sac-client.ts
+++ b/contrib/examples/mock-sac-client/mock-sac-client.ts
@@ -1,0 +1,35 @@
+// Example: a mock SacClientLike (BalanceReader) returning a fixed balance
+// for any token/account pair, configured at construction time — for use in
+// offline tests that need a balance reader without a real RPC call.
+//
+// Run with: npx tsx mock-sac-client.ts
+
+import type { BalanceReader } from "../../../src/balances";
+
+/**
+ * A mock BalanceReader: getTokenBalance always resolves with the same
+ * fixed balance, regardless of which token contract or holder is asked
+ * for — useful as the reader passed to createBalanceService (src/balances.ts)
+ * in offline tests.
+ */
+export function createMockBalanceReader(fixedBalance: bigint): BalanceReader {
+  return {
+    async getTokenBalance(_tokenContractId: string, _holder: string) {
+      return fixedBalance;
+    },
+  };
+}
+
+async function main() {
+  const reader = createMockBalanceReader(500_000_000n);
+
+  const accounts = ["GALICE", "GBOB", "CCONTRACTHOLDERXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"];
+  for (const account of accounts) {
+    const balance = await reader.getTokenBalance("CANYTOKENCONTRACT", account);
+    console.log(`${account}: ${balance} (fixed, regardless of token or account)`);
+  }
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main();
+}

--- a/contrib/examples/mock-wallet-backend/README.md
+++ b/contrib/examples/mock-wallet-backend/README.md
@@ -1,0 +1,29 @@
+# Mock wallet backend for offline testing
+
+A mock `WalletBackend` implementing `submitWalletCreation`, `lookupContractId`,
+and `submitTransaction`, each returning a fixed, documented canned response
+instead of a real network call — useful for offline tests that need to wire
+a backend into `createVellarWallet()`.
+
+## Canned responses
+
+| Method | Returns |
+| --- | --- |
+| `submitWalletCreation` | `{ sessionId: CANNED_SESSION_ID }` |
+| `lookupContractId` | `{ contractId: CANNED_CONTRACT_ID, sessionId: CANNED_SESSION_ID }` |
+| `submitTransaction` | `{ hash: CANNED_TX_HASH }` |
+
+## Run it
+
+```sh
+npx tsx mock-wallet-backend.ts
+```
+
+Wires the mock backend (plus a minimal mock passkey kit) into the real
+`createVellarWallet()` and calls `create()`, printing the resulting session.
+
+## Tests
+
+```sh
+npx vitest run contrib/examples/mock-wallet-backend
+```

--- a/contrib/examples/mock-wallet-backend/mock-wallet-backend.test.ts
+++ b/contrib/examples/mock-wallet-backend/mock-wallet-backend.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+import {
+  CANNED_CONTRACT_ID,
+  CANNED_SESSION_ID,
+  CANNED_TX_HASH,
+  createMockWalletBackend,
+} from "./mock-wallet-backend";
+
+describe("createMockWalletBackend", () => {
+  it("submitWalletCreation returns the canned session id", async () => {
+    const backend = createMockWalletBackend();
+    await expect(
+      backend.submitWalletCreation({
+        keyId: "any",
+        contractId: "any",
+        network: "testnet",
+        signedTx: "any",
+      }),
+    ).resolves.toEqual({ sessionId: CANNED_SESSION_ID });
+  });
+
+  it("lookupContractId returns the canned contract and session id", async () => {
+    const backend = createMockWalletBackend();
+    await expect(backend.lookupContractId({ keyId: "any", network: "testnet" })).resolves.toEqual({
+      contractId: CANNED_CONTRACT_ID,
+      sessionId: CANNED_SESSION_ID,
+    });
+  });
+
+  it("submitTransaction returns the canned tx hash", async () => {
+    const backend = createMockWalletBackend();
+    await expect(
+      backend.submitTransaction({ signedXdr: "any", network: "testnet" }),
+    ).resolves.toEqual({ hash: CANNED_TX_HASH });
+  });
+});

--- a/contrib/examples/mock-wallet-backend/mock-wallet-backend.ts
+++ b/contrib/examples/mock-wallet-backend/mock-wallet-backend.ts
@@ -1,0 +1,75 @@
+// Example: a mock WalletBackend returning fixed, documented canned responses
+// for create, connect, and submit — for offline tests that need a
+// createVellarWallet() backend without a real gateway.
+//
+// Run with: npx tsx mock-wallet-backend.ts
+
+import { createVellarWallet, type PasskeyKitLike, type WalletBackend } from "../../../src/index";
+
+export const CANNED_SESSION_ID = "mock-session-id-canned";
+export const CANNED_CONTRACT_ID = "CMOCKBACKENDCONTRACTADDRESSXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX";
+export const CANNED_TX_HASH = "mock-tx-hash-canned";
+
+/**
+ * A mock WalletBackend for offline tests: every call resolves immediately
+ * with a fixed, documented response instead of making a network request.
+ *
+ *   - submitWalletCreation → { sessionId: CANNED_SESSION_ID }
+ *   - lookupContractId     → { contractId: CANNED_CONTRACT_ID, sessionId: CANNED_SESSION_ID }
+ *   - submitTransaction    → { hash: CANNED_TX_HASH }
+ */
+export function createMockWalletBackend(): WalletBackend & {
+  submitTransaction(input: {
+    signedXdr: string;
+    network: "testnet" | "mainnet";
+  }): Promise<{ hash: string }>;
+} {
+  return {
+    async submitWalletCreation() {
+      return { sessionId: CANNED_SESSION_ID };
+    },
+    async lookupContractId() {
+      return { contractId: CANNED_CONTRACT_ID, sessionId: CANNED_SESSION_ID };
+    },
+    async submitTransaction() {
+      return { hash: CANNED_TX_HASH };
+    },
+  };
+}
+
+/** A minimal PasskeyKit stand-in, just enough to drive create()/connect(). */
+function createMockPasskeyKit(): PasskeyKitLike {
+  return {
+    async createWallet(_app: string, user: string) {
+      return {
+        keyIdBase64: `mock-keyid-${user.toLowerCase().replace(/\s+/g, "-")}`,
+        contractId: CANNED_CONTRACT_ID,
+        signedTx: "mock-signed-deployment-tx",
+      };
+    },
+    async connectWallet() {
+      return { keyIdBase64: "mock-keyid-reconnect", contractId: CANNED_CONTRACT_ID };
+    },
+    async sign(tx: unknown) {
+      return tx;
+    },
+  };
+}
+
+async function main() {
+  const wallet = createVellarWallet({
+    network: "testnet",
+    appName: "vellar-example",
+    kit: createMockPasskeyKit(),
+    backend: createMockWalletBackend(),
+    sac: { getSACClient: () => ({ transfer: async () => "mock-tx" }) },
+    isValidAddress: () => true,
+  });
+
+  const session = await wallet.create({ username: "Offline Test User" });
+  console.log("Wired mock backend into createVellarWallet(); session:", session);
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main();
+}

--- a/contrib/examples/mock-webauthn-assertion/README.md
+++ b/contrib/examples/mock-webauthn-assertion/README.md
@@ -1,0 +1,36 @@
+# Mock WebAuthnAssertionSigner
+
+A self-contained example implementing a mock `WebAuthnAssertionSigner` (see
+`src/x402-signer.ts`) that returns a fixed, canned assertion for any payload
+hash — for use in tests of the passkey x402 signer
+(`createPasskeyX402Signer`).
+
+> **The returned assertion is NOT cryptographically valid.** `MOCK_ASSERTION`
+> is deterministic filler (`authenticatorData`, `clientDataJSON`, `signature`,
+> and `keyId` are each a fixed, repeated byte value). It will build a
+> structurally correct signed auth entry, but the "signature" bytes are not a
+> real secp256r1 signature and will be rejected by any real on-chain
+> `__check_auth`. Use this only to exercise code paths that consume a
+> `WebAuthnAssertionSigner`, never against a real network.
+
+## What it does
+
+- `createMockWebAuthnAssertionSigner()` returns a `WebAuthnAssertionSigner`
+  whose `sign()` always resolves to `MOCK_ASSERTION`, regardless of the
+  payload hash it's given.
+- `signDummyEntryWithMock()` wires that mock signer into
+  `createPasskeyX402Signer` and uses it to sign a dummy V1
+  (`sorobanCredentialsAddress`) auth entry, returning the signed entry XDR —
+  demonstrating the full integration.
+
+## Run it
+
+```sh
+npx tsx contrib/examples/mock-webauthn-assertion/mock-webauthn-assertion.ts
+```
+
+## Test it
+
+```sh
+npm test -- contrib/examples/mock-webauthn-assertion
+```

--- a/contrib/examples/mock-webauthn-assertion/mock-webauthn-assertion.test.ts
+++ b/contrib/examples/mock-webauthn-assertion/mock-webauthn-assertion.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+import { xdr } from "@stellar/stellar-sdk";
+import {
+  createMockWebAuthnAssertionSigner,
+  MOCK_ASSERTION,
+  signDummyEntryWithMock,
+} from "./mock-webauthn-assertion";
+
+describe("createMockWebAuthnAssertionSigner", () => {
+  it("returns the fixed canned assertion for any payload hash", async () => {
+    const signer = createMockWebAuthnAssertionSigner();
+    const a = await signer.sign(new Uint8Array(32).fill(1));
+    const b = await signer.sign(new Uint8Array(32).fill(2));
+    expect(a).toEqual(MOCK_ASSERTION);
+    expect(b).toEqual(MOCK_ASSERTION);
+    expect(a.authenticatorData).toHaveLength(37);
+    expect(a.clientDataJSON).toHaveLength(50);
+    expect(a.signature).toHaveLength(64);
+    expect(a.keyId).toHaveLength(20);
+  });
+});
+
+describe("signDummyEntryWithMock", () => {
+  it("wires the mock into createPasskeyX402Signer and produces a signed V1 entry", async () => {
+    const signedXdr = await signDummyEntryWithMock();
+    const signed = xdr.SorobanAuthorizationEntry.fromXDR(signedXdr, "base64");
+    expect(signed.credentials().switch().name).toBe("sorobanCredentialsAddress");
+
+    const map = signed.credentials().address().signature().vec()![0]!.map()!;
+    const key = map[0]!.key();
+    expect(key.vec()![0]!.sym().toString()).toBe("Secp256r1");
+    expect(new Uint8Array(key.vec()![1]!.bytes())).toEqual(MOCK_ASSERTION.keyId);
+  });
+});

--- a/contrib/examples/mock-webauthn-assertion/mock-webauthn-assertion.ts
+++ b/contrib/examples/mock-webauthn-assertion/mock-webauthn-assertion.ts
@@ -1,0 +1,90 @@
+// Standalone example: a mock WebAuthnAssertionSigner that returns a fixed,
+// canned assertion for any payload hash, for use in tests of the passkey
+// x402 signer (createPasskeyX402Signer). See ./README.md — the returned
+// assertion is NOT cryptographically valid.
+
+import { Address, nativeToScVal, xdr } from "@stellar/stellar-sdk";
+import {
+  createPasskeyX402Signer,
+  type WebAuthnAssertion,
+  type WebAuthnAssertionSigner,
+} from "../../../src/x402-signer";
+
+/** A fixed, canned WebAuthn assertion. Every field is deterministic filler —
+ * this is NOT a real secp256r1 signature and will NOT pass on-chain
+ * verification. It exists purely to exercise code paths that consume a
+ * `WebAuthnAssertionSigner` without a real browser/passkey ceremony. */
+export const MOCK_ASSERTION: WebAuthnAssertion = {
+  authenticatorData: new Uint8Array(37).fill(0xa1),
+  clientDataJSON: new Uint8Array(50).fill(0xc1),
+  signature: new Uint8Array(64).fill(0xf1),
+  keyId: new Uint8Array(20).fill(0x99),
+};
+
+/** Builds a `WebAuthnAssertionSigner` that returns `MOCK_ASSERTION` for any
+ * payload hash it's asked to sign — no browser, no real passkey involved. */
+export function createMockWebAuthnAssertionSigner(): WebAuthnAssertionSigner {
+  return {
+    async sign(_payloadHash: Uint8Array): Promise<WebAuthnAssertion> {
+      return MOCK_ASSERTION;
+    },
+  };
+}
+
+/** Builds a minimal V1 (`sorobanCredentialsAddress`) auth entry for
+ * `contractAddress`, invoking a dummy `transfer` call — just enough
+ * structure for `createPasskeyX402Signer` to sign. Mirrors the fixture used
+ * in `src/x402-signer.test.ts`. */
+function makeV1AuthEntry(contractAddress: string, otherContractAddress: string) {
+  const addr = new Address(contractAddress);
+  const credentials = xdr.SorobanCredentials.sorobanCredentialsAddress(
+    new xdr.SorobanAddressCredentials({
+      address: addr.toScAddress(),
+      nonce: xdr.Int64.fromString("1"),
+      signatureExpirationLedger: 0,
+      signature: xdr.ScVal.scvVoid(),
+    }),
+  );
+  const rootInvocation = new xdr.SorobanAuthorizedInvocation({
+    function: xdr.SorobanAuthorizedFunction.sorobanAuthorizedFunctionTypeContractFn(
+      new xdr.InvokeContractArgs({
+        contractAddress: new Address(otherContractAddress).toScAddress(),
+        functionName: "transfer",
+        args: [
+          nativeToScVal(contractAddress, { type: "address" }),
+          nativeToScVal(otherContractAddress, { type: "address" }),
+          nativeToScVal(1n, { type: "i128" }),
+        ],
+      }),
+    ),
+    subInvocations: [],
+  });
+  return new xdr.SorobanAuthorizationEntry({ credentials, rootInvocation });
+}
+
+const PASSPHRASE = "Test SDF Network ; September 2015";
+const WALLET_ADDRESS = "CC5ZSTLTYKPNIFDSJ4233RVZPALGHHDBRTXGIN6Z3AJCWU57VR5ITXXR";
+const OTHER_ADDRESS = "CBIN4HTPJM2QLJ32DTRO6OCLIMM7TR7D74JDIPVQYLNYGL7SBWOXH5ND";
+
+/** Wires the mock signer into `createPasskeyX402Signer` and signs a dummy
+ * V1 auth entry, returning the signed entry XDR. */
+export async function signDummyEntryWithMock(): Promise<string> {
+  const signer = createPasskeyX402Signer({
+    address: WALLET_ADDRESS,
+    webAuthn: createMockWebAuthnAssertionSigner(),
+  });
+  const entry = makeV1AuthEntry(WALLET_ADDRESS, OTHER_ADDRESS);
+  return signer.signAuthEntry(entry.toXDR("base64"), {
+    networkPassphrase: PASSPHRASE,
+    expirationLedger: 1000,
+  });
+}
+
+export async function main(): Promise<void> {
+  const signedXdr = await signDummyEntryWithMock();
+  console.log(`signed with mock WebAuthn assertion, entry XDR length: ${signedXdr.length}`);
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main();
+}

--- a/contrib/examples/mock-x402-client/README.md
+++ b/contrib/examples/mock-x402-client/README.md
@@ -1,0 +1,27 @@
+# mock-x402-client
+
+Self-contained example that provides a mock version of the `X402Client` interface
+intended for unit tests.
+
+## Usage
+
+```ts
+import { createMockX402Client } from "./index";
+
+const client = createMockX402Client({ paid: true });
+
+const result = await client.fetch("https://example.com/resource");
+console.log(result.paid); // true
+
+const payment = await client.createPayment(result.settlement!, { maxAmount: 100000n });
+console.log(payment.header); // base64 payment payload
+```
+
+## Options
+
+- `paid?: boolean` — if true, `fetch` resolves with `paid: true` and a sample settlement.
+- `response?: Response` — override the returned underlying `Response` object.
+- `samplePayment?: SignedPayment` — override the value returned by `createPayment`.
+- `sampleRequirements?: PaymentRequirements` — override the requirements embedded in the sample payment.
+
+Ref: `X402Client`, `SignedPayment`, `PaymentRequirements`.

--- a/contrib/examples/mock-x402-client/index.ts
+++ b/contrib/examples/mock-x402-client/index.ts
@@ -1,0 +1,73 @@
+import type { X402Client, X402FetchInit, X402Response } from "../../../src/x402-types";
+import type { SignedPayment, PaymentRequirements } from "../../../src/x402-types";
+
+/**
+ * Mock X402Client for unit tests.
+ *
+ * Configurable behavior:
+ * - `fetch(...)` resolves with a canned X402Response. Set `paid` to true or false.
+ * - `createPayment(...)` always resolves with a fixed sample SignedPayment shape.
+ */
+export interface MockX402ClientOptions {
+  /** Whether the mock fetch should report a successful paid response. Default: false. */
+  paid?: boolean;
+  /** Optional canned response to return from fetch. */
+  response?: Response;
+  /** Fixed sample payment to return from createPayment. Default: a minimal SignedPayment. */
+  samplePayment?: SignedPayment;
+  /** Optional canned 402 payment requirements for use in the sample payment. */
+  sampleRequirements?: PaymentRequirements;
+}
+
+const SAMPLE_REQUIREMENTS: PaymentRequirements = {
+  scheme: "exact",
+  network: "stellar:testnet",
+  asset: "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHHHHH",
+  amount: "1000000",
+  payTo: "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+  maxTimeoutSeconds: 120,
+};
+
+const SAMPLE_PAYMENT: SignedPayment = {
+  header: "eyJ4MDAyVmVyc2lvbiI6MiwiYWNjZXB0ZWQiOnsic2NoZW1lIjoiZXhjZXB0IiwibmV0d29yayI6InN0ZWxsYXI6dGVzdG5ldCIsImFzc2V0IjoiQ0FBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFHSEhISCIEYW1vdW50IjoiMTAwMDAwMCIsInBheVRvIjoiR0FBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBIn19fQ==",
+  requirements: SAMPLE_REQUIREMENTS,
+  amount: 1000000n,
+};
+
+export function createMockX402Client(opts: MockX402ClientOptions = {}): X402Client {
+  const paid = opts.paid ?? false;
+  const response = opts.response ?? new Response("OK", { status: 200 });
+  const samplePayment: SignedPayment = opts.samplePayment ?? {
+    ...SAMPLE_PAYMENT,
+    ...(opts.sampleRequirements ? { requirements: opts.sampleRequirements } : {}),
+  };
+
+  return {
+    async fetch(_url: string, _init?: X402FetchInit): Promise<X402Response> {
+      if (paid) {
+        return {
+          response,
+          paid: true,
+          settlement: {
+            transaction: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            payer: "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHHHHH",
+            asset: SAMPLE_REQUIREMENTS.asset,
+            amount: BigInt(SAMPLE_REQUIREMENTS.amount),
+            network: "testnet",
+          },
+        };
+      }
+      return { response, paid: false };
+    },
+    async createPayment(): Promise<SignedPayment> {
+      // Return a copy to prevent accidental mutation of the singleton sample.
+      return {
+        ...samplePayment,
+        requirements: { ...samplePayment.requirements },
+        amount: samplePayment.amount,
+      };
+    },
+  } satisfies X402Client;
+}
+
+export { SAMPLE_REQUIREMENTS, SAMPLE_PAYMENT };

--- a/contrib/examples/mock-x402-client/test.ts
+++ b/contrib/examples/mock-x402-client/test.ts
@@ -1,0 +1,43 @@
+import { createMockX402Client } from "./index";
+
+// 1) unpaid fetch – should return paid=false and no settlement
+{
+  const client = createMockX402Client({ paid: false });
+  const result = await client.fetch("https://example.com/resource", { maxAmount: 0n });
+  console.assert(result.paid === false, "expected unpaid");
+  console.assert(result.settlement === undefined, "expected no settlement");
+  console.log("ok: unpaid fetch → paid=false");
+}
+
+// 2) paid fetch – should return paid=true and a populated settlement
+{
+  const client = createMockX402Client({ paid: true });
+  const result = await client.fetch("https://example.com/resource", { maxAmount: 0n });
+  console.assert(result.paid === true, "expected paid");
+  console.assert(result.settlement !== undefined, "expected settlement");
+  console.assert(result.settlement!.transaction.length > 0, "expected tx hash");
+  console.log("ok: paid fetch → paid=true, settlement present");
+}
+
+// 3) createPayment returns a stable signed-payment shape
+{
+  const client = createMockX402Client();
+  const payment = await client.createPayment(
+    {
+      scheme: "exact",
+      network: "stellar:testnet",
+      asset: "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHHHHH",
+      amount: "2500000",
+      payTo: "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+      maxTimeoutSeconds: 120,
+    },
+    { maxAmount: 5000000n },
+  );
+  console.assert(typeof payment.header === "string" && payment.header.length > 0, "expected header string");
+  // The mock returns the fixed sample payment shape, ignoring the inputs.
+  console.assert(payment.amount === 1000000n, "expected sample amount");
+  console.assert(payment.requirements.amount === "1000000", "expected sample requirements.amount");
+  console.log("ok: createPayment → SignedPayment shape");
+}
+
+console.log("mock-x402-client tests passed");

--- a/contrib/examples/mock-x402-resource/README.md
+++ b/contrib/examples/mock-x402-resource/README.md
@@ -1,0 +1,24 @@
+# Mock x402 resource server
+
+A minimal in-process mock of an x402-protected resource. Returns a mock
+`PAYMENT-REQUIRED`-style payload (HTTP 402, base64 JSON) until a
+`PAYMENT-SIGNATURE` header is present on the request, then returns the
+protected resource. This mock never validates the header's actual
+signature — a real facilitator would.
+
+## Run it
+
+```sh
+npx tsx mock-x402-resource.ts
+```
+
+Demonstrates both cases: an unpaid request (402 + `PAYMENT-REQUIRED` header)
+and a paid request (200 + resource body).
+
+## Tests
+
+Covers the unpaid and the paid request case:
+
+```sh
+npx vitest run contrib/examples/mock-x402-resource
+```

--- a/contrib/examples/mock-x402-resource/mock-x402-resource.test.ts
+++ b/contrib/examples/mock-x402-resource/mock-x402-resource.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+import { handleResourceRequest } from "./mock-x402-resource";
+
+describe("handleResourceRequest", () => {
+  it("returns 402 with a PAYMENT-REQUIRED header when no payment header is present", () => {
+    const response = handleResourceRequest({ headers: {} });
+    expect(response.status).toBe(402);
+    expect(response.headers["PAYMENT-REQUIRED"]).toBeTruthy();
+
+    const decoded = JSON.parse(atob(response.headers["PAYMENT-REQUIRED"]!));
+    expect(decoded.x402Version).toBe(2);
+    expect(decoded.accepts[0].scheme).toBe("exact");
+  });
+
+  it("returns 200 with the resource when a payment header is present", () => {
+    const response = handleResourceRequest({
+      headers: { "PAYMENT-SIGNATURE": "mock-signature-value" },
+    });
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual({ data: "the protected resource content" });
+  });
+
+  it("accepts a lowercase header name", () => {
+    const response = handleResourceRequest({
+      headers: { "payment-signature": "mock-signature-value" },
+    });
+    expect(response.status).toBe(200);
+  });
+});

--- a/contrib/examples/mock-x402-resource/mock-x402-resource.ts
+++ b/contrib/examples/mock-x402-resource/mock-x402-resource.ts
@@ -1,0 +1,71 @@
+// Example: a minimal in-process mock of an x402-protected resource server.
+// Returns a mock PAYMENT-REQUIRED-style payload (402) until a payment header
+// is present on the request, then returns the resource.
+//
+// Run with: npx tsx mock-x402-resource.ts
+
+export interface MockRequest {
+  headers: Record<string, string>;
+}
+
+export interface MockResponse {
+  status: number;
+  headers: Record<string, string>;
+  body: unknown;
+}
+
+// Browser-safe base64, matching src/x402-client.ts's utf8ToBase64 (this
+// package targets bundlers/browsers, no Buffer).
+function utf8ToBase64(s: string): string {
+  const bytes = new TextEncoder().encode(s);
+  let bin = "";
+  for (const b of bytes) bin += String.fromCharCode(b);
+  return btoa(bin);
+}
+
+const PAYMENT_HEADER = "PAYMENT-SIGNATURE";
+
+const PAYMENT_REQUIRED_PAYLOAD = {
+  x402Version: 2,
+  accepts: [
+    {
+      scheme: "exact",
+      network: "stellar:testnet",
+      asset: "CUSDCAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+      amount: "1000000",
+      payTo: "CPAYTOSAMPLEADDRESSXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+    },
+  ],
+};
+
+/** Handles a request to a protected resource: 402 without a payment header,
+ * 200 with the resource once one is present (this mock never validates the
+ * header's actual signature — a real facilitator would). */
+export function handleResourceRequest(request: MockRequest): MockResponse {
+  const paymentHeader = request.headers[PAYMENT_HEADER] ?? request.headers[PAYMENT_HEADER.toLowerCase()];
+
+  if (!paymentHeader) {
+    return {
+      status: 402,
+      headers: {
+        "PAYMENT-REQUIRED": utf8ToBase64(JSON.stringify(PAYMENT_REQUIRED_PAYLOAD)),
+      },
+      body: { error: "Payment required" },
+    };
+  }
+
+  return { status: 200, headers: {}, body: { data: "the protected resource content" } };
+}
+
+function main() {
+  console.log("Unpaid request:");
+  console.log(handleResourceRequest({ headers: {} }));
+
+  console.log();
+  console.log("Paid request (payment header present):");
+  console.log(handleResourceRequest({ headers: { "PAYMENT-SIGNATURE": "mock-signature-value" } }));
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main();
+}

--- a/contrib/examples/multi-asset-summary/README.md
+++ b/contrib/examples/multi-asset-summary/README.md
@@ -1,0 +1,33 @@
+# Multi-asset balance summary
+
+Formats a readable "SYMBOL: amount" summary line per asset from a sample
+array of balances across several assets (`vellar-sdk`'s `TokenBalance` shape,
+`src/balances.ts`), sorted alphabetically by asset code. Reuses the SDK's
+own `formatTokenAmount` for the amount formatting.
+
+## Run it
+
+```sh
+npx tsx multi-asset-summary.ts
+```
+
+Expected output:
+
+```
+With balances:
+AQUA: 50000
+USDC: 250
+XLM: 1000
+
+With no balances:
+No balances.
+```
+
+An empty balances array prints a clear "No balances." message instead of an
+empty output.
+
+## Tests
+
+```sh
+npx vitest run contrib/examples/multi-asset-summary
+```

--- a/contrib/examples/multi-asset-summary/multi-asset-summary.test.ts
+++ b/contrib/examples/multi-asset-summary/multi-asset-summary.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+import type { TokenBalance } from "../../../src/balances";
+import { formatMultiAssetSummary } from "./multi-asset-summary";
+
+describe("formatMultiAssetSummary", () => {
+  it("prints a clear message for an empty array", () => {
+    expect(formatMultiAssetSummary([])).toBe("No balances.");
+  });
+
+  it("formats one line per asset", () => {
+    const balances: TokenBalance[] = [
+      { symbol: "XLM", contractId: "CNATIVE", decimals: 7, amount: 1_000_000_000n },
+    ];
+    expect(formatMultiAssetSummary(balances)).toBe("XLM: 100");
+  });
+
+  it("sorts the summary alphabetically by asset code", () => {
+    const balances: TokenBalance[] = [
+      { symbol: "XLM", contractId: "CNATIVE", decimals: 7, amount: 100n },
+      { symbol: "AQUA", contractId: "CAQUA", decimals: 7, amount: 200n },
+      { symbol: "USDC", contractId: "CUSDC", decimals: 7, amount: 300n },
+    ];
+    const lines = formatMultiAssetSummary(balances).split("\n");
+    expect(lines.map((l) => l.split(":")[0])).toEqual(["AQUA", "USDC", "XLM"]);
+  });
+
+  it("does not mutate the input array order", () => {
+    const balances: TokenBalance[] = [
+      { symbol: "XLM", contractId: "CNATIVE", decimals: 7, amount: 100n },
+      { symbol: "AQUA", contractId: "CAQUA", decimals: 7, amount: 200n },
+    ];
+    formatMultiAssetSummary(balances);
+    expect(balances[0]!.symbol).toBe("XLM"); // original order untouched
+  });
+});

--- a/contrib/examples/multi-asset-summary/multi-asset-summary.ts
+++ b/contrib/examples/multi-asset-summary/multi-asset-summary.ts
@@ -1,0 +1,35 @@
+// Example: format a readable summary line per asset from a sample array of
+// balances across several assets, sorted alphabetically by asset code.
+//
+// Run with: npx tsx multi-asset-summary.ts
+
+import { formatTokenAmount, type TokenBalance } from "../../../src/balances";
+
+/** Formats a "SYMBOL: amount" line per asset, sorted alphabetically by
+ * symbol. An empty array prints a clear "No balances." message. */
+export function formatMultiAssetSummary(balances: TokenBalance[]): string {
+  if (balances.length === 0) {
+    return "No balances.";
+  }
+
+  const sorted = [...balances].sort((a, b) => a.symbol.localeCompare(b.symbol));
+  return sorted.map((b) => `${b.symbol}: ${formatTokenAmount(b.amount, b.decimals)}`).join("\n");
+}
+
+function main() {
+  const sampleBalances: TokenBalance[] = [
+    { symbol: "USDC", contractId: "CUSDC", decimals: 7, amount: 250_000_0000n },
+    { symbol: "XLM", contractId: "CNATIVE", decimals: 7, amount: 1_000_000_0000n },
+    { symbol: "AQUA", contractId: "CAQUA", decimals: 7, amount: 50_000_0000000n },
+  ];
+
+  console.log("With balances:");
+  console.log(formatMultiAssetSummary(sampleBalances));
+  console.log();
+  console.log("With no balances:");
+  console.log(formatMultiAssetSummary([]));
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main();
+}

--- a/contrib/examples/multi-signer-approval-demo/README.md
+++ b/contrib/examples/multi-signer-approval-demo/README.md
@@ -1,0 +1,39 @@
+# Multi-signer approval demo
+
+Several mock signers each approve a sample transaction until a configured
+threshold is met, at which point it's marked ready. Approvals are
+deduplicated by signer id — a signer approving twice only counts once
+toward the threshold.
+
+## The flow
+
+1. Construct `new MultiSignerApproval(threshold)`.
+2. Each signer calls `approve(signerId)` independently and in any order.
+3. `approvalCount` reports the number of **distinct** signers who've
+   approved; `isReady` becomes `true` once that count reaches the threshold.
+
+## Run it
+
+```sh
+npx tsx multi-signer-approval-demo.ts
+```
+
+Expected output (threshold 2, `signer-alice` approves twice, then
+`signer-bob` approves once — reaching threshold on the second *distinct*
+signer, not the third call):
+
+```
+Threshold: 2 of 3 signers
+signer-alice approves...
+  approvals: 1, ready: false
+signer-alice approves again (should not double-count)...
+  approvals: 1, ready: false
+signer-bob approves...
+  approvals: 2, ready: true
+```
+
+## Tests
+
+```sh
+npx vitest run contrib/examples/multi-signer-approval-demo
+```

--- a/contrib/examples/multi-signer-approval-demo/multi-signer-approval-demo.test.ts
+++ b/contrib/examples/multi-signer-approval-demo/multi-signer-approval-demo.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+import { MultiSignerApproval } from "./multi-signer-approval-demo";
+
+describe("MultiSignerApproval", () => {
+  it("is not ready before the threshold is reached", () => {
+    const approval = new MultiSignerApproval(3);
+    approval.approve("alice");
+    approval.approve("bob");
+    expect(approval.approvalCount).toBe(2);
+    expect(approval.isReady).toBe(false);
+  });
+
+  it("becomes ready once distinct approvals reach the threshold", () => {
+    const approval = new MultiSignerApproval(3);
+    approval.approve("alice");
+    approval.approve("bob");
+    approval.approve("carol");
+    expect(approval.approvalCount).toBe(3);
+    expect(approval.isReady).toBe(true);
+  });
+
+  it("a signer approving twice only counts once", () => {
+    const approval = new MultiSignerApproval(2);
+    approval.approve("alice");
+    approval.approve("alice");
+    approval.approve("alice");
+    expect(approval.approvalCount).toBe(1);
+    expect(approval.isReady).toBe(false);
+
+    approval.approve("bob");
+    expect(approval.approvalCount).toBe(2);
+    expect(approval.isReady).toBe(true);
+  });
+
+  it("rejects a non-positive threshold", () => {
+    expect(() => new MultiSignerApproval(0)).toThrow(RangeError);
+    expect(() => new MultiSignerApproval(-1)).toThrow(RangeError);
+  });
+});

--- a/contrib/examples/multi-signer-approval-demo/multi-signer-approval-demo.ts
+++ b/contrib/examples/multi-signer-approval-demo/multi-signer-approval-demo.ts
@@ -1,0 +1,56 @@
+// Example: several mock signers each approve a sample transaction until a
+// configured threshold is met, then it's marked ready. A signer approving
+// twice only counts once toward the threshold — approvals are deduplicated
+// by signer id.
+//
+// Run with: npx tsx multi-signer-approval-demo.ts
+
+export class MultiSignerApproval {
+  #threshold: number;
+  #approvals = new Set<string>();
+
+  constructor(threshold: number) {
+    if (threshold <= 0) {
+      throw new RangeError(`threshold must be a positive number, got ${threshold}`);
+    }
+    this.#threshold = threshold;
+  }
+
+  /** Records an approval from `signerId`. A repeat approval from the same
+   * signer is a no-op — it does not count twice toward the threshold. */
+  approve(signerId: string): void {
+    this.#approvals.add(signerId);
+  }
+
+  get approvalCount(): number {
+    return this.#approvals.size;
+  }
+
+  /** True once distinct approvals reach (or exceed) the threshold. */
+  get isReady(): boolean {
+    return this.#approvals.size >= this.#threshold;
+  }
+}
+
+function main() {
+  const approval = new MultiSignerApproval(2);
+  const signers = ["signer-alice", "signer-bob", "signer-carol"];
+
+  console.log(`Threshold: 2 of ${signers.length} signers`);
+
+  console.log(`${signers[0]} approves...`);
+  approval.approve(signers[0]!);
+  console.log(`  approvals: ${approval.approvalCount}, ready: ${approval.isReady}`);
+
+  console.log(`${signers[0]} approves again (should not double-count)...`);
+  approval.approve(signers[0]!);
+  console.log(`  approvals: ${approval.approvalCount}, ready: ${approval.isReady}`);
+
+  console.log(`${signers[1]} approves...`);
+  approval.approve(signers[1]!);
+  console.log(`  approvals: ${approval.approvalCount}, ready: ${approval.isReady}`);
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main();
+}

--- a/contrib/examples/nonce-tracker/README.md
+++ b/contrib/examples/nonce-tracker/README.md
@@ -1,0 +1,32 @@
+# Simple in-memory nonce tracker
+
+Records used nonce values per account in memory, to detect and reject a
+repeated nonce — useful for replay protection on a signed request.
+
+`checkAndConsume(account, nonce)` returns `true` and marks the nonce used
+the first time it's seen for that account; a second check for the same
+account+nonce pair returns `false` without re-marking anything. Nonces are
+tracked independently per account — the same nonce string is fresh again
+for a different account.
+
+## Run it
+
+```sh
+npx tsx nonce-tracker.ts
+```
+
+Expected output:
+
+```
+First check of nonce 'abc' for account GALICE: true
+Second check of the same nonce (should be rejected): false
+Same nonce, different account (should be fresh): true
+```
+
+## Tests
+
+Covers a fresh nonce accepted and a repeated nonce rejected:
+
+```sh
+npx vitest run contrib/examples/nonce-tracker
+```

--- a/contrib/examples/nonce-tracker/nonce-tracker.test.ts
+++ b/contrib/examples/nonce-tracker/nonce-tracker.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+import { NonceTracker } from "./nonce-tracker";
+
+describe("NonceTracker", () => {
+  it("accepts a fresh nonce", () => {
+    const tracker = new NonceTracker();
+    expect(tracker.checkAndConsume("GALICE", "n1")).toBe(true);
+  });
+
+  it("rejects a repeated nonce for the same account", () => {
+    const tracker = new NonceTracker();
+    tracker.checkAndConsume("GALICE", "n1");
+    expect(tracker.checkAndConsume("GALICE", "n1")).toBe(false);
+  });
+
+  it("tracks nonces independently per account", () => {
+    const tracker = new NonceTracker();
+    tracker.checkAndConsume("GALICE", "n1");
+    expect(tracker.checkAndConsume("GBOB", "n1")).toBe(true);
+  });
+
+  it("accepts a different nonce for an account that already used one", () => {
+    const tracker = new NonceTracker();
+    tracker.checkAndConsume("GALICE", "n1");
+    expect(tracker.checkAndConsume("GALICE", "n2")).toBe(true);
+  });
+});

--- a/contrib/examples/nonce-tracker/nonce-tracker.ts
+++ b/contrib/examples/nonce-tracker/nonce-tracker.ts
@@ -1,0 +1,39 @@
+// Example: an in-memory tracker recording used nonce values per account,
+// to detect and reject a repeated nonce (e.g. for replay protection on a
+// signed request).
+//
+// Run with: npx tsx nonce-tracker.ts
+
+export class NonceTracker {
+  #used = new Map<string, Set<string>>();
+
+  /**
+   * Checks whether `nonce` is fresh for `account`. If fresh, marks it used
+   * (so a second check for the same account+nonce returns false) and
+   * returns true. If already used, returns false without side effects.
+   */
+  checkAndConsume(account: string, nonce: string): boolean {
+    let seen = this.#used.get(account);
+    if (!seen) {
+      seen = new Set();
+      this.#used.set(account, seen);
+    }
+    if (seen.has(nonce)) {
+      return false;
+    }
+    seen.add(nonce);
+    return true;
+  }
+}
+
+function main() {
+  const tracker = new NonceTracker();
+
+  console.log("First check of nonce 'abc' for account GALICE:", tracker.checkAndConsume("GALICE", "abc"));
+  console.log("Second check of the same nonce (should be rejected):", tracker.checkAndConsume("GALICE", "abc"));
+  console.log("Same nonce, different account (should be fresh):", tracker.checkAndConsume("GBOB", "abc"));
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main();
+}

--- a/contrib/examples/onboarding-checklist-runner/README.md
+++ b/contrib/examples/onboarding-checklist-runner/README.md
@@ -1,0 +1,44 @@
+# Wallet onboarding checklist runner
+
+Walks through a fixed sequence of onboarding steps against mocked
+dependencies, tracking which steps are complete after each run.
+`runOnboardingChecklist()` runs steps **in order**, stops at the first
+failure, and reports both `completed` and `remaining` (the failed step and
+everything after it) so a caller can show progress even on a partial run.
+
+## The steps
+
+`buildMockChecklist()` builds the standard four-step checklist, in order:
+
+1. **create-wallet** — register a passkey and create the smart account.
+2. **fund-account** — sponsor-fund the new account so it can pay fees.
+3. **verify-balance** — confirm the funded balance actually landed.
+4. **attach-policy** — attach a default spending-limit policy.
+
+Each step operates on shared mock state (an in-closure account id, balance,
+and policy flag) standing in for a real wallet/backend round trip — no
+network calls.
+
+## Run it
+
+```sh
+npx tsx onboarding-checklist-runner.ts
+```
+
+Expected output:
+
+```
+Running 4 onboarding steps: create-wallet -> fund-account -> verify-balance -> attach-policy
+
+Completed: [ 'create-wallet', 'fund-account', 'verify-balance', 'attach-policy' ]
+Remaining: (none — onboarding complete)
+```
+
+## Tests
+
+Covers the full checklist completing, and a partial run where a step fails
+partway through:
+
+```sh
+npx vitest run contrib/examples/onboarding-checklist-runner
+```

--- a/contrib/examples/onboarding-checklist-runner/onboarding-checklist-runner.test.ts
+++ b/contrib/examples/onboarding-checklist-runner/onboarding-checklist-runner.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+import { buildMockChecklist, runOnboardingChecklist, type OnboardingStep } from "./onboarding-checklist-runner";
+
+describe("runOnboardingChecklist", () => {
+  it("completes all four steps of the standard mock checklist in order", async () => {
+    const result = await runOnboardingChecklist(buildMockChecklist());
+    expect(result.completed).toEqual(["create-wallet", "fund-account", "verify-balance", "attach-policy"]);
+    expect(result.remaining).toEqual([]);
+  });
+
+  it("stops at the first failing step, reporting it and everything after as remaining", async () => {
+    const steps: OnboardingStep[] = [
+      { id: "step-1", description: "ok", async run() {} },
+      { id: "step-2", description: "fails", async run() { throw new Error("boom"); } },
+      { id: "step-3", description: "never reached", async run() {} },
+    ];
+
+    const result = await runOnboardingChecklist(steps);
+    expect(result.completed).toEqual(["step-1"]);
+    expect(result.remaining).toEqual(["step-2", "step-3"]);
+  });
+
+  it("runs steps in the given order, not concurrently", async () => {
+    const order: string[] = [];
+    const steps: OnboardingStep[] = [
+      { id: "a", description: "", async run() { order.push("a"); } },
+      { id: "b", description: "", async run() { order.push("b"); } },
+    ];
+    await runOnboardingChecklist(steps);
+    expect(order).toEqual(["a", "b"]);
+  });
+
+  it("returns an empty result for an empty checklist", async () => {
+    expect(await runOnboardingChecklist([])).toEqual({ completed: [], remaining: [] });
+  });
+});
+
+describe("buildMockChecklist", () => {
+  it("includes at least four distinct steps", () => {
+    const steps = buildMockChecklist();
+    expect(steps.length).toBeGreaterThanOrEqual(4);
+    expect(new Set(steps.map((s) => s.id)).size).toBe(steps.length);
+  });
+});

--- a/contrib/examples/onboarding-checklist-runner/onboarding-checklist-runner.ts
+++ b/contrib/examples/onboarding-checklist-runner/onboarding-checklist-runner.ts
@@ -1,0 +1,96 @@
+// Example: walk through a fixed sequence of wallet onboarding steps
+// against mocked dependencies, tracking which steps are complete after
+// each run.
+//
+// Steps (in order):
+//   1. create-wallet     — register a passkey and create the smart account.
+//   2. fund-account       — sponsor-fund the new account so it can pay fees.
+//   3. verify-balance     — confirm the funded balance actually landed.
+//   4. attach-policy      — attach a default spending-limit policy.
+//
+// Run with: npx tsx onboarding-checklist-runner.ts
+
+export interface OnboardingStep {
+  id: string;
+  description: string;
+  run: () => Promise<void>;
+}
+
+export interface ChecklistResult {
+  completed: string[];
+  remaining: string[];
+}
+
+/** Runs each step in order, stopping at the first failure. Returns which
+ * steps completed and which remain (including the failed one and anything
+ * after it), so a caller can show progress even on a partial run. */
+export async function runOnboardingChecklist(steps: OnboardingStep[]): Promise<ChecklistResult> {
+  const completed: string[] = [];
+
+  for (let i = 0; i < steps.length; i++) {
+    try {
+      await steps[i]!.run();
+      completed.push(steps[i]!.id);
+    } catch {
+      return { completed, remaining: steps.slice(i).map((s) => s.id) };
+    }
+  }
+
+  return { completed, remaining: [] };
+}
+
+/** Builds the standard four-step checklist against mocked dependencies. */
+export function buildMockChecklist(): OnboardingStep[] {
+  // Shared mutable mock state the steps operate on, standing in for a real
+  // wallet/backend round trip.
+  let accountId: string | undefined;
+  let balance = 0n;
+  let policyAttached = false;
+
+  return [
+    {
+      id: "create-wallet",
+      description: "Register a passkey and create the smart account.",
+      async run() {
+        accountId = "CMOCKONBOARDEDACCOUNTXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX";
+      },
+    },
+    {
+      id: "fund-account",
+      description: "Sponsor-fund the new account so it can pay fees.",
+      async run() {
+        if (!accountId) throw new Error("fund-account requires create-wallet to have run first");
+        balance = 5_0000000n; // 5 XLM, in stroops
+      },
+    },
+    {
+      id: "verify-balance",
+      description: "Confirm the funded balance actually landed.",
+      async run() {
+        if (balance <= 0n) throw new Error("verify-balance: account has no balance");
+      },
+    },
+    {
+      id: "attach-policy",
+      description: "Attach a default spending-limit policy.",
+      async run() {
+        policyAttached = true;
+      },
+    },
+  ];
+}
+
+async function main() {
+  const steps = buildMockChecklist();
+  console.log(`Running ${steps.length} onboarding steps: ${steps.map((s) => s.id).join(" -> ")}`);
+
+  const result = await runOnboardingChecklist(steps);
+
+  console.log();
+  console.log("Completed:", result.completed);
+  console.log("Remaining:", result.remaining.length > 0 ? result.remaining : "(none — onboarding complete)");
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main();
+}

--- a/contrib/examples/parse-to-stroops/README.md
+++ b/contrib/examples/parse-to-stroops/README.md
@@ -1,0 +1,28 @@
+# Parse a human-readable amount into stroops
+
+Converts a human-readable XLM amount string into raw stroops as a `bigint`
+(1 XLM = 10,000,000 stroops). A thin wrapper over `vellar-sdk`'s own
+`parseTokenAmount` (`src/payments.ts`), fixed to XLM's 7 decimal places —
+reuses the SDK's exact parsing/validation rules rather than reimplementing
+them.
+
+## Examples
+
+| Input | Output |
+| --- | --- |
+| `10` | `100000000` stroops |
+| `10.5` | `105000000` stroops |
+| `0.0000001` | `1` stroop |
+| `1.12345678` (8 decimal places) | rejected — `Amount supports at most 7 decimal places` |
+
+## Run it
+
+```sh
+npx tsx parse-to-stroops.ts <amount>
+```
+
+## Tests
+
+```sh
+npx vitest run contrib/examples/parse-to-stroops
+```

--- a/contrib/examples/parse-to-stroops/parse-to-stroops.test.ts
+++ b/contrib/examples/parse-to-stroops/parse-to-stroops.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+import { parseToStroops } from "./parse-to-stroops";
+
+describe("parseToStroops", () => {
+  it("converts a whole XLM amount to stroops", () => {
+    expect(parseToStroops("10")).toBe(100_000_000n);
+  });
+
+  it("converts a fractional XLM amount to stroops", () => {
+    expect(parseToStroops("10.5")).toBe(105_000_000n);
+  });
+
+  it("converts the smallest unit (1 stroop)", () => {
+    expect(parseToStroops("0.0000001")).toBe(1n);
+  });
+
+  it("rejects an amount with more than 7 decimal places", () => {
+    expect(() => parseToStroops("1.12345678")).toThrow(/at most 7 decimal places/);
+  });
+
+  it("rejects a zero amount", () => {
+    expect(() => parseToStroops("0")).toThrow();
+  });
+});

--- a/contrib/examples/parse-to-stroops/parse-to-stroops.ts
+++ b/contrib/examples/parse-to-stroops/parse-to-stroops.ts
@@ -1,0 +1,33 @@
+// Example: convert a human-readable XLM amount string into raw stroops as a
+// bigint (1 XLM = 10,000,000 stroops, XLM's 7 decimal places).
+//
+// Run with: npx tsx parse-to-stroops.ts <amount>
+
+import { parseTokenAmount } from "../../../src/payments";
+
+const XLM_DECIMALS = 7;
+
+/** Thin wrapper over the SDK's parseTokenAmount, fixed to XLM's 7 decimals. */
+export function parseToStroops(amount: string): bigint {
+  return parseTokenAmount(amount, XLM_DECIMALS);
+}
+
+function main() {
+  const amount = process.argv[2];
+  if (!amount) {
+    console.error("Usage: npx tsx parse-to-stroops.ts <amount>");
+    process.exitCode = 1;
+    return;
+  }
+
+  try {
+    console.log(`${amount} XLM = ${parseToStroops(amount)} stroops`);
+  } catch (err) {
+    console.error(`Error: ${err instanceof Error ? err.message : String(err)}`);
+    process.exitCode = 1;
+  }
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main();
+}

--- a/contrib/examples/percentage-of-amount/README.md
+++ b/contrib/examples/percentage-of-amount/README.md
@@ -1,0 +1,31 @@
+# Percentage of Amount Example (#109)
+
+Provides a utility `percentageOf` that computes a given percentage of a base unit token amount (such as Stellar stroops), returning a `bigint` result. Uses basis points (1% = 100 bps) to prevent floating-point precision loss.
+
+## Edge Cases
+
+- **0%**: Handled as an explicit edge case returning `0n`.
+- **100%**: Handled as an explicit edge case returning the exact `BigInt(amount)`.
+
+## Examples & Expected Outputs
+
+| Base Amount (Stroops) | Percentage | Expected Result (BigInt Stroops) | Notes |
+| --- | --- | --- | --- |
+| `10000000` | `0%` | `0` | 0% Edge case |
+| `10000000` | `100%` | `10000000` | 100% Edge case |
+| `10000000` | `5%` | `500000` | 5% of 10 XLM |
+| `10000000` | `2.5%` | `250000` | Fractional fee (250 bps) |
+| `500000000` | `0.5%` | `2500000` | Protocol fee (50 bps) |
+| `100` | `50%` | `50` | 50% of 100 units |
+
+## Run it
+
+```sh
+npx tsx contrib/examples/percentage-of-amount/percentage-of-amount.ts
+```
+
+## Tests
+
+```sh
+npx vitest run contrib/examples/percentage-of-amount
+```

--- a/contrib/examples/percentage-of-amount/percentage-of-amount.test.ts
+++ b/contrib/examples/percentage-of-amount/percentage-of-amount.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest';
+import { percentageOf } from './percentage-of-amount';
+
+describe('percentage-of-amount (#109)', () => {
+  it('handles 0% edge case returning 0n', () => {
+    expect(percentageOf(1000000n, 0)).toBe(0n);
+    expect(percentageOf('5000000', 0)).toBe(0n);
+  });
+
+  it('handles 100% edge case returning full base amount', () => {
+    expect(percentageOf(1000000n, 100)).toBe(1000000n);
+    expect(percentageOf('5000000', 100)).toBe(5000000n);
+  });
+
+  it('computes standard percentages correctly', () => {
+    expect(percentageOf(10000000n, 5)).toBe(500000n);
+    expect(percentageOf('100', 50)).toBe(50n);
+  });
+
+  it('computes fractional percentages using basis points accurately', () => {
+    expect(percentageOf(10000000n, 2.5)).toBe(250000n);
+    expect(percentageOf(500000000n, 0.5)).toBe(2500000n);
+  });
+
+  it('accepts bigint, string, or number input types', () => {
+    expect(percentageOf(1000n, 10)).toBe(100n);
+    expect(percentageOf('1000', 10)).toBe(100n);
+    expect(percentageOf(1000, 10)).toBe(100n);
+  });
+});

--- a/contrib/examples/percentage-of-amount/percentage-of-amount.ts
+++ b/contrib/examples/percentage-of-amount/percentage-of-amount.ts
@@ -1,0 +1,59 @@
+// Example: Compute a given percentage of a base unit token amount using bigint arithmetic.
+//
+// Run with: npx tsx contrib/examples/percentage-of-amount/percentage-of-amount.ts
+
+/**
+ * Computes a given percentage of a base unit token amount, returning a bigint result.
+ * Uses basis points (1% = 100 bps) to maintain precision without floating point inaccuracies.
+ *
+ * Edge cases:
+ * - 0% returns 0n.
+ * - 100% returns BigInt(amount).
+ *
+ * @param amount - Base unit token amount (e.g. stroops, wei, satoshis).
+ * @param percentage - Percentage value from 0 to 100 (e.g. 5, 2.5, 0, 100).
+ */
+export function percentageOf(
+  amount: bigint | string | number,
+  percentage: number,
+): bigint {
+  const baseAmount = BigInt(amount);
+
+  if (percentage <= 0) {
+    return 0n;
+  }
+  if (percentage >= 100) {
+    return baseAmount;
+  }
+
+  // Convert percentage to basis points (e.g. 2.5% -> 250 bps, 5% -> 500 bps)
+  const basisPoints = BigInt(Math.round(percentage * 100));
+  return (baseAmount * basisPoints) / 10000n;
+}
+
+function main() {
+  console.log('=== Percentage of Amount Example ===\n');
+
+  const testCases = [
+    { amount: '10000000', percentage: 0, note: '0% Edge case (Returns 0)' },
+    { amount: '10000000', percentage: 100, note: '100% Edge case (Returns full amount)' },
+    { amount: '10000000', percentage: 5, note: '5% of 10,000,000 stroops (10 XLM)' },
+    { amount: '10000000', percentage: 2.5, note: '2.5% fee calculation' },
+    { amount: '500000000', percentage: 0.5, note: '0.5% protocol fee' },
+    { amount: '100', percentage: 50, note: '50% of 100' },
+  ];
+
+  console.log('Base Amount (Stroops) | Percentage | Result (BigInt Stroops) | Notes');
+  console.log('----------------------|------------|-------------------------|-----------------------------');
+
+  for (const tc of testCases) {
+    const result = percentageOf(tc.amount, tc.percentage);
+    console.log(
+      `${tc.amount.padEnd(21)} | ${(tc.percentage + '%').padEnd(10)} | ${result.toString().padEnd(23)} | ${tc.note}`,
+    );
+  }
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main();
+}

--- a/contrib/examples/policy-audit-trail/README.md
+++ b/contrib/examples/policy-audit-trail/README.md
@@ -1,0 +1,43 @@
+# Policy audit trail formatter
+
+`formatAuditTrail(events)` takes a list of policy change events (`create`,
+`update`, `remove`) and renders them as a readable chronological audit
+trail — **oldest first**. Input order is never assumed to already be
+sorted: events are sorted by `timestamp` before rendering, so passing them
+in any order (e.g. as fetched newest-first from an API) still produces a
+correct trail.
+
+## Input shape
+
+```ts
+interface PolicyChangeEvent {
+  action: "create" | "update" | "remove";
+  policyId: string;
+  timestamp: string; // ISO 8601
+}
+```
+
+Each rendered line includes the action, the policy id, and the timestamp:
+`[<timestamp>] <Action> policy (<policyId>)`.
+
+## Run it
+
+```sh
+npx tsx policy-audit-trail.ts
+```
+
+Expected output (the sample events are given out of order; the trail is
+still oldest-first):
+
+```
+[2026-01-10T12:00:00Z] Created policy (spending-limit-policy)
+[2026-01-20T16:45:00Z] Created policy (signer-threshold-policy)
+[2026-02-14T08:30:00Z] Updated policy (signer-threshold-policy)
+[2026-03-03T09:15:00Z] Removed policy (spending-limit-policy)
+```
+
+## Tests
+
+```sh
+npx vitest run contrib/examples/policy-audit-trail
+```

--- a/contrib/examples/policy-audit-trail/policy-audit-trail.test.ts
+++ b/contrib/examples/policy-audit-trail/policy-audit-trail.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+import { formatAuditTrail, type PolicyChangeEvent } from "./policy-audit-trail";
+
+describe("formatAuditTrail", () => {
+  it("renders each entry with action, policy id, and timestamp", () => {
+    const events: PolicyChangeEvent[] = [
+      { action: "create", policyId: "policy-1", timestamp: "2026-01-01T00:00:00Z" },
+    ];
+    expect(formatAuditTrail(events)).toBe("[2026-01-01T00:00:00Z] Created policy (policy-1)");
+  });
+
+  it("labels update and remove actions distinctly from create", () => {
+    const events: PolicyChangeEvent[] = [
+      { action: "update", policyId: "policy-1", timestamp: "2026-01-01T00:00:00Z" },
+      { action: "remove", policyId: "policy-2", timestamp: "2026-01-02T00:00:00Z" },
+    ];
+    const trail = formatAuditTrail(events);
+    expect(trail).toContain("Updated policy (policy-1)");
+    expect(trail).toContain("Removed policy (policy-2)");
+  });
+
+  it("orders entries oldest first regardless of input order", () => {
+    const events: PolicyChangeEvent[] = [
+      { action: "remove", policyId: "b", timestamp: "2026-03-01T00:00:00Z" },
+      { action: "create", policyId: "a", timestamp: "2026-01-01T00:00:00Z" },
+      { action: "update", policyId: "c", timestamp: "2026-02-01T00:00:00Z" },
+    ];
+
+    const lines = formatAuditTrail(events).split("\n");
+    expect(lines[0]).toContain("(a)");
+    expect(lines[1]).toContain("(c)");
+    expect(lines[2]).toContain("(b)");
+  });
+
+  it("does not mutate the input array", () => {
+    const events: PolicyChangeEvent[] = [
+      { action: "remove", policyId: "b", timestamp: "2026-03-01T00:00:00Z" },
+      { action: "create", policyId: "a", timestamp: "2026-01-01T00:00:00Z" },
+    ];
+    const original = [...events];
+    formatAuditTrail(events);
+    expect(events).toEqual(original);
+  });
+
+  it("returns an empty string for an empty event list", () => {
+    expect(formatAuditTrail([])).toBe("");
+  });
+});

--- a/contrib/examples/policy-audit-trail/policy-audit-trail.ts
+++ b/contrib/examples/policy-audit-trail/policy-audit-trail.ts
@@ -1,0 +1,57 @@
+// Example: format a list of sample policy change events (create, update,
+// remove) as a readable chronological audit trail — oldest first. Input
+// order is never assumed to already be sorted: events are sorted by
+// timestamp before rendering, so passing them in any order (e.g. as fetched
+// newest-first from an API) still produces a correct trail.
+//
+// Run with: npx tsx policy-audit-trail.ts
+
+export type PolicyChangeAction = "create" | "update" | "remove";
+
+export interface PolicyChangeEvent {
+  action: PolicyChangeAction;
+  policyId: string;
+  /** ISO 8601 timestamp. */
+  timestamp: string;
+}
+
+function actionLabel(action: PolicyChangeAction): string {
+  switch (action) {
+    case "create":
+      return "Created";
+    case "update":
+      return "Updated";
+    case "remove":
+      return "Removed";
+  }
+}
+
+/**
+ * Formats `events` as a readable chronological audit trail, **oldest
+ * first**. Input order is never assumed to already be sorted — events are
+ * sorted by `timestamp` before rendering, so a caller can pass them in any
+ * order and get a correct trail regardless.
+ */
+export function formatAuditTrail(events: PolicyChangeEvent[]): string {
+  const sorted = [...events].sort((a, b) => a.timestamp.localeCompare(b.timestamp));
+  return sorted
+    .map((event) => `[${event.timestamp}] ${actionLabel(event.action)} policy (${event.policyId})`)
+    .join("\n");
+}
+
+function main() {
+  // Deliberately out of chronological order, to demonstrate that
+  // formatAuditTrail sorts rather than trusting input order.
+  const events: PolicyChangeEvent[] = [
+    { action: "remove", policyId: "spending-limit-policy", timestamp: "2026-03-03T09:15:00Z" },
+    { action: "create", policyId: "spending-limit-policy", timestamp: "2026-01-10T12:00:00Z" },
+    { action: "update", policyId: "signer-threshold-policy", timestamp: "2026-02-14T08:30:00Z" },
+    { action: "create", policyId: "signer-threshold-policy", timestamp: "2026-01-20T16:45:00Z" },
+  ];
+
+  console.log(formatAuditTrail(events));
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main();
+}

--- a/contrib/examples/policy-dry-run-harness/README.md
+++ b/contrib/examples/policy-dry-run-harness/README.md
@@ -1,0 +1,49 @@
+# Policy dry-run harness
+
+Evaluates a candidate `PolicyDefinition` against a list of sample
+transactions and reports pass/fail per transaction, with a human-readable
+reason for every failing check — useful for sanity-checking a policy body
+before it's ever deployed on-chain.
+
+## Checks applied
+
+For each transaction, in the order given:
+
+1. **Signer threshold** — `policy.threshold` vs. the transaction's `signerCount`.
+2. **Per-transaction limit** — `policy.spendingLimits.perTxXlm`.
+3. **Daily limit** — `policy.spendingLimits.dailyXlm`, tracked as a **running
+   total across the whole batch** in array order. A transaction that's fine
+   on its own can still fail here once earlier transactions in the batch have
+   used up the daily allowance.
+4. **Contract allowlist** — `policy.allowlistedContracts`, only checked when
+   the transaction has a `contractId` and the policy defines a non-empty list.
+
+A check that the policy doesn't define (e.g. no `threshold` field) is simply
+skipped. A transaction can fail more than one check at once — every failing
+reason is reported, not just the first.
+
+## Run it
+
+```sh
+npx tsx policy-dry-run-harness.ts
+```
+
+Expected output, against the sample policy (threshold 2, 200 XLM/tx, 500
+XLM/day, one allowlisted contract) and four sample transactions:
+
+```
+tx-1: PASS
+tx-2: FAIL
+  - Amount 250 XLM exceeds per-transaction limit of 200 XLM
+tx-3: FAIL
+  - Requires 2 signer(s); transaction has 1
+tx-4: FAIL
+  - Cumulative spend 680 XLM (including this transaction) exceeds daily limit of 500 XLM
+  - Contract CUNKNOWNCONTRACTXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX is not in the allowlist [CALLOWEDCONTRACTXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX]
+```
+
+## Tests
+
+```sh
+npx vitest run contrib/examples/policy-dry-run-harness
+```

--- a/contrib/examples/policy-dry-run-harness/policy-dry-run-harness.test.ts
+++ b/contrib/examples/policy-dry-run-harness/policy-dry-run-harness.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from "vitest";
+import { dryRunPolicy, type SampleTransaction } from "./policy-dry-run-harness";
+import type { PolicyDefinition } from "../../../src/types";
+
+const basePolicy: PolicyDefinition = {
+  version: "1",
+  type: "spending-limit",
+  owners: ["GA", "GB"],
+  threshold: 2,
+  spendingLimits: { dailyXlm: "500", perTxXlm: "200" },
+  allowlistedContracts: ["CALLOWED"],
+};
+
+describe("dryRunPolicy", () => {
+  it("passes a transaction that satisfies every check", () => {
+    const [result] = dryRunPolicy(basePolicy, [
+      { id: "tx-1", amountXlm: "100", signerCount: 2, contractId: "CALLOWED" },
+    ]);
+    expect(result).toEqual({ transactionId: "tx-1", passed: true, reasons: [] });
+  });
+
+  it("reports a per-transaction limit violation with a clear reason", () => {
+    const [result] = dryRunPolicy(basePolicy, [{ id: "tx-1", amountXlm: "250", signerCount: 2 }]);
+    expect(result?.passed).toBe(false);
+    expect(result?.reasons).toEqual([
+      "Amount 250 XLM exceeds per-transaction limit of 200 XLM",
+    ]);
+  });
+
+  it("reports a signer-threshold violation", () => {
+    const [result] = dryRunPolicy(basePolicy, [{ id: "tx-1", amountXlm: "50", signerCount: 1 }]);
+    expect(result?.passed).toBe(false);
+    expect(result?.reasons).toEqual(["Requires 2 signer(s); transaction has 1"]);
+  });
+
+  it("reports a non-allowlisted contract", () => {
+    const [result] = dryRunPolicy(basePolicy, [
+      { id: "tx-1", amountXlm: "50", signerCount: 2, contractId: "CNOTALLOWED" },
+    ]);
+    expect(result?.passed).toBe(false);
+    expect(result?.reasons).toEqual(["Contract CNOTALLOWED is not in the allowlist [CALLOWED]"]);
+  });
+
+  it("accumulates a running daily total across the batch, in order", () => {
+    // No per-tx limit here, isolating the daily-accumulation behavior:
+    // each transaction is individually fine, but the third pushes the
+    // running total over the daily limit.
+    const policy: PolicyDefinition = { ...basePolicy, spendingLimits: { dailyXlm: "500" } };
+    const transactions: SampleTransaction[] = [
+      { id: "tx-1", amountXlm: "200", signerCount: 2 },
+      { id: "tx-2", amountXlm: "200", signerCount: 2 },
+      { id: "tx-3", amountXlm: "200", signerCount: 2 }, // cumulative 600 > 500 daily limit
+    ];
+    const results = dryRunPolicy(policy, transactions);
+    expect(results[0]?.passed).toBe(true);
+    expect(results[1]?.passed).toBe(true);
+    expect(results[2]?.passed).toBe(false);
+    expect(results[2]?.reasons).toEqual([
+      "Cumulative spend 600 XLM (including this transaction) exceeds daily limit of 500 XLM",
+    ]);
+  });
+
+  it("reports every failing check for a transaction, not just the first", () => {
+    const policy: PolicyDefinition = {
+      ...basePolicy,
+      spendingLimits: { dailyXlm: "10", perTxXlm: "5" },
+    };
+    const [result] = dryRunPolicy(policy, [
+      { id: "tx-1", amountXlm: "20", signerCount: 1, contractId: "CNOTALLOWED" },
+    ]);
+    expect(result?.passed).toBe(false);
+    expect(result?.reasons).toHaveLength(4);
+  });
+
+  it("skips checks the policy does not define", () => {
+    const permissive: PolicyDefinition = { version: "1", type: "none", owners: ["GA"] };
+    const [result] = dryRunPolicy(permissive, [
+      { id: "tx-1", amountXlm: "1000000", signerCount: 0, contractId: "CANYTHING" },
+    ]);
+    expect(result).toEqual({ transactionId: "tx-1", passed: true, reasons: [] });
+  });
+});

--- a/contrib/examples/policy-dry-run-harness/policy-dry-run-harness.ts
+++ b/contrib/examples/policy-dry-run-harness/policy-dry-run-harness.ts
@@ -1,0 +1,138 @@
+// Example: a dry-run harness that evaluates a candidate PolicyDefinition
+// against a list of sample transactions and reports pass/fail with a reason
+// per failing check — useful for testing a policy body before deploying it.
+//
+// Run with: npx tsx policy-dry-run-harness.ts
+
+import type { PolicyDefinition } from "../../../src/types";
+
+/** A simplified transaction shape sufficient to evaluate the policy checks
+ * this harness understands (signer threshold, per-tx and daily spending
+ * limits, contract allowlist). Not a real Stellar transaction. */
+export interface SampleTransaction {
+  id: string;
+  amountXlm: string;
+  contractId?: string;
+  signerCount: number;
+}
+
+export interface DryRunResult {
+  transactionId: string;
+  passed: boolean;
+  /** Empty when passed. One entry per failing check, human-readable. */
+  reasons: string[];
+}
+
+// XLM has 7 decimal places (stroops); comparisons/sums are done as bigint
+// stroops so this never suffers float rounding on amount comparisons.
+const XLM_SCALE = 7;
+
+function toStroops(decimal: string): bigint {
+  const trimmed = decimal.trim();
+  if (!/^\d+(\.\d+)?$/.test(trimmed)) {
+    throw new Error(`"${decimal}" is not a valid decimal XLM amount`);
+  }
+  const [whole = "0", fraction = ""] = trimmed.split(".");
+  if (fraction.length > XLM_SCALE) {
+    throw new Error(`"${decimal}" has more than ${XLM_SCALE} decimal places`);
+  }
+  return BigInt(whole) * 10n ** BigInt(XLM_SCALE) + BigInt(fraction.padEnd(XLM_SCALE, "0") || "0");
+}
+
+function fromStroops(stroops: bigint): string {
+  const scale = 10n ** BigInt(XLM_SCALE);
+  const whole = stroops / scale;
+  const frac = (stroops % scale).toString().padStart(XLM_SCALE, "0").replace(/0+$/, "");
+  return frac ? `${whole}.${frac}` : `${whole}`;
+}
+
+/**
+ * Evaluates `transactions` in order against `policy`. Checks applied per
+ * transaction:
+ *   - signer threshold (policy.threshold vs. tx.signerCount)
+ *   - per-transaction spending limit (policy.spendingLimits.perTxXlm)
+ *   - cumulative daily spending limit (policy.spendingLimits.dailyXlm) —
+ *     tracked as a running total across the array, in the given order, so
+ *     an individually-fine transaction can still fail once earlier ones in
+ *     the batch have used up the daily allowance
+ *   - contract allowlist (policy.allowlistedContracts), when the tx has a
+ *     contractId and the policy defines a non-empty allowlist
+ *
+ * A transaction can fail more than one check; every failing reason is
+ * reported, not just the first.
+ */
+export function dryRunPolicy(policy: PolicyDefinition, transactions: SampleTransaction[]): DryRunResult[] {
+  const dailyLimit = policy.spendingLimits?.dailyXlm;
+  let cumulative = 0n;
+
+  return transactions.map((tx) => {
+    const reasons: string[] = [];
+
+    if (policy.threshold !== undefined && tx.signerCount < policy.threshold) {
+      reasons.push(`Requires ${policy.threshold} signer(s); transaction has ${tx.signerCount}`);
+    }
+
+    const perTxLimit = policy.spendingLimits?.perTxXlm;
+    if (perTxLimit !== undefined && toStroops(tx.amountXlm) > toStroops(perTxLimit)) {
+      reasons.push(`Amount ${tx.amountXlm} XLM exceeds per-transaction limit of ${perTxLimit} XLM`);
+    }
+
+    cumulative += toStroops(tx.amountXlm);
+    if (dailyLimit !== undefined && cumulative > toStroops(dailyLimit)) {
+      reasons.push(
+        `Cumulative spend ${fromStroops(cumulative)} XLM (including this transaction) exceeds daily limit of ${dailyLimit} XLM`,
+      );
+    }
+
+    if (
+      tx.contractId &&
+      policy.allowlistedContracts &&
+      policy.allowlistedContracts.length > 0 &&
+      !policy.allowlistedContracts.includes(tx.contractId)
+    ) {
+      reasons.push(
+        `Contract ${tx.contractId} is not in the allowlist [${policy.allowlistedContracts.join(", ")}]`,
+      );
+    }
+
+    return { transactionId: tx.id, passed: reasons.length === 0, reasons };
+  });
+}
+
+function samplePolicy(): PolicyDefinition {
+  return {
+    version: "1",
+    type: "spending-limit",
+    owners: ["GOWNER1XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX", "GOWNER2XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"],
+    threshold: 2,
+    spendingLimits: { dailyXlm: "500", perTxXlm: "200" },
+    allowlistedContracts: ["CALLOWEDCONTRACTXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"],
+  };
+}
+
+function sampleTransactions(): SampleTransaction[] {
+  return [
+    { id: "tx-1", amountXlm: "100", signerCount: 2, contractId: "CALLOWEDCONTRACTXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX" },
+    { id: "tx-2", amountXlm: "250", signerCount: 2 }, // exceeds per-tx limit
+    { id: "tx-3", amountXlm: "150", signerCount: 1 }, // under threshold
+    { id: "tx-4", amountXlm: "180", signerCount: 2, contractId: "CUNKNOWNCONTRACTXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX" }, // not allowlisted, and pushes daily total over 500
+  ];
+}
+
+function main() {
+  const results = dryRunPolicy(samplePolicy(), sampleTransactions());
+  for (const result of results) {
+    if (result.passed) {
+      console.log(`${result.transactionId}: PASS`);
+    } else {
+      console.log(`${result.transactionId}: FAIL`);
+      for (const reason of result.reasons) {
+        console.log(`  - ${reason}`);
+      }
+    }
+  }
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main();
+}

--- a/contrib/examples/policy-limit-recommender/README.md
+++ b/contrib/examples/policy-limit-recommender/README.md
@@ -1,0 +1,65 @@
+# Policy limit recommendation helper
+
+`recommendSpendingLimit()` suggests a spending limit value from a sample of
+an account's recent payment history, using a simple percentile-style
+calculation plus a headroom multiplier. It's an advisory number for a human
+to review before setting a real policy's `spendingLimits` value (see
+`src/types.ts`'s `PolicyDefinition`) — not a payment amount itself, so this
+example works in plain numbers rather than the fixed-point/bigint arithmetic
+other examples use for actual on-chain amounts.
+
+## The calculation
+
+1. Sort the sample ascending.
+2. Take the **90th percentile** (nearest-rank method) as the baseline —
+   "at or above 90% of past payments". Using a percentile instead of the raw
+   maximum means a single unusually large outlier payment doesn't single-handedly
+   set the limit.
+3. Multiply that baseline by a **1.5x headroom multiplier**, so the
+   recommended limit isn't a razor's edge against typical spend.
+
+Both the percentile and the headroom multiplier are configurable via
+`RecommendationOptions`.
+
+## Usage
+
+```ts
+import { recommendSpendingLimit } from "./policy-limit-recommender";
+
+const recommendation = recommendSpendingLimit([12, 8, 45, 15, 9, 60, 11, 14, 10, 13]);
+// {
+//   sampleSize: 10,
+//   percentile: 90,
+//   percentileValue: 45,
+//   headroomMultiplier: 1.5,
+//   recommendedLimit: 67.5,
+// }
+
+// Custom percentile / multiplier:
+recommendSpendingLimit(history, { percentile: 75, headroomMultiplier: 2 });
+```
+
+Throws for an empty sample, a negative or non-finite amount, or a percentile
+outside `(0, 100]` — a silently wrong recommendation would be worse than a
+loud failure here.
+
+## Run it
+
+```sh
+npx tsx policy-limit-recommender.ts
+```
+
+Expected output:
+
+```
+Sample: 10 payments
+P90 of sample: 45
+Headroom multiplier: 1.5x
+Recommended spending limit: 67.5
+```
+
+## Tests
+
+```sh
+npx vitest run contrib/examples/policy-limit-recommender
+```

--- a/contrib/examples/policy-limit-recommender/policy-limit-recommender.test.ts
+++ b/contrib/examples/policy-limit-recommender/policy-limit-recommender.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+import { recommendSpendingLimit } from "./policy-limit-recommender";
+
+describe("recommendSpendingLimit", () => {
+  it("uses the 90th percentile with 1.5x headroom by default", () => {
+    const amounts = [12, 8, 45, 15, 9, 60, 11, 14, 10, 13]; // sorted: 8 9 10 11 12 13 14 15 45 60
+    const result = recommendSpendingLimit(amounts);
+    expect(result.percentile).toBe(90);
+    expect(result.percentileValue).toBe(45); // rank = ceil(0.9*10) = 9 -> index 8 -> 45
+    expect(result.headroomMultiplier).toBe(1.5);
+    expect(result.recommendedLimit).toBe(67.5);
+    expect(result.sampleSize).toBe(10);
+  });
+
+  it("honors a custom percentile", () => {
+    const amounts = [10, 20, 30, 40, 50];
+    const result = recommendSpendingLimit(amounts, { percentile: 50 });
+    expect(result.percentileValue).toBe(30); // rank = ceil(0.5*5) = 3 -> index 2 -> 30
+  });
+
+  it("honors a custom headroom multiplier", () => {
+    const amounts = [100];
+    const result = recommendSpendingLimit(amounts, { headroomMultiplier: 2 });
+    expect(result.recommendedLimit).toBe(200);
+  });
+
+  it("uses the single value for a sample of one", () => {
+    const result = recommendSpendingLimit([42]);
+    expect(result.percentileValue).toBe(42);
+    expect(result.recommendedLimit).toBe(63);
+  });
+
+  it("does not mutate the input array", () => {
+    const amounts = [30, 10, 20];
+    recommendSpendingLimit(amounts);
+    expect(amounts).toEqual([30, 10, 20]);
+  });
+
+  it("throws for an empty sample", () => {
+    expect(() => recommendSpendingLimit([])).toThrow(/at least one historical payment/);
+  });
+
+  it("throws for a negative amount", () => {
+    expect(() => recommendSpendingLimit([10, -5])).toThrow(/not a valid non-negative payment amount/);
+  });
+
+  it("throws for a non-finite amount", () => {
+    expect(() => recommendSpendingLimit([10, Infinity])).toThrow(/not a valid non-negative payment amount/);
+  });
+
+  it("throws for a percentile of 0", () => {
+    expect(() => recommendSpendingLimit([10], { percentile: 0 })).toThrow(/percentile must be in/);
+  });
+
+  it("throws for a percentile above 100", () => {
+    expect(() => recommendSpendingLimit([10], { percentile: 101 })).toThrow(/percentile must be in/);
+  });
+});

--- a/contrib/examples/policy-limit-recommender/policy-limit-recommender.ts
+++ b/contrib/examples/policy-limit-recommender/policy-limit-recommender.ts
@@ -1,0 +1,87 @@
+// Example: suggest a spending limit value from a sample of an account's
+// recent payment history, using a simple percentile-style calculation plus
+// a headroom multiplier.
+//
+// This is an advisory number for a human to review before setting a real
+// policy.spendingLimits value (see src/types.ts's PolicyDefinition) — not a
+// payment amount itself, so plain numbers are fine here (contrast with
+// src/payments.ts's parseTokenAmount, which avoids floats because it
+// touches actual on-chain amounts).
+//
+// Run with: npx tsx policy-limit-recommender.ts
+
+export interface RecommendationOptions {
+  /** Percentile (0-100] of the sorted historical sample to use as the
+   * baseline before headroom is applied. Default: 90. */
+  percentile?: number;
+  /** Multiplier applied to the percentile value for headroom above typical
+   * spend. Default: 1.5. */
+  headroomMultiplier?: number;
+}
+
+export interface LimitRecommendation {
+  sampleSize: number;
+  percentile: number;
+  percentileValue: number;
+  headroomMultiplier: number;
+  recommendedLimit: number;
+}
+
+const DEFAULT_PERCENTILE = 90;
+const DEFAULT_HEADROOM_MULTIPLIER = 1.5;
+
+/** Nearest-rank percentile of a sample sorted ascending. */
+function percentileOf(sortedAmounts: number[], percentile: number): number {
+  const rank = Math.ceil((percentile / 100) * sortedAmounts.length);
+  const index = Math.min(Math.max(rank, 1), sortedAmounts.length) - 1;
+  return sortedAmounts[index]!;
+}
+
+/**
+ * Recommends a spending limit from a sample of historical payment amounts:
+ * takes the `percentile`-th value of the sorted sample (default 90th — "at
+ * or above 90% of past payments", which drops extreme outliers like a
+ * single unusually large payment), then multiplies it by
+ * `headroomMultiplier` (default 1.5x) so the limit isn't a razor's edge
+ * against typical activity.
+ */
+export function recommendSpendingLimit(
+  amounts: number[],
+  options: RecommendationOptions = {},
+): LimitRecommendation {
+  if (amounts.length === 0) {
+    throw new Error("amounts must contain at least one historical payment");
+  }
+  for (const amount of amounts) {
+    if (!Number.isFinite(amount) || amount < 0) {
+      throw new Error(`"${amount}" is not a valid non-negative payment amount`);
+    }
+  }
+
+  const percentile = options.percentile ?? DEFAULT_PERCENTILE;
+  if (percentile <= 0 || percentile > 100) {
+    throw new Error(`percentile must be in (0, 100], got ${percentile}`);
+  }
+  const headroomMultiplier = options.headroomMultiplier ?? DEFAULT_HEADROOM_MULTIPLIER;
+
+  const sorted = [...amounts].sort((a, b) => a - b);
+  const percentileValue = percentileOf(sorted, percentile);
+  const recommendedLimit = percentileValue * headroomMultiplier;
+
+  return { sampleSize: amounts.length, percentile, percentileValue, headroomMultiplier, recommendedLimit };
+}
+
+function main() {
+  const recentPayments = [12, 8, 45, 15, 9, 60, 11, 14, 10, 13];
+
+  const recommendation = recommendSpendingLimit(recentPayments);
+
+  console.log(`Sample: ${recommendation.sampleSize} payments`);
+  console.log(`P${recommendation.percentile} of sample: ${recommendation.percentileValue}`);
+  console.log(`Headroom multiplier: ${recommendation.headroomMultiplier}x`);
+  console.log(`Recommended spending limit: ${recommendation.recommendedLimit}`);
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main();
+}

--- a/contrib/examples/policy-migration-dry-run/README.md
+++ b/contrib/examples/policy-migration-dry-run/README.md
@@ -1,0 +1,47 @@
+# Policy migration dry run
+
+Previews what an old-style (pre-v1) policy configuration would look like
+migrated to the current `PolicyDefinition` shape (`src/types.ts`), **without
+applying anything**. Reports any old fields that have no equivalent in the
+new shape, so a caller can decide what to do with them before migrating for
+real.
+
+## Field mapping
+
+| Old field | New field | Notes |
+| --- | --- | --- |
+| `policyOwner` (single string) | `owners` (`string[]`) | Wrapped in a single-element array — the new shape supports multiple owners, the old one didn't. |
+| `dailyLimit` | `spendingLimits.dailyXlm` | |
+| `perTxLimit` | `spendingLimits.perTxXlm` | |
+| `allowedContracts` | `allowlistedContracts` | |
+| `adminDelaySeconds` | `timelocks.adminActionDelaySeconds` | |
+| `legacyFlag` | *(none)* | Every policy is now versioned by its deployed contract wasm hash instead. Dropped. |
+| `notes` | *(none)* | Free-text notes had no structured home in the old shape either. Dropped. |
+
+## Run it
+
+```sh
+npx tsx policy-migration-dry-run.ts
+```
+
+Expected output (against the sample old config with all fields, including
+the two unmapped ones):
+
+```
+Migration preview: {
+  version: '1',
+  type: 'spending-limit',
+  owners: [ 'GOWNERAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF' ],
+  spendingLimits: { dailyXlm: '100', perTxXlm: '20' },
+  allowlistedContracts: [ 'CUSDCAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA' ],
+  timelocks: { adminActionDelaySeconds: 3600 }
+}
+
+Unmapped fields (dropped, no equivalent in the new shape): [ 'legacyFlag', 'notes' ]
+```
+
+## Tests
+
+```sh
+npx vitest run contrib/examples/policy-migration-dry-run
+```

--- a/contrib/examples/policy-migration-dry-run/policy-migration-dry-run.test.ts
+++ b/contrib/examples/policy-migration-dry-run/policy-migration-dry-run.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+import { previewMigration } from "./policy-migration-dry-run";
+
+describe("previewMigration", () => {
+  it("wraps policyOwner in the owners array", () => {
+    const { preview } = previewMigration({ policyOwner: "GOWNER" });
+    expect(preview.owners).toEqual(["GOWNER"]);
+    expect(preview.version).toBe("1");
+    expect(preview.type).toBe("spending-limit");
+  });
+
+  it("maps dailyLimit/perTxLimit into spendingLimits", () => {
+    const { preview } = previewMigration({ policyOwner: "GOWNER", dailyLimit: "100", perTxLimit: "20" });
+    expect(preview.spendingLimits).toEqual({ dailyXlm: "100", perTxXlm: "20" });
+  });
+
+  it("maps allowedContracts into allowlistedContracts", () => {
+    const { preview } = previewMigration({ policyOwner: "GOWNER", allowedContracts: ["CUSDC"] });
+    expect(preview.allowlistedContracts).toEqual(["CUSDC"]);
+  });
+
+  it("maps adminDelaySeconds into timelocks", () => {
+    const { preview } = previewMigration({ policyOwner: "GOWNER", adminDelaySeconds: 3600 });
+    expect(preview.timelocks).toEqual({ adminActionDelaySeconds: 3600 });
+  });
+
+  it("reports fields with no equivalent in the new shape", () => {
+    const { unmappedFields } = previewMigration({
+      policyOwner: "GOWNER",
+      legacyFlag: true,
+      notes: "some notes",
+    });
+    expect(unmappedFields).toEqual(["legacyFlag", "notes"]);
+  });
+
+  it("reports no unmapped fields when only mapped fields are present", () => {
+    const { unmappedFields } = previewMigration({ policyOwner: "GOWNER", dailyLimit: "100" });
+    expect(unmappedFields).toEqual([]);
+  });
+
+  it("omits spendingLimits/allowlistedContracts/timelocks entirely when the old config lacks them", () => {
+    const { preview } = previewMigration({ policyOwner: "GOWNER" });
+    expect(preview.spendingLimits).toBeUndefined();
+    expect(preview.allowlistedContracts).toBeUndefined();
+    expect(preview.timelocks).toBeUndefined();
+  });
+});

--- a/contrib/examples/policy-migration-dry-run/policy-migration-dry-run.ts
+++ b/contrib/examples/policy-migration-dry-run/policy-migration-dry-run.ts
@@ -1,0 +1,93 @@
+// Example: preview what an old-style (pre-v1) policy configuration would
+// look like migrated to the current PolicyDefinition shape (src/types.ts),
+// without applying anything. Reports any old fields that have no
+// equivalent in the new shape, so a caller can decide what to do with them
+// before actually migrating.
+//
+// Field mapping (documented — see the README for the full table):
+//   policyOwner (string)     -> owners (string[], wrapped in an array)
+//   dailyLimit                -> spendingLimits.dailyXlm
+//   perTxLimit                -> spendingLimits.perTxXlm
+//   allowedContracts           -> allowlistedContracts
+//   adminDelaySeconds          -> timelocks.adminActionDelaySeconds
+//   legacyFlag, notes          -> no equivalent (reported as unmapped)
+//
+// Run with: npx tsx policy-migration-dry-run.ts
+
+import type { PolicyDefinition } from "../../../src/types";
+
+export interface OldPolicyConfig {
+  policyOwner: string;
+  dailyLimit?: string;
+  perTxLimit?: string;
+  allowedContracts?: string[];
+  adminDelaySeconds?: number;
+  /** No longer meaningful — every policy is versioned by contract wasm now. */
+  legacyFlag?: boolean;
+  /** Free-text notes had no structured home in the old shape either; still none in the new one. */
+  notes?: string;
+}
+
+export interface MigrationPreview {
+  preview: PolicyDefinition;
+  unmappedFields: string[];
+}
+
+const MAPPED_OLD_FIELDS = new Set([
+  "policyOwner",
+  "dailyLimit",
+  "perTxLimit",
+  "allowedContracts",
+  "adminDelaySeconds",
+]);
+
+/** Builds a preview of the migrated PolicyDefinition, plus a list of old
+ * fields that had no equivalent and were dropped. Does not mutate or
+ * persist anything — purely a dry-run preview. */
+export function previewMigration(old: OldPolicyConfig): MigrationPreview {
+  const preview: PolicyDefinition = {
+    version: "1",
+    type: "spending-limit",
+    owners: [old.policyOwner],
+  };
+
+  if (old.dailyLimit !== undefined || old.perTxLimit !== undefined) {
+    preview.spendingLimits = {
+      ...(old.dailyLimit !== undefined && { dailyXlm: old.dailyLimit }),
+      ...(old.perTxLimit !== undefined && { perTxXlm: old.perTxLimit }),
+    };
+  }
+  if (old.allowedContracts !== undefined) {
+    preview.allowlistedContracts = old.allowedContracts;
+  }
+  if (old.adminDelaySeconds !== undefined) {
+    preview.timelocks = { adminActionDelaySeconds: old.adminDelaySeconds };
+  }
+
+  const unmappedFields = Object.entries(old)
+    .filter(([key, value]) => !MAPPED_OLD_FIELDS.has(key) && value !== undefined)
+    .map(([key]) => key);
+
+  return { preview, unmappedFields };
+}
+
+function main() {
+  const sampleOldConfig: OldPolicyConfig = {
+    policyOwner: "GOWNERAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF",
+    dailyLimit: "100",
+    perTxLimit: "20",
+    allowedContracts: ["CUSDCAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"],
+    adminDelaySeconds: 3600,
+    legacyFlag: true,
+    notes: "Migrated from the v0 policy service",
+  };
+
+  const { preview, unmappedFields } = previewMigration(sampleOldConfig);
+  console.log("Migration preview:", preview);
+  console.log();
+  console.log("Unmapped fields (dropped, no equivalent in the new shape):", unmappedFields);
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main();
+}

--- a/contrib/examples/policy-simulation-batch-runner/README.md
+++ b/contrib/examples/policy-simulation-batch-runner/README.md
@@ -1,0 +1,43 @@
+# Policy simulation batch runner
+
+Simulates a candidate spending-limit policy against a batch of sample
+transactions all at once — a local evaluation (no network call) against the
+policy's `spendingLimits` and `allowlistedContracts` — and summarizes total
+pass/fail counts with a reason for each failure.
+
+## How it evaluates a transaction
+
+For each transaction, in this order:
+
+1. **Per-transaction limit** — fails if `amountXlm` exceeds
+   `spendingLimits.perTxXlm`.
+2. **Allowlist** — fails if the transaction has a `contractId` and
+   `allowlistedContracts` is set but doesn't include it.
+3. **Cumulative daily limit** — fails if adding this transaction's amount to
+   the running daily total (of previously *passed* transactions only) would
+   exceed `spendingLimits.dailyXlm`.
+
+A failed transaction's amount is never added to the running daily total —
+only passed transactions accumulate.
+
+## Run it
+
+```sh
+npx tsx batch-runner.ts
+```
+
+Expected output (5 sample transactions against a 200 XLM per-tx / 300 XLM
+daily / one-contract-allowlist policy):
+
+```
+Batch summary: 2/5 passed, 3/5 failed
+  FAIL tx-2: amount 250 XLM exceeds per-transaction limit 200 XLM
+  FAIL tx-3: contract CNOTALLOWLISTEDXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX is not in the allowlisted contracts
+  FAIL tx-5: cumulative daily total 350.00 XLM would exceed daily limit 300 XLM
+```
+
+## Tests
+
+```sh
+npx vitest run contrib/examples/policy-simulation-batch-runner
+```

--- a/contrib/examples/policy-simulation-batch-runner/batch-runner.test.ts
+++ b/contrib/examples/policy-simulation-batch-runner/batch-runner.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from "vitest";
+import type { PolicyDefinition } from "../../../src/types";
+import { runPolicySimulationBatch, type SampleTransaction } from "./batch-runner";
+
+describe("runPolicySimulationBatch", () => {
+  const policy: PolicyDefinition = {
+    version: "1",
+    type: "spending-limit",
+    owners: ["GOWNER"],
+    spendingLimits: { dailyXlm: "300", perTxXlm: "200" },
+    allowlistedContracts: ["CALLOWED"],
+  };
+
+  it("passes transactions within both the per-tx and daily limits", () => {
+    const transactions: SampleTransaction[] = [
+      { id: "tx-1", amountXlm: "100" },
+      { id: "tx-2", amountXlm: "150" },
+    ];
+    const result = runPolicySimulationBatch(policy, transactions);
+    expect(result).toEqual({ total: 2, passed: 2, failed: 0, failures: [] });
+  });
+
+  it("fails a transaction over the per-tx limit", () => {
+    const result = runPolicySimulationBatch(policy, [{ id: "tx-1", amountXlm: "250" }]);
+    expect(result.passed).toBe(0);
+    expect(result.failed).toBe(1);
+    expect(result.failures[0]).toEqual({
+      id: "tx-1",
+      reason: "amount 250 XLM exceeds per-transaction limit 200 XLM",
+    });
+  });
+
+  it("fails a transaction to a non-allowlisted contract", () => {
+    const result = runPolicySimulationBatch(policy, [
+      { id: "tx-1", amountXlm: "10", contractId: "CBADCONTRACT" },
+    ]);
+    expect(result.failures[0]).toEqual({
+      id: "tx-1",
+      reason: "contract CBADCONTRACT is not in the allowlisted contracts",
+    });
+  });
+
+  it("passes a transaction to an allowlisted contract", () => {
+    const result = runPolicySimulationBatch(policy, [
+      { id: "tx-1", amountXlm: "10", contractId: "CALLOWED" },
+    ]);
+    expect(result.passed).toBe(1);
+    expect(result.failed).toBe(0);
+  });
+
+  it("fails once the cumulative daily total would be exceeded, without double counting the failed amount", () => {
+    const transactions: SampleTransaction[] = [
+      { id: "tx-1", amountXlm: "200" },
+      { id: "tx-2", amountXlm: "150" }, // 200 + 150 = 350 > 300 daily limit
+      { id: "tx-3", amountXlm: "50" }, // 200 + 50 = 250 <= 300: passes, since tx-2's amount was never added
+    ];
+    const result = runPolicySimulationBatch(policy, transactions);
+    expect(result.passed).toBe(2);
+    expect(result.failed).toBe(1);
+    expect(result.failures[0]?.id).toBe("tx-2");
+    expect(result.failures[0]?.reason).toContain("exceed daily limit");
+  });
+
+  it("returns an empty summary for an empty batch", () => {
+    expect(runPolicySimulationBatch(policy, [])).toEqual({
+      total: 0,
+      passed: 0,
+      failed: 0,
+      failures: [],
+    });
+  });
+});

--- a/contrib/examples/policy-simulation-batch-runner/batch-runner.ts
+++ b/contrib/examples/policy-simulation-batch-runner/batch-runner.ts
@@ -1,0 +1,97 @@
+// Example: simulate a candidate spending-limit policy against a batch of
+// sample transactions all at once (no network call — a local evaluation
+// against the policy's spendingLimits/allowlistedContracts), and summarize
+// pass/fail counts with a reason for each failure.
+//
+// Run with: npx tsx batch-runner.ts
+
+import type { PolicyDefinition } from "../../../src/types";
+
+export interface SampleTransaction {
+  id: string;
+  /** Payment amount in whole XLM, as a decimal string. */
+  amountXlm: string;
+  /** Destination contract, when the transaction is a contract invocation. */
+  contractId?: string;
+}
+
+export interface BatchResult {
+  total: number;
+  passed: number;
+  failed: number;
+  failures: Array<{ id: string; reason: string }>;
+}
+
+/**
+ * Evaluates each transaction against the policy's per-tx limit, allowlist,
+ * and cumulative daily limit (in that order — the first violated rule is the
+ * reported reason). Transactions are evaluated in array order, and the daily
+ * total accumulates only over transactions that pass the earlier checks.
+ */
+export function runPolicySimulationBatch(
+  policy: PolicyDefinition,
+  transactions: SampleTransaction[],
+): BatchResult {
+  const perTxLimit = policy.spendingLimits?.perTxXlm
+    ? Number(policy.spendingLimits.perTxXlm)
+    : undefined;
+  const dailyLimit = policy.spendingLimits?.dailyXlm
+    ? Number(policy.spendingLimits.dailyXlm)
+    : undefined;
+  const allowlist = policy.allowlistedContracts;
+
+  const failures: BatchResult["failures"] = [];
+  let passed = 0;
+  let dailyTotal = 0;
+
+  for (const tx of transactions) {
+    const amount = Number(tx.amountXlm);
+    let reason: string | undefined;
+
+    if (perTxLimit !== undefined && amount > perTxLimit) {
+      reason = `amount ${tx.amountXlm} XLM exceeds per-transaction limit ${policy.spendingLimits!.perTxXlm} XLM`;
+    } else if (allowlist && allowlist.length > 0 && tx.contractId && !allowlist.includes(tx.contractId)) {
+      reason = `contract ${tx.contractId} is not in the allowlisted contracts`;
+    } else if (dailyLimit !== undefined && dailyTotal + amount > dailyLimit) {
+      reason = `cumulative daily total ${(dailyTotal + amount).toFixed(2)} XLM would exceed daily limit ${policy.spendingLimits!.dailyXlm} XLM`;
+    }
+
+    if (reason) {
+      failures.push({ id: tx.id, reason });
+    } else {
+      passed++;
+      dailyTotal += amount;
+    }
+  }
+
+  return { total: transactions.length, passed, failed: failures.length, failures };
+}
+
+function main() {
+  const samplePolicy: PolicyDefinition = {
+    version: "1",
+    type: "spending-limit",
+    owners: ["GOWNERAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF"],
+    spendingLimits: { dailyXlm: "300", perTxXlm: "200" },
+    allowlistedContracts: ["CUSDCAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"],
+  };
+
+  const sampleTransactions: SampleTransaction[] = [
+    { id: "tx-1", amountXlm: "100" }, // passes; daily total now 100
+    { id: "tx-2", amountXlm: "250" }, // fails: exceeds the 200 XLM per-tx limit
+    { id: "tx-3", amountXlm: "50", contractId: "CNOTALLOWLISTEDXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX" }, // fails: contract not allowlisted
+    { id: "tx-4", amountXlm: "150", contractId: "CUSDCAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA" }, // passes; daily total now 250
+    { id: "tx-5", amountXlm: "100" }, // fails: 250 + 100 = 350 exceeds the 300 XLM daily limit
+  ];
+
+  const result = runPolicySimulationBatch(samplePolicy, sampleTransactions);
+
+  console.log(`Batch summary: ${result.passed}/${result.total} passed, ${result.failed}/${result.total} failed`);
+  for (const failure of result.failures) {
+    console.log(`  FAIL ${failure.id}: ${failure.reason}`);
+  }
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main();
+}

--- a/contrib/examples/policy-summary-card/README.md
+++ b/contrib/examples/policy-summary-card/README.md
@@ -1,0 +1,31 @@
+# Policy summary card
+
+Formats a policy record as a multi-line text summary suitable for printing
+in a terminal — e.g. a CLI listing a wallet's attached policies. Includes the
+policy id, type, limit, and window; a policy missing the optional `limit`
+and/or `window` fields (e.g. a `signer-limits` policy with no spending cap)
+omits those lines cleanly instead of printing them blank.
+
+## Run it
+
+```sh
+npx tsx policy-summary-card.ts
+```
+
+Expected output:
+
+```
+Policy ID: policy_7f3a9c2e
+Type:      spending-limit
+Limit:     100 XLM/day
+Window:    24h
+
+Policy ID: policy_a1b2c3d4
+Type:      signer-limits
+```
+
+## Tests
+
+```sh
+npx vitest run contrib/examples/policy-summary-card
+```

--- a/contrib/examples/policy-summary-card/policy-summary-card.test.ts
+++ b/contrib/examples/policy-summary-card/policy-summary-card.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+import { formatPolicySummaryCard } from "./policy-summary-card";
+
+describe("formatPolicySummaryCard", () => {
+  it("includes id, type, limit, and window when all are present", () => {
+    const card = formatPolicySummaryCard({
+      id: "policy_1",
+      type: "spending-limit",
+      limit: "100 XLM/day",
+      window: "24h",
+    });
+    expect(card).toBe(
+      ["Policy ID: policy_1", "Type:      spending-limit", "Limit:     100 XLM/day", "Window:    24h"].join("\n"),
+    );
+  });
+
+  it("omits the limit and window lines cleanly when absent", () => {
+    const card = formatPolicySummaryCard({ id: "policy_2", type: "signer-limits" });
+    expect(card).toBe("Policy ID: policy_2\nType:      signer-limits");
+    expect(card).not.toContain("Limit:");
+    expect(card).not.toContain("Window:");
+  });
+
+  it("omits only the window line when limit is present but window is not", () => {
+    const card = formatPolicySummaryCard({ id: "policy_3", type: "spending-limit", limit: "50 XLM/tx" });
+    expect(card).toContain("Limit:     50 XLM/tx");
+    expect(card).not.toContain("Window:");
+  });
+});

--- a/contrib/examples/policy-summary-card/policy-summary-card.ts
+++ b/contrib/examples/policy-summary-card/policy-summary-card.ts
@@ -1,0 +1,50 @@
+// Example: format a policy record as a multi-line text summary suitable for
+// printing in a terminal (e.g. a CLI listing a wallet's attached policies).
+//
+// Run with: npx tsx policy-summary-card.ts
+
+export interface PolicyRecord {
+  id: string;
+  type: string;
+  /** Human-readable spending limit, e.g. "100 XLM/day". Omitted if the
+   * policy has no spending limit (e.g. a signer-limits-only policy). */
+  limit?: string;
+  /** Human-readable rolling window, e.g. "24h". Omitted along with `limit`
+   * when there's no windowed limit to describe. */
+  window?: string;
+}
+
+/** Formats a policy record as a labelled multi-line card. Missing optional
+ * fields (limit, window) are omitted as whole lines, not printed blank. */
+export function formatPolicySummaryCard(policy: PolicyRecord): string {
+  const lines = [`Policy ID: ${policy.id}`, `Type:      ${policy.type}`];
+  if (policy.limit !== undefined) {
+    lines.push(`Limit:     ${policy.limit}`);
+  }
+  if (policy.window !== undefined) {
+    lines.push(`Window:    ${policy.window}`);
+  }
+  return lines.join("\n");
+}
+
+function main() {
+  const withLimits: PolicyRecord = {
+    id: "policy_7f3a9c2e",
+    type: "spending-limit",
+    limit: "100 XLM/day",
+    window: "24h",
+  };
+
+  const withoutLimits: PolicyRecord = {
+    id: "policy_a1b2c3d4",
+    type: "signer-limits",
+  };
+
+  console.log(formatPolicySummaryCard(withLimits));
+  console.log();
+  console.log(formatPolicySummaryCard(withoutLimits));
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main();
+}

--- a/contrib/examples/poll-until-final/README.md
+++ b/contrib/examples/poll-until-final/README.md
@@ -1,0 +1,27 @@
+# Poll a transaction hash until finality
+
+Polls a status function for a transaction hash on an interval until it
+reports `"success"` or `"failed"`, or rejects with `PollTimeoutError` once a
+maximum number of attempts is exhausted.
+
+## Run it
+
+```sh
+npx tsx poll-until-final.ts
+```
+
+Uses a mock status function that reports `"pending"` for the first two calls
+and `"success"` on the third:
+
+```
+Final status after 3 calls: success
+```
+
+## Tests
+
+Uses a mock status function and an injected no-op `sleep`, so the tests run
+instantly with no real delays:
+
+```sh
+npx vitest run contrib/examples/poll-until-final
+```

--- a/contrib/examples/poll-until-final/poll-until-final.test.ts
+++ b/contrib/examples/poll-until-final/poll-until-final.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it, vi } from "vitest";
+import { PollTimeoutError, pollUntilFinal, type StatusFn } from "./poll-until-final";
+
+const noSleep = vi.fn(async () => {});
+
+describe("pollUntilFinal", () => {
+  it("resolves as soon as a non-pending status is seen", async () => {
+    let calls = 0;
+    const getStatus: StatusFn = async () => {
+      calls++;
+      return calls < 3 ? "pending" : "success";
+    };
+
+    const result = await pollUntilFinal(getStatus, "hash", {
+      intervalMs: 10,
+      maxAttempts: 5,
+      sleep: noSleep,
+    });
+
+    expect(result).toBe("success");
+    expect(calls).toBe(3);
+  });
+
+  it("resolves with 'failed' when that's the reported status", async () => {
+    const getStatus: StatusFn = async () => "failed";
+    await expect(
+      pollUntilFinal(getStatus, "hash", { intervalMs: 10, maxAttempts: 3, sleep: noSleep }),
+    ).resolves.toBe("failed");
+  });
+
+  it("rejects with PollTimeoutError once attempts are exhausted", async () => {
+    const getStatus: StatusFn = async () => "pending";
+    await expect(
+      pollUntilFinal(getStatus, "hash", { intervalMs: 10, maxAttempts: 3, sleep: noSleep }),
+    ).rejects.toThrow(PollTimeoutError);
+  });
+
+  it("calls getStatus exactly maxAttempts times when never final", async () => {
+    let calls = 0;
+    const getStatus: StatusFn = async () => {
+      calls++;
+      return "pending";
+    };
+    await expect(
+      pollUntilFinal(getStatus, "hash", { intervalMs: 10, maxAttempts: 4, sleep: noSleep }),
+    ).rejects.toThrow();
+    expect(calls).toBe(4);
+  });
+
+  it("does not sleep after the final attempt", async () => {
+    const sleep = vi.fn(async () => {});
+    const getStatus: StatusFn = async () => "pending";
+    await expect(
+      pollUntilFinal(getStatus, "hash", { intervalMs: 10, maxAttempts: 3, sleep }),
+    ).rejects.toThrow();
+    expect(sleep).toHaveBeenCalledTimes(2);
+  });
+});

--- a/contrib/examples/poll-until-final/poll-until-final.ts
+++ b/contrib/examples/poll-until-final/poll-until-final.ts
@@ -1,0 +1,63 @@
+// Example: poll a status function for a transaction hash on an interval
+// until it reports a final ("success" | "failed") status, or reject once a
+// maximum number of attempts is exhausted.
+//
+// Run with: npx tsx poll-until-final.ts
+
+export type TxStatus = "pending" | "success" | "failed";
+export type StatusFn = (hash: string) => Promise<TxStatus>;
+
+export class PollTimeoutError extends Error {
+  constructor(hash: string, maxAttempts: number) {
+    super(`Transaction ${hash} was still pending after ${maxAttempts} attempts`);
+    this.name = "PollTimeoutError";
+  }
+}
+
+export interface PollOptions {
+  intervalMs: number;
+  maxAttempts: number;
+  /** Injectable sleep, so tests can run without real delays. */
+  sleep?: (ms: number) => Promise<void>;
+}
+
+/**
+ * Calls `getStatus(hash)` up to `maxAttempts` times, waiting `intervalMs`
+ * between attempts. Resolves as soon as a non-pending status is seen;
+ * rejects with PollTimeoutError if every attempt returns "pending".
+ */
+export async function pollUntilFinal(
+  getStatus: StatusFn,
+  hash: string,
+  options: PollOptions,
+): Promise<"success" | "failed"> {
+  const sleep = options.sleep ?? ((ms) => new Promise<void>((resolve) => setTimeout(resolve, ms)));
+
+  for (let attempt = 1; attempt <= options.maxAttempts; attempt++) {
+    const status = await getStatus(hash);
+    if (status !== "pending") return status;
+    if (attempt < options.maxAttempts) {
+      await sleep(options.intervalMs);
+    }
+  }
+  throw new PollTimeoutError(hash, options.maxAttempts);
+}
+
+async function main() {
+  // A mock status function: pending for the first two calls, then success.
+  let calls = 0;
+  const mockGetStatus: StatusFn = async () => {
+    calls++;
+    return calls < 3 ? "pending" : "success";
+  };
+
+  const result = await pollUntilFinal(mockGetStatus, "mock-tx-hash", {
+    intervalMs: 50,
+    maxAttempts: 5,
+  });
+  console.log(`Final status after ${calls} calls: ${result}`);
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main();
+}

--- a/contrib/examples/print-session/README.md
+++ b/contrib/examples/print-session/README.md
@@ -1,0 +1,35 @@
+# Print a wallet session
+
+Pretty-prints a `WalletSession` object's fields to the console with clear
+labels, using a hardcoded sample session.
+
+## The WalletSession shape
+
+From `vellar-sdk`'s `src/types.ts`:
+
+```ts
+interface WalletSession {
+  accountId: string;
+  network: "testnet" | "mainnet";
+  connected: boolean;
+  authMethod: "passkey";
+  createdAt: string;   // ISO timestamp
+  lastActiveAt: string; // ISO timestamp
+  serverSessionId?: string; // present after a real create()/connect()
+  keyId?: string;            // present after a real create()/connect()
+}
+```
+
+`serverSessionId` and `keyId` are optional — printed as `(none)` when absent.
+
+## Run it
+
+```sh
+npx tsx print-session.ts
+```
+
+## Tests
+
+```sh
+npx vitest run contrib/examples/print-session
+```

--- a/contrib/examples/print-session/print-session.test.ts
+++ b/contrib/examples/print-session/print-session.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it, vi } from "vitest";
+import { printSession, type WalletSession } from "./print-session";
+
+describe("printSession", () => {
+  it("labels and prints every field, including a value", () => {
+    const spy = vi.spyOn(console, "log").mockImplementation(() => {});
+    const session: WalletSession = {
+      accountId: "CFULL",
+      network: "mainnet",
+      connected: true,
+      authMethod: "passkey",
+      createdAt: "2026-01-01T00:00:00.000Z",
+      lastActiveAt: "2026-01-02T00:00:00.000Z",
+      serverSessionId: "sess_1",
+      keyId: "key_1",
+    };
+    printSession(session);
+
+    const lines = spy.mock.calls.map((call) => call.join(" "));
+    expect(lines.some((l) => l.includes("Account ID:") && l.includes("CFULL"))).toBe(true);
+    expect(lines.some((l) => l.includes("Server session ID:") && l.includes("sess_1"))).toBe(true);
+    expect(lines.some((l) => l.includes("Key ID:") && l.includes("key_1"))).toBe(true);
+    spy.mockRestore();
+  });
+
+  it("falls back to (none) for optional fields when absent", () => {
+    const spy = vi.spyOn(console, "log").mockImplementation(() => {});
+    const session: WalletSession = {
+      accountId: "CMIN",
+      network: "testnet",
+      connected: false,
+      authMethod: "passkey",
+      createdAt: "2026-01-01T00:00:00.000Z",
+      lastActiveAt: "2026-01-01T00:00:00.000Z",
+    };
+    printSession(session);
+
+    const lines = spy.mock.calls.map((call) => call.join(" "));
+    expect(lines.some((l) => l.includes("Server session ID:") && l.includes("(none)"))).toBe(true);
+    expect(lines.some((l) => l.includes("Key ID:") && l.includes("(none)"))).toBe(true);
+    spy.mockRestore();
+  });
+});

--- a/contrib/examples/print-session/print-session.ts
+++ b/contrib/examples/print-session/print-session.ts
@@ -1,0 +1,44 @@
+// Example: pretty-print a WalletSession's fields to the console with clear
+// labels. Uses a hardcoded sample session (see the WalletSession shape from
+// vellar-sdk's src/types.ts).
+//
+// Run with: npx tsx print-session.ts
+
+export interface WalletSession {
+  accountId: string;
+  network: "testnet" | "mainnet";
+  connected: boolean;
+  authMethod: "passkey";
+  createdAt: string;
+  lastActiveAt: string;
+  serverSessionId?: string;
+  keyId?: string;
+}
+
+const sampleSession: WalletSession = {
+  accountId: "CABC123SAMPLEWALLETCONTRACTADDRESSXXXXXXXXXXXXXXXXXXXXXX",
+  network: "testnet",
+  connected: true,
+  authMethod: "passkey",
+  createdAt: "2026-01-15T09:30:00.000Z",
+  lastActiveAt: "2026-01-15T10:12:45.000Z",
+  serverSessionId: "sess_7f3a9c2e",
+  keyId: "keyid-abc123base64url",
+};
+
+export function printSession(session: WalletSession): void {
+  console.log("Wallet session");
+  console.log("  Account ID:        ", session.accountId);
+  console.log("  Network:           ", session.network);
+  console.log("  Connected:         ", session.connected);
+  console.log("  Auth method:       ", session.authMethod);
+  console.log("  Created at:        ", session.createdAt);
+  console.log("  Last active at:    ", session.lastActiveAt);
+  console.log("  Server session ID: ", session.serverSessionId ?? "(none)");
+  console.log("  Key ID:            ", session.keyId ?? "(none)");
+}
+
+// Only run when executed directly (not when imported by the test file).
+if (import.meta.url === `file://${process.argv[1]}`) {
+  printSession(sampleSession);
+}

--- a/contrib/examples/rate-limited-fetch-queue/README.md
+++ b/contrib/examples/rate-limited-fetch-queue/README.md
@@ -1,0 +1,60 @@
+# rate-limited-fetch-queue
+
+A small, self contained queue that runs `fetch` calls with a maximum number
+in flight at once, queuing the rest and starting them in FIFO order as
+slots free up.
+
+## Usage
+
+```ts
+import { RateLimitedFetchQueue } from "./rate-limited-fetch-queue";
+
+const queue = new RateLimitedFetchQueue({ maxConcurrent: 3 });
+
+const results = await Promise.all(
+  urls.map((url) => queue.enqueue(url).then((res) => res.json())),
+);
+```
+
+## API
+
+```ts
+new RateLimitedFetchQueue(options: RateLimitedFetchQueueOptions)
+```
+
+- `options.maxConcurrent` — maximum number of `fetch` calls in flight at
+  once.
+- `options.fetchFn` — optional `fetch` implementation override, useful for
+  tests.
+
+Methods:
+
+- `queue.enqueue(input, init?)` — returns a `Promise<Response>` that
+  resolves/rejects the same way `fetch(input, init)` would.
+- `queue.pending` — number of calls still waiting for a slot.
+- `queue.inFlight` — number of calls currently running.
+
+Each call to `enqueue` returns its own promise, so results line up with the
+order calls were enqueued (e.g. via `Promise.all`) even though the
+underlying requests may finish in a different order.
+
+## Demo
+
+`demo.ts` enqueues 5 fake requests with `maxConcurrent: 2` and logs when
+each one starts/finishes, showing only 2 running at a time and the final
+results array preserving enqueue order:
+
+```sh
+npx tsx demo.ts
+# [0ms] start  /a
+# [0ms] start  /b
+# [300ms] finish /a
+# [300ms] start  /c
+# [300ms] finish /b
+# [300ms] start  /d
+# [600ms] finish /c
+# [600ms] start  /e
+# [600ms] finish /d
+# [900ms] finish /e
+# results (in enqueue order): [ '/a', '/b', '/c', '/d', '/e' ]
+```

--- a/contrib/examples/rate-limited-fetch-queue/demo.ts
+++ b/contrib/examples/rate-limited-fetch-queue/demo.ts
@@ -1,0 +1,40 @@
+/**
+ * Demonstrates RateLimitedFetchQueue enqueuing more calls than the
+ * concurrency limit. Uses a fake `fetchFn` with an artificial delay instead
+ * of hitting the network. Run with:
+ *
+ *   npx tsx demo.ts
+ */
+
+import { RateLimitedFetchQueue } from "./rate-limited-fetch-queue";
+
+const start = Date.now();
+const elapsed = () => `${Date.now() - start}ms`;
+
+const fakeFetch = (input: RequestInfo | URL): Promise<Response> => {
+  const label = String(input);
+  const delayMs = 300;
+
+  console.log(`[${elapsed()}] start  ${label}`);
+
+  return new Promise((resolve) => {
+    setTimeout(() => {
+      console.log(`[${elapsed()}] finish ${label}`);
+      resolve(new Response(label));
+    }, delayMs);
+  });
+};
+
+async function main() {
+  const queue = new RateLimitedFetchQueue({ maxConcurrent: 2, fetchFn: fakeFetch as typeof fetch });
+
+  const urls = ["/a", "/b", "/c", "/d", "/e"];
+
+  // Enqueue all five up front; only 2 should be "in flight" at a time.
+  const results = await Promise.all(urls.map((url) => queue.enqueue(url).then((r) => r.text())));
+
+  // Results line up with the enqueue order, regardless of completion order.
+  console.log("results (in enqueue order):", results);
+}
+
+main();

--- a/contrib/examples/rate-limited-fetch-queue/rate-limited-fetch-queue.ts
+++ b/contrib/examples/rate-limited-fetch-queue/rate-limited-fetch-queue.ts
@@ -1,0 +1,69 @@
+/**
+ * A queue that runs `fetch` calls with a maximum number in flight at once,
+ * queuing the rest. Requests start in FIFO order as concurrency slots free
+ * up; each call's returned promise resolves independently with its own
+ * response once it completes.
+ */
+
+type FetchLike = typeof fetch;
+type FetchInput = Parameters<FetchLike>[0];
+type FetchInit = Parameters<FetchLike>[1];
+
+interface QueuedTask {
+  input: FetchInput;
+  init: FetchInit;
+  resolve: (response: Response) => void;
+  reject: (reason: unknown) => void;
+}
+
+export interface RateLimitedFetchQueueOptions {
+  maxConcurrent: number;
+  /** Injectable fetch implementation, mainly useful for tests. */
+  fetchFn?: FetchLike;
+}
+
+export class RateLimitedFetchQueue {
+  private readonly maxConcurrent: number;
+  private readonly fetchFn: FetchLike;
+  private readonly queue: QueuedTask[] = [];
+  private active = 0;
+
+  constructor(options: RateLimitedFetchQueueOptions) {
+    if (options.maxConcurrent < 1) {
+      throw new RangeError("maxConcurrent must be at least 1");
+    }
+    this.maxConcurrent = options.maxConcurrent;
+    this.fetchFn = options.fetchFn ?? fetch;
+  }
+
+  /** Enqueues a fetch call. Resolves/rejects like `fetch` would. */
+  enqueue(input: FetchInput, init?: FetchInit): Promise<Response> {
+    return new Promise((resolve, reject) => {
+      this.queue.push({ input, init, resolve, reject });
+      this.drain();
+    });
+  }
+
+  get pending(): number {
+    return this.queue.length;
+  }
+
+  get inFlight(): number {
+    return this.active;
+  }
+
+  private drain(): void {
+    while (this.active < this.maxConcurrent && this.queue.length > 0) {
+      const task = this.queue.shift();
+      if (!task) break;
+
+      this.active++;
+      this.fetchFn(task.input, task.init)
+        .then(task.resolve, task.reject)
+        .finally(() => {
+          this.active--;
+          this.drain();
+        });
+    }
+  }
+}

--- a/contrib/examples/read-token-balance/README.md
+++ b/contrib/examples/read-token-balance/README.md
@@ -1,0 +1,30 @@
+# Read a SEP-41 token balance
+
+Reads a SEP-41 token balance for a given account and token contract id,
+using `vellar-sdk`'s RPC-backed balance reader (`createRpcBalanceReader`,
+`vellar-sdk/rpc`). Prints the balance in raw base units — this script
+doesn't assume any particular decimals, unlike `read-xlm-balance` which
+formats specifically for XLM's 7 decimals.
+
+## Finding a testnet token contract id
+
+Stellar Laboratory's testnet asset explorer, or the Stellar testnet Friendbot
+issuers used by common SDF sample tokens, are the usual sources for a
+testnet SAC (Stellar Asset Contract) id to test against. The SAC id is
+deterministic from the asset code + issuer + network passphrase — a wallet's
+own `nativeToken()` helper (`src/balances-rpc.ts`) shows the same derivation
+for the native asset.
+
+## Run it
+
+```sh
+npx tsx read-token-balance.ts <accountId> <tokenContractId>
+```
+
+## Tests
+
+Injects a mock `BalanceReader`, so the tests don't depend on a live RPC call:
+
+```sh
+npx vitest run contrib/examples/read-token-balance
+```

--- a/contrib/examples/read-token-balance/read-token-balance.test.ts
+++ b/contrib/examples/read-token-balance/read-token-balance.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it, vi } from "vitest";
+import type { BalanceReader } from "../../../src/balances";
+import { readTokenBalance } from "./read-token-balance";
+
+describe("readTokenBalance", () => {
+  it("returns the raw base-unit balance from the reader", async () => {
+    const reader: BalanceReader = { getTokenBalance: vi.fn().mockResolvedValue(42_500_000n) };
+    await expect(readTokenBalance(reader, "CTOKEN", "GHOLDER")).resolves.toBe(42_500_000n);
+    expect(reader.getTokenBalance).toHaveBeenCalledWith("CTOKEN", "GHOLDER");
+  });
+
+  it("propagates reader failures", async () => {
+    const reader: BalanceReader = { getTokenBalance: vi.fn().mockRejectedValue(new Error("rpc down")) };
+    await expect(readTokenBalance(reader, "CTOKEN", "GHOLDER")).rejects.toThrow("rpc down");
+  });
+});

--- a/contrib/examples/read-token-balance/read-token-balance.ts
+++ b/contrib/examples/read-token-balance/read-token-balance.ts
@@ -1,0 +1,48 @@
+// Example: read a SEP-41 token balance for a given account and token
+// contract id, using the SDK's RPC-backed balance reader. Prints the
+// balance in raw base units (unlike read-xlm-balance, this does not assume
+// 7 decimals — it just prints the raw bigint the contract returns).
+//
+// Run with: npx tsx read-token-balance.ts <accountId> <tokenContractId>
+
+import type { BalanceReader } from "../../../src/balances";
+import { createRpcBalanceReader } from "../../../src/rpc";
+import { TESTNET } from "../../../src/config";
+
+/** Reads one token balance. Reader is injected so this is directly
+ * unit-testable without a real RPC round trip. */
+export async function readTokenBalance(
+  reader: BalanceReader,
+  tokenContractId: string,
+  accountId: string,
+): Promise<bigint> {
+  return reader.getTokenBalance(tokenContractId, accountId);
+}
+
+async function main() {
+  const [accountId, tokenContractId] = process.argv.slice(2);
+  if (!accountId || !tokenContractId) {
+    console.error("Usage: npx tsx read-token-balance.ts <accountId> <tokenContractId>");
+    process.exitCode = 1;
+    return;
+  }
+
+  const reader = createRpcBalanceReader({
+    rpcUrl: TESTNET.rpcUrl,
+    networkPassphrase: TESTNET.networkPassphrase,
+  });
+
+  try {
+    const balance = await readTokenBalance(reader, tokenContractId, accountId);
+    console.log(`Account:  ${accountId}`);
+    console.log(`Token:    ${tokenContractId}`);
+    console.log(`Balance:  ${balance} (raw base units)`);
+  } catch (err) {
+    console.error(`Error reading balance: ${err instanceof Error ? err.message : String(err)}`);
+    process.exitCode = 1;
+  }
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main();
+}

--- a/contrib/examples/read-xlm-balance/README.md
+++ b/contrib/examples/read-xlm-balance/README.md
@@ -1,0 +1,43 @@
+# Read a native XLM balance
+
+Reads a native XLM balance for a given account using `vellar-sdk`'s
+RPC-backed balance reader (`createRpcBalanceReader` from the `vellar-sdk/rpc`
+subpath), and prints both the raw stroops amount and the formatted XLM
+amount.
+
+## Testnet RPC URL used
+
+`TESTNET.rpcUrl` from `src/config.ts`: `https://soroban-testnet.stellar.org`
+(SDF's public testnet Soroban RPC). The balance read is a simulated
+`balance(id)` contract call — no signature and no fee required.
+
+## Run it
+
+```sh
+npx tsx read-balance.ts <accountId>
+```
+
+Example:
+
+```sh
+npx tsx read-balance.ts GBRPYHIL2CI3FNQ4BXLFMNDLFJUNPU2HY3ZMFSHONUCEOASW7QC7OX2H
+```
+
+Expected output shape:
+
+```
+Account:  GBRPYHIL2CI3FNQ4BXLFMNDLFJUNPU2HY3ZMFSHONUCEOASW7QC7OX2H
+Balance:  1250000000 stroops (125 XLM)
+```
+
+Requires network access to reach the testnet RPC; the account must exist on
+testnet or the simulation call will fail with a clear error.
+
+## Tests
+
+The unit tests inject a mock `BalanceReader` so they don't depend on a live
+RPC call:
+
+```sh
+npx vitest run contrib/examples/read-xlm-balance
+```

--- a/contrib/examples/read-xlm-balance/read-balance.test.ts
+++ b/contrib/examples/read-xlm-balance/read-balance.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it, vi } from "vitest";
+import type { BalanceReader } from "../../../src/balances";
+import { readXlmBalance } from "./read-balance";
+
+describe("readXlmBalance", () => {
+  const xlm = { symbol: "XLM", contractId: "CNATIVE", decimals: 7 };
+
+  it("returns both raw stroops and formatted XLM", async () => {
+    const reader: BalanceReader = {
+      getTokenBalance: vi.fn().mockResolvedValue(1_250_000_000n),
+    };
+
+    const result = await readXlmBalance(reader, xlm, "GHOLDER");
+
+    expect(result.stroops).toBe(1_250_000_000n);
+    expect(result.xlm).toBe("125");
+    expect(reader.getTokenBalance).toHaveBeenCalledWith("CNATIVE", "GHOLDER");
+  });
+
+  it("propagates reader failures", async () => {
+    const reader: BalanceReader = {
+      getTokenBalance: vi.fn().mockRejectedValue(new Error("rpc unreachable")),
+    };
+    await expect(readXlmBalance(reader, xlm, "GHOLDER")).rejects.toThrow("rpc unreachable");
+  });
+});

--- a/contrib/examples/read-xlm-balance/read-balance.ts
+++ b/contrib/examples/read-xlm-balance/read-balance.ts
@@ -1,0 +1,55 @@
+// Example: read a native XLM balance for a given account using the SDK's
+// RPC-backed balance reader, and print both the raw stroops amount and the
+// formatted XLM amount.
+//
+// Run with: npx tsx read-balance.ts <accountId>
+// Example:  npx tsx read-balance.ts GBRPYHIL2CI3FNQ4BXLFMNDLFJUNPU2HY3ZMFSHONUCEOASW7QC7OX2H
+
+import { formatTokenAmount, type BalanceReader, type TokenInfo } from "../../../src/balances";
+import { createRpcBalanceReader, nativeToken } from "../../../src/rpc";
+import { TESTNET } from "../../../src/config";
+
+export interface XlmBalanceResult {
+  stroops: bigint;
+  xlm: string;
+}
+
+/** Reads and formats one account's native balance. Reader/token are injected
+ * so this is directly unit-testable without a real RPC round trip. */
+export async function readXlmBalance(
+  reader: BalanceReader,
+  token: TokenInfo,
+  accountId: string,
+): Promise<XlmBalanceResult> {
+  const stroops = await reader.getTokenBalance(token.contractId, accountId);
+  return { stroops, xlm: formatTokenAmount(stroops, token.decimals) };
+}
+
+async function main() {
+  const accountId = process.argv[2];
+  if (!accountId) {
+    console.error("Usage: npx tsx read-balance.ts <accountId>");
+    process.exitCode = 1;
+    return;
+  }
+
+  const reader = createRpcBalanceReader({
+    rpcUrl: TESTNET.rpcUrl,
+    networkPassphrase: TESTNET.networkPassphrase,
+  });
+  const token = nativeToken(TESTNET.networkPassphrase);
+
+  try {
+    const { stroops, xlm } = await readXlmBalance(reader, token, accountId);
+    console.log(`Account:  ${accountId}`);
+    console.log(`Balance:  ${stroops} stroops (${xlm} XLM)`);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    console.error(`Error reading balance: ${message}`);
+    process.exitCode = 1;
+  }
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main();
+}

--- a/contrib/examples/relative-time/README.md
+++ b/contrib/examples/relative-time/README.md
@@ -1,0 +1,29 @@
+# Format Relative Time Example (#112)
+
+Converts ISO timestamps into human-readable relative time strings (such as `"5 minutes ago"`, `"2 hours ago"`). Crucially handles timestamps in the future by clearly indicating that with `"in X ..."` phrasing (e.g. `"in 10 minutes"`) rather than showing negative values.
+
+## Examples & Expected Outputs
+
+Assume current reference time is `2026-08-27T12:00:00.000Z`:
+
+| Input Timestamp | Direction | Expected Relative Output |
+| --- | --- | --- |
+| `2026-08-27T11:59:58.000Z` | Past (<5s) | `just now` |
+| `2026-08-27T11:55:00.000Z` | Past | `5 minutes ago` |
+| `2026-08-27T10:00:00.000Z` | Past | `2 hours ago` |
+| `2026-08-24T12:00:00.000Z` | Past | `3 days ago` |
+| `2026-08-27T12:10:00.000Z` | **Future** | `in 10 minutes` |
+| `2026-08-29T12:00:00.000Z` | **Future** | `in 2 days` |
+| `invalid-date-string` | Invalid | `invalid date` |
+
+## Run it
+
+```sh
+npx tsx contrib/examples/relative-time/relative-time.ts
+```
+
+## Tests
+
+```sh
+npx vitest run contrib/examples/relative-time
+```

--- a/contrib/examples/relative-time/relative-time.test.ts
+++ b/contrib/examples/relative-time/relative-time.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest';
+import { formatRelativeTime } from './relative-time';
+
+describe('relative-time (#112)', () => {
+  const baseNow = new Date('2026-08-27T12:00:00.000Z');
+
+  it('formats past timestamps correctly', () => {
+    expect(formatRelativeTime('2026-08-27T11:59:58.000Z', baseNow)).toBe(
+      'just now',
+    );
+    expect(formatRelativeTime('2026-08-27T11:55:00.000Z', baseNow)).toBe(
+      '5 minutes ago',
+    );
+    expect(formatRelativeTime('2026-08-27T10:00:00.000Z', baseNow)).toBe(
+      '2 hours ago',
+    );
+    expect(formatRelativeTime('2026-08-24T12:00:00.000Z', baseNow)).toBe(
+      '3 days ago',
+    );
+  });
+
+  it('handles future timestamps with "in X" phrasing instead of negative values', () => {
+    expect(formatRelativeTime('2026-08-27T12:10:00.000Z', baseNow)).toBe(
+      'in 10 minutes',
+    );
+    expect(formatRelativeTime('2026-08-29T12:00:00.000Z', baseNow)).toBe(
+      'in 2 days',
+    );
+  });
+
+  it('handles invalid timestamps gracefully', () => {
+    expect(formatRelativeTime('invalid-date-string', baseNow)).toBe(
+      'invalid date',
+    );
+  });
+});

--- a/contrib/examples/relative-time/relative-time.ts
+++ b/contrib/examples/relative-time/relative-time.ts
@@ -1,0 +1,80 @@
+// Example: Convert an ISO timestamp into a relative time string (e.g., "5 minutes ago", "in 10 minutes").
+//
+// Run with: npx tsx contrib/examples/relative-time/relative-time.ts
+
+/**
+ * Formats an ISO timestamp string or Date object into a human-readable relative time string.
+ * Correctly handles future timestamps by returning "in X ..." instead of negative durations.
+ */
+export function formatRelativeTime(
+  timestamp: string | Date,
+  now: Date = new Date(),
+): string {
+  const targetDate = typeof timestamp === 'string' ? new Date(timestamp) : timestamp;
+  const targetMs = targetDate.getTime();
+  const nowMs = now.getTime();
+
+  if (isNaN(targetMs)) {
+    return 'invalid date';
+  }
+
+  const diffMs = targetMs - nowMs;
+  const isFuture = diffMs > 0;
+  const absSeconds = Math.floor(Math.abs(diffMs) / 1000);
+
+  if (absSeconds < 5) {
+    return 'just now';
+  }
+
+  const minutes = Math.floor(absSeconds / 60);
+  const hours = Math.floor(minutes / 60);
+  const days = Math.floor(hours / 24);
+  const months = Math.floor(days / 30);
+  const years = Math.floor(days / 365);
+
+  let timeUnitString = '';
+  if (years >= 1) {
+    timeUnitString = `${years} ${years === 1 ? 'year' : 'years'}`;
+  } else if (months >= 1) {
+    timeUnitString = `${months} ${months === 1 ? 'month' : 'months'}`;
+  } else if (days >= 1) {
+    timeUnitString = `${days} ${days === 1 ? 'day' : 'days'}`;
+  } else if (hours >= 1) {
+    timeUnitString = `${hours} ${hours === 1 ? 'hour' : 'hours'}`;
+  } else if (minutes >= 1) {
+    timeUnitString = `${minutes} ${minutes === 1 ? 'minute' : 'minutes'}`;
+  } else {
+    timeUnitString = `${absSeconds} ${absSeconds === 1 ? 'second' : 'seconds'}`;
+  }
+
+  return isFuture ? `in ${timeUnitString}` : `${timeUnitString} ago`;
+}
+
+function main() {
+  console.log('=== Format Relative Time Example ===\n');
+
+  const now = new Date('2026-08-27T12:00:00.000Z');
+
+  const exampleTimestamps = [
+    { label: 'Just now', iso: '2026-08-27T11:59:58.000Z' },
+    { label: '5 minutes ago', iso: '2026-08-27T11:55:00.000Z' },
+    { label: '2 hours ago', iso: '2026-08-27T10:00:00.000Z' },
+    { label: '3 days ago', iso: '2026-08-24T12:00:00.000Z' },
+    { label: 'Future: in 10 minutes', iso: '2026-08-27T12:10:00.000Z' },
+    { label: 'Future: in 2 days', iso: '2026-08-29T12:00:00.000Z' },
+    { label: 'Invalid ISO format', iso: 'not-a-timestamp' },
+  ];
+
+  console.log(`Base reference time (NOW): ${now.toISOString()}\n`);
+  console.log('Timestamp                              -> Formatted Relative Time');
+  console.log('------------------------------------------------------------------');
+
+  for (const item of exampleTimestamps) {
+    const formatted = formatRelativeTime(item.iso, now);
+    console.log(`${item.iso.padEnd(38)} -> ${formatted}`);
+  }
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main();
+}

--- a/contrib/examples/request-dedupe-cache/README.md
+++ b/contrib/examples/request-dedupe-cache/README.md
@@ -1,0 +1,37 @@
+# request-dedupe-cache
+
+Deduplicates in-flight async requests by key so concurrent callers for the same key share one underlying call. Results are cached for subsequent calls.
+
+## Usage
+
+```ts
+import { RequestDedupeCache } from "./index";
+
+const cache = new RequestDedupeCache<string>();
+
+const factory = async (key: string): Promise<string> => {
+  const res = await fetch(`/api/${key}`);
+  return res.json();
+};
+
+// These two calls run concurrently for the same key; only one network request fires.
+const [a, b] = await Promise.all([
+  cache.get("resource-1", factory),
+  cache.get("resource-1", factory),
+]);
+
+console.log(a, b); // Both resolve to the same value
+```
+
+## API
+
+- `cache.get(key, factory)` — returns a cached value, an in-flight promise, or starts a new request.
+- `cache.invalidate(key)` — clears the cached entry so the next call re-runs the factory.
+- `cache.clear()` — clears all cached and in-flight entries.
+
+## Notes
+
+- Keys are plain strings.
+- The factory receives the key as its argument.
+- A second call for a key already in flight awaits the same promise.
+- After the in-flight request resolves the result is cached.

--- a/contrib/examples/request-dedupe-cache/index.ts
+++ b/contrib/examples/request-dedupe-cache/index.ts
@@ -1,0 +1,53 @@
+/**
+ * Request deduplication cache.
+ *
+ * If multiple callers request the same key while a request is already in flight,
+ * all callers share the same underlying promise. Results are cached so subsequent
+ * calls return the cached value.
+ */
+
+export class RequestDedupeCache<T> {
+  private inFlight = new Map<string, Promise<T>>();
+  private cached = new Map<string, T>();
+
+  /**
+   * Run `factory(key)` only if this key is not already in flight or cached.
+   * Subsequent callers for the same key await the same in-flight promise.
+   */
+  async get(key: string, factory: (key: string) => Promise<T>): Promise<T> {
+    if (this.cached.has(key)) {
+      return this.cached.get(key)!;
+    }
+    if (this.inFlight.has(key)) {
+      return this.inFlight.get(key)!;
+    }
+
+    const promise = factory(key);
+    this.inFlight.set(key, promise);
+
+    // Cache the result when it resolves, and clear the in-flight marker.
+    promise.then(
+      (value) => {
+        this.cached.set(key, value);
+        this.inFlight.delete(key);
+      },
+      () => {
+        this.inFlight.delete(key);
+      },
+    );
+
+    return promise;
+  }
+
+  /** Invalidate a cached entry so the next call re-runs the factory. */
+  invalidate(key: string): void {
+    this.cached.delete(key);
+    this.inFlight.delete(key);
+  }
+
+  /** Clear all cached and in-flight entries. */
+  clear(): void {
+    this.cached.clear();
+    this.inFlight.clear();
+  }
+}

--- a/contrib/examples/request-dedupe-cache/test.ts
+++ b/contrib/examples/request-dedupe-cache/test.ts
@@ -1,0 +1,58 @@
+import { RequestDedupeCache } from "./index";
+
+console.log("request-dedupe-cache tests:");
+
+{
+  const cache = new RequestDedupeCache<string>();
+  let factoryCalls = 0;
+
+  const factory = async (key: string): Promise<string> => {
+    factoryCalls++;
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    return `value-for-${key}`;
+  };
+
+  // Fire two concurrent calls for the same key.
+  const [a, b] = await Promise.all([cache.get("key-1", factory), cache.get("key-1", factory)]);
+
+  console.assert(a === "value-for-key-1", "expected first value");
+  console.assert(b === "value-for-key-1", "expected second value");
+  console.assert(factoryCalls === 1, `expected 1 factory call, got ${factoryCalls}`);
+  console.log("ok: concurrent calls for same key share one factory call");
+}
+
+{
+  const cache = new RequestDedupeCache<string>();
+  let factoryCalls = 0;
+
+  const factory = async (key: string): Promise<string> => {
+    factoryCalls++;
+    return `value-${key}-${Date.now()}`;
+  };
+
+  const first = await cache.get("key-1", factory);
+  const second = await cache.get("key-1", factory);
+
+  console.assert(first === second, "expected cached value");
+  console.assert(factoryCalls === 1, `expected 1 factory call after cache hit, got ${factoryCalls}`);
+  console.log("ok: second call returns cached value");
+}
+
+{
+  const cache = new RequestDedupeCache<string>();
+  let factoryCalls = 0;
+
+  const factory = async (key: string): Promise<string> => {
+    factoryCalls++;
+    return `value-${key}`;
+  };
+
+  await cache.get("key-1", factory);
+  cache.invalidate("key-1");
+  await cache.get("key-1", factory);
+
+  console.assert(factoryCalls === 2, `expected 2 factory calls after invalidation, got ${factoryCalls}`);
+  console.log("ok: invalidation forces re-run");
+}
+
+console.log("request-dedupe-cache tests passed");

--- a/contrib/examples/retrying-fetch/README.md
+++ b/contrib/examples/retrying-fetch/README.md
@@ -1,0 +1,27 @@
+# Retrying fetch wrapper
+
+Wraps `fetch` with a configurable number of retries on network failure (a
+thrown error), waiting a fixed delay between attempts. A resolved response —
+even a non-2xx one — is returned as-is on the first attempt; only a thrown
+error (e.g. DNS/connection failure) triggers a retry.
+
+## Run it
+
+```sh
+npx tsx retrying-fetch.ts
+```
+
+Uses a mock fetch that fails twice with a network error, then succeeds:
+
+```
+Succeeded after 3 attempts, status 200
+```
+
+## Tests
+
+Uses a mock fetch and an injected no-op `sleep`, so the tests run instantly
+with no real delays:
+
+```sh
+npx vitest run contrib/examples/retrying-fetch
+```

--- a/contrib/examples/retrying-fetch/retrying-fetch.test.ts
+++ b/contrib/examples/retrying-fetch/retrying-fetch.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it, vi } from "vitest";
+import { createRetryingFetch, type FetchLike } from "./retrying-fetch";
+
+const noSleep = vi.fn(async () => {});
+
+describe("createRetryingFetch", () => {
+  it("succeeds on the first attempt with no retries needed", async () => {
+    const mockFetch: FetchLike = vi.fn(async () => new Response("ok"));
+    const retryingFetch = createRetryingFetch(mockFetch, { maxRetries: 3, delayMs: 10, sleep: noSleep });
+
+    await retryingFetch("https://example.com");
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("retries after a fixed number of failures, then succeeds", async () => {
+    let calls = 0;
+    const mockFetch: FetchLike = async () => {
+      calls++;
+      if (calls < 3) throw new Error("network error");
+      return new Response("ok");
+    };
+
+    const retryingFetch = createRetryingFetch(mockFetch, { maxRetries: 3, delayMs: 10, sleep: noSleep });
+    const response = await retryingFetch("https://example.com");
+
+    expect(calls).toBe(3);
+    expect(response.status).toBe(200);
+  });
+
+  it("does not retry a resolved non-2xx response", async () => {
+    const mockFetch: FetchLike = vi.fn(async () => new Response("not found", { status: 404 }));
+    const retryingFetch = createRetryingFetch(mockFetch, { maxRetries: 3, delayMs: 10, sleep: noSleep });
+
+    const response = await retryingFetch("https://example.com");
+    expect(response.status).toBe(404);
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("re-throws the last error once retries are exhausted", async () => {
+    const mockFetch: FetchLike = vi.fn(async () => {
+      throw new Error("always fails");
+    });
+    const retryingFetch = createRetryingFetch(mockFetch, { maxRetries: 2, delayMs: 10, sleep: noSleep });
+
+    await expect(retryingFetch("https://example.com")).rejects.toThrow("always fails");
+    expect(mockFetch).toHaveBeenCalledTimes(3); // initial attempt + 2 retries
+  });
+});

--- a/contrib/examples/retrying-fetch/retrying-fetch.ts
+++ b/contrib/examples/retrying-fetch/retrying-fetch.ts
@@ -1,0 +1,60 @@
+// Example: wrap fetch with a configurable number of retries on network
+// failure (a thrown error — e.g. DNS/connection failure), waiting a fixed
+// delay between attempts. Does NOT retry on a successful response, even a
+// non-2xx one — only a thrown error is treated as retryable.
+//
+// Run with: npx tsx retrying-fetch.ts
+
+export type FetchLike = (url: string, init?: RequestInit) => Promise<Response>;
+
+export interface RetryingFetchOptions {
+  maxRetries: number;
+  delayMs: number;
+  /** Injectable sleep, so tests can run without real delays. */
+  sleep?: (ms: number) => Promise<void>;
+}
+
+/**
+ * Wraps `fetchImpl`, retrying up to `maxRetries` additional times if it
+ * throws (a network-level failure). A response that resolves — even a 4xx
+ * or 5xx — is returned as-is on the first attempt; only a rejection
+ * triggers a retry. Re-throws the last error once retries are exhausted.
+ */
+export function createRetryingFetch(fetchImpl: FetchLike, options: RetryingFetchOptions): FetchLike {
+  const sleep = options.sleep ?? ((ms) => new Promise<void>((resolve) => setTimeout(resolve, ms)));
+
+  return async (url, init) => {
+    let lastError: unknown;
+    for (let attempt = 0; attempt <= options.maxRetries; attempt++) {
+      try {
+        return await fetchImpl(url, init);
+      } catch (err) {
+        lastError = err;
+        if (attempt < options.maxRetries) {
+          await sleep(options.delayMs);
+        }
+      }
+    }
+    throw lastError;
+  };
+}
+
+async function main() {
+  // A mock fetch that fails twice with a network error, then succeeds.
+  let calls = 0;
+  const mockFetch: FetchLike = async () => {
+    calls++;
+    if (calls < 3) {
+      throw new Error("network error (mock)");
+    }
+    return new Response("ok", { status: 200 });
+  };
+
+  const retryingFetch = createRetryingFetch(mockFetch, { maxRetries: 3, delayMs: 100 });
+  const response = await retryingFetch("https://example.com");
+  console.log(`Succeeded after ${calls} attempts, status ${response.status}`);
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main();
+}

--- a/contrib/examples/session-budget-dashboard-source/README.md
+++ b/contrib/examples/session-budget-dashboard-source/README.md
@@ -1,0 +1,66 @@
+# Session budget dashboard source
+
+A data source function, `buildSessionBudgetDashboardSource()`, that
+combines a mock session with a mock x402 budget tracker into a single flat
+object — session expiry info alongside remaining budget and recent spend —
+suitable for feeding a dashboard UI.
+
+## Returned shape
+
+```ts
+interface SessionBudgetDashboardSource {
+  accountId: string;
+  sessionExpiresAt: string;      // ISO timestamp, from the session
+  sessionStatus: "active" | "expiring_soon" | "expired";
+  totalBudget: bigint;           // from the budget tracker
+  remainingBudget: bigint;       // totalBudget - spent
+  recentSpend: { amount: bigint; at: string }[];
+}
+```
+
+`sessionStatus` is computed the same way as the `session-key-dashboard-source`
+example, given a simulated "now" (defaults to the real current time, but the
+demo and tests pass a fixed one for reproducibility):
+
+- **`expired`** — expiry is at or before now.
+- **`expiring_soon`** — expiry is within the next 24 hours.
+- **`active`** — expiry is more than 24 hours out.
+
+`remainingBudget` is simply `totalBudget - spent`; `recentSpend` is carried
+through from the input budget tracker unchanged.
+
+## Usage
+
+```ts
+import { buildSessionBudgetDashboardSource } from "./session-budget-dashboard-source";
+
+const source = buildSessionBudgetDashboardSource(
+  { accountId: "CACCOUNT...", expiresAt: "2026-07-01T00:00:00.000Z" },
+  { totalBudget: 1_000_000n, spent: 400_000n, recentSpend: [{ amount: 400_000n, at: "2026-06-15T10:00:00.000Z" }] },
+);
+// { accountId, sessionExpiresAt, sessionStatus: "active", totalBudget: 1000000n, remainingBudget: 600000n, recentSpend: [...] }
+```
+
+## Run it
+
+```sh
+npx tsx session-budget-dashboard-source.ts
+```
+
+Expected output (against a fixed `now` of `2026-06-15T12:00:00.000Z`, with
+a session expiring 8 hours later):
+
+```
+Account: CDASHBOARDDEMOACCOUNTXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+Session: expiring_soon (expires 2026-06-15T20:00:00.000Z)
+Budget: 350000 remaining of 1000000
+Recent spend:
+  300000 at 2026-06-15T09:00:00.000Z
+  350000 at 2026-06-15T11:30:00.000Z
+```
+
+## Tests
+
+```sh
+npx vitest run contrib/examples/session-budget-dashboard-source
+```

--- a/contrib/examples/session-budget-dashboard-source/session-budget-dashboard-source.test.ts
+++ b/contrib/examples/session-budget-dashboard-source/session-budget-dashboard-source.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "vitest";
+import { buildSessionBudgetDashboardSource, type MockBudgetTracker, type MockSession } from "./session-budget-dashboard-source";
+
+describe("buildSessionBudgetDashboardSource", () => {
+  const now = new Date("2026-06-15T12:00:00.000Z");
+
+  const session: MockSession = {
+    accountId: "CACCOUNT",
+    expiresAt: "2026-07-01T00:00:00.000Z", // well over 24h out
+  };
+
+  const budget: MockBudgetTracker = {
+    totalBudget: 1_000_000n,
+    spent: 400_000n,
+    recentSpend: [{ amount: 400_000n, at: "2026-06-15T10:00:00.000Z" }],
+  };
+
+  it("combines session and budget fields into one flat object", () => {
+    const result = buildSessionBudgetDashboardSource(session, budget, now);
+    expect(result).toEqual({
+      accountId: "CACCOUNT",
+      sessionExpiresAt: "2026-07-01T00:00:00.000Z",
+      sessionStatus: "active",
+      totalBudget: 1_000_000n,
+      remainingBudget: 600_000n,
+      recentSpend: [{ amount: 400_000n, at: "2026-06-15T10:00:00.000Z" }],
+    });
+  });
+
+  it("marks a session expiring within 24h as expiring_soon", () => {
+    const soon: MockSession = { accountId: "CACCOUNT", expiresAt: "2026-06-15T20:00:00.000Z" };
+    const result = buildSessionBudgetDashboardSource(soon, budget, now);
+    expect(result.sessionStatus).toBe("expiring_soon");
+  });
+
+  it("marks a session past its expiry as expired", () => {
+    const expired: MockSession = { accountId: "CACCOUNT", expiresAt: "2026-06-01T00:00:00.000Z" };
+    const result = buildSessionBudgetDashboardSource(expired, budget, now);
+    expect(result.sessionStatus).toBe("expired");
+  });
+
+  it("treats an expiry exactly at now as expired (inclusive boundary)", () => {
+    const atNow: MockSession = { accountId: "CACCOUNT", expiresAt: now.toISOString() };
+    const result = buildSessionBudgetDashboardSource(atNow, budget, now);
+    expect(result.sessionStatus).toBe("expired");
+  });
+
+  it("computes remainingBudget as totalBudget minus spent", () => {
+    const zeroSpent: MockBudgetTracker = { totalBudget: 500n, spent: 0n, recentSpend: [] };
+    const result = buildSessionBudgetDashboardSource(session, zeroSpent, now);
+    expect(result.remainingBudget).toBe(500n);
+  });
+
+  it("carries recentSpend through unchanged", () => {
+    const withHistory: MockBudgetTracker = {
+      totalBudget: 100n,
+      spent: 30n,
+      recentSpend: [
+        { amount: 10n, at: "2026-06-15T08:00:00.000Z" },
+        { amount: 20n, at: "2026-06-15T09:00:00.000Z" },
+      ],
+    };
+    const result = buildSessionBudgetDashboardSource(session, withHistory, now);
+    expect(result.recentSpend).toEqual(withHistory.recentSpend);
+  });
+});

--- a/contrib/examples/session-budget-dashboard-source/session-budget-dashboard-source.ts
+++ b/contrib/examples/session-budget-dashboard-source/session-budget-dashboard-source.ts
@@ -1,0 +1,100 @@
+// Example: a data source function that combines a mock session with a mock
+// x402 budget tracker into a single object suitable for feeding a
+// dashboard UI — session expiry info alongside remaining budget and recent
+// spend.
+//
+// Run with: npx tsx session-budget-dashboard-source.ts
+
+export type SessionExpiryStatus = "active" | "expiring_soon" | "expired";
+
+export interface MockSession {
+  accountId: string;
+  expiresAt: string;
+}
+
+export interface MockSpendRecord {
+  amount: bigint;
+  at: string;
+}
+
+export interface MockBudgetTracker {
+  totalBudget: bigint;
+  spent: bigint;
+  recentSpend: MockSpendRecord[];
+}
+
+export interface SessionBudgetDashboardSource {
+  accountId: string;
+  sessionExpiresAt: string;
+  sessionStatus: SessionExpiryStatus;
+  totalBudget: bigint;
+  remainingBudget: bigint;
+  recentSpend: MockSpendRecord[];
+}
+
+// A session within this window of expiry (but not yet expired) is
+// "expiring soon" — same 24h lead time as the session-key-dashboard-source
+// example, for the same reason: enough lead time for a dashboard to flag it.
+const EXPIRING_SOON_WINDOW_MS = 24 * 60 * 60 * 1000; // 24h
+
+function sessionStatusFor(expiresAt: string, now: Date): SessionExpiryStatus {
+  const msUntilExpiry = new Date(expiresAt).getTime() - now.getTime();
+  if (msUntilExpiry <= 0) return "expired";
+  if (msUntilExpiry <= EXPIRING_SOON_WINDOW_MS) return "expiring_soon";
+  return "active";
+}
+
+/**
+ * Combines a mock session and a mock budget tracker into a single flat
+ * object shaped for a dashboard UI: session expiry status alongside
+ * remaining budget and recent spend history. Given a simulated "now"
+ * (defaults to the real current time, but the demo and tests pass a fixed
+ * one for reproducibility).
+ */
+export function buildSessionBudgetDashboardSource(
+  session: MockSession,
+  budget: MockBudgetTracker,
+  now: Date = new Date(),
+): SessionBudgetDashboardSource {
+  return {
+    accountId: session.accountId,
+    sessionExpiresAt: session.expiresAt,
+    sessionStatus: sessionStatusFor(session.expiresAt, now),
+    totalBudget: budget.totalBudget,
+    remainingBudget: budget.totalBudget - budget.spent,
+    recentSpend: budget.recentSpend,
+  };
+}
+
+function main() {
+  // A fixed "now" so the example's output is reproducible.
+  const now = new Date("2026-06-15T12:00:00.000Z");
+
+  const session: MockSession = {
+    accountId: "CDASHBOARDDEMOACCOUNTXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+    expiresAt: "2026-06-15T20:00:00.000Z", // 8h out
+  };
+
+  const budget: MockBudgetTracker = {
+    totalBudget: 1_000_000n,
+    spent: 650_000n,
+    recentSpend: [
+      { amount: 300_000n, at: "2026-06-15T09:00:00.000Z" },
+      { amount: 350_000n, at: "2026-06-15T11:30:00.000Z" },
+    ],
+  };
+
+  const dashboardSource = buildSessionBudgetDashboardSource(session, budget, now);
+
+  console.log(`Account: ${dashboardSource.accountId}`);
+  console.log(`Session: ${dashboardSource.sessionStatus} (expires ${dashboardSource.sessionExpiresAt})`);
+  console.log(`Budget: ${dashboardSource.remainingBudget} remaining of ${dashboardSource.totalBudget}`);
+  console.log("Recent spend:");
+  for (const record of dashboardSource.recentSpend) {
+    console.log(`  ${record.amount} at ${record.at}`);
+  }
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main();
+}

--- a/contrib/examples/session-expiry-check/README.md
+++ b/contrib/examples/session-expiry-check/README.md
@@ -1,0 +1,30 @@
+# Session expiry check
+
+Checks a mock session expiry timestamp against the current time and reports
+`EXPIRED` or `ACTIVE`.
+
+## Run it
+
+```sh
+npx tsx session-expiry-check.ts <iso-timestamp>
+```
+
+Example — a timestamp in the past:
+
+```sh
+npx tsx session-expiry-check.ts 2020-01-01T00:00:00.000Z
+# Session expiry (2020-01-01T00:00:00.000Z): EXPIRED
+```
+
+Example — a timestamp in the future:
+
+```sh
+npx tsx session-expiry-check.ts 2030-01-01T00:00:00.000Z
+# Session expiry (2030-01-01T00:00:00.000Z): ACTIVE
+```
+
+## Tests
+
+```sh
+npx vitest run contrib/examples/session-expiry-check
+```

--- a/contrib/examples/session-expiry-check/session-expiry-check.test.ts
+++ b/contrib/examples/session-expiry-check/session-expiry-check.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+import { checkExpiry } from "./session-expiry-check";
+
+describe("checkExpiry", () => {
+  const now = new Date("2026-06-15T12:00:00.000Z");
+
+  it("reports a past timestamp as expired", () => {
+    expect(checkExpiry("2020-01-01T00:00:00.000Z", now)).toBe("expired");
+  });
+
+  it("reports a future timestamp as active", () => {
+    expect(checkExpiry("2030-01-01T00:00:00.000Z", now)).toBe("active");
+  });
+
+  it("treats an expiry exactly at now as expired", () => {
+    expect(checkExpiry(now.toISOString(), now)).toBe("expired");
+  });
+
+  it("rejects an invalid timestamp", () => {
+    expect(() => checkExpiry("not-a-date", now)).toThrow(RangeError);
+  });
+});

--- a/contrib/examples/session-expiry-check/session-expiry-check.ts
+++ b/contrib/examples/session-expiry-check/session-expiry-check.ts
@@ -1,0 +1,38 @@
+// Example: check a mock session expiry timestamp against the current time
+// and report whether it's expired or active.
+//
+// Run with: npx tsx session-expiry-check.ts <iso-timestamp>
+// Example:  npx tsx session-expiry-check.ts 2020-01-01T00:00:00.000Z
+
+export type ExpiryResult = "expired" | "active";
+
+export function checkExpiry(expiresAt: string, now: Date = new Date()): ExpiryResult {
+  const expiry = new Date(expiresAt);
+  if (Number.isNaN(expiry.getTime())) {
+    throw new RangeError(`"${expiresAt}" is not a valid ISO timestamp`);
+  }
+  return expiry.getTime() <= now.getTime() ? "expired" : "active";
+}
+
+function main() {
+  const arg = process.argv[2];
+  if (!arg) {
+    console.error("Usage: npx tsx session-expiry-check.ts <iso-timestamp>");
+    process.exitCode = 1;
+    return;
+  }
+
+  try {
+    const result = checkExpiry(arg);
+    console.log(`Session expiry (${arg}): ${result.toUpperCase()}`);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    console.error(`Error: ${message}`);
+    process.exitCode = 1;
+  }
+}
+
+// Only run when executed directly (not when imported by the test file).
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main();
+}

--- a/contrib/examples/session-expiry-watcher/README.md
+++ b/contrib/examples/session-expiry-watcher/README.md
@@ -1,0 +1,58 @@
+# session-expiry-watcher
+
+A small, self contained module that watches a session object with an
+`expiresAt` timestamp and invokes a callback shortly before it expires,
+using a single `setTimeout` timer.
+
+## Usage
+
+```ts
+import { SessionExpiryWatcher } from "./session-expiry-watcher";
+
+const watcher = new SessionExpiryWatcher(
+  { expiresAt: Date.now() + 60_000 },
+  {
+    warnBeforeMs: 10_000, // fire 10s before expiry
+    onExpiringSoon: (session) => {
+      console.log("Session expiring soon:", session.expiresAt);
+    },
+  },
+);
+
+watcher.start();
+
+// Later, e.g. on logout or component unmount:
+watcher.stop();
+```
+
+## API
+
+```ts
+new SessionExpiryWatcher(session: SessionLike, options: SessionExpiryWatcherOptions)
+```
+
+- `session.expiresAt` — epoch milliseconds when the session expires.
+- `options.warnBeforeMs` — how many milliseconds before expiry to fire the
+  callback.
+- `options.onExpiringSoon` — called once, shortly before expiry.
+- `options.now` — optional clock override, useful for tests.
+
+Methods:
+
+- `watcher.start()` — starts (or restarts) the timer.
+- `watcher.stop()` — clears the timer; safe to call multiple times.
+- `watcher.isRunning` — whether a timer is currently scheduled.
+
+If `expiresAt - warnBeforeMs` is already in the past, the callback fires on
+the next tick.
+
+## Demo
+
+`demo.ts` creates a session with a 2 second lifetime and a 1 second warning
+window, then logs when the callback fires:
+
+```sh
+npx tsx demo.ts
+# Starting watcher, expect a warning in ~1s...
+# Session expiring soon at 2026-07-27T12:00:01.000Z
+```

--- a/contrib/examples/session-expiry-watcher/demo.ts
+++ b/contrib/examples/session-expiry-watcher/demo.ts
@@ -1,0 +1,28 @@
+/**
+ * Demonstrates SessionExpiryWatcher with a short-lived session so the
+ * callback fires within a couple of seconds. Run with:
+ *
+ *   npx tsx demo.ts
+ */
+
+import { SessionExpiryWatcher, type SessionLike } from "./session-expiry-watcher";
+
+const SESSION_LIFETIME_MS = 2000;
+const WARN_BEFORE_MS = 1000;
+
+const session: SessionLike = {
+  expiresAt: Date.now() + SESSION_LIFETIME_MS,
+};
+
+const watcher = new SessionExpiryWatcher(session, {
+  warnBeforeMs: WARN_BEFORE_MS,
+  onExpiringSoon: (s) => {
+    console.log(`Session expiring soon at ${new Date(s.expiresAt).toISOString()}`);
+  },
+});
+
+console.log("Starting watcher, expect a warning in ~1s...");
+watcher.start();
+
+// Stopping the watcher after it has already fired is a no-op.
+setTimeout(() => watcher.stop(), SESSION_LIFETIME_MS + 500);

--- a/contrib/examples/session-expiry-watcher/session-expiry-watcher.ts
+++ b/contrib/examples/session-expiry-watcher/session-expiry-watcher.ts
@@ -1,0 +1,54 @@
+/**
+ * Watches a session object with an `expiresAt` timestamp and invokes a
+ * callback shortly before it expires, using a single timer.
+ */
+
+export interface SessionLike {
+  expiresAt: number; // epoch milliseconds
+}
+
+export interface SessionExpiryWatcherOptions {
+  /** How many milliseconds before expiry the callback should fire. */
+  warnBeforeMs: number;
+  /** Called once, shortly before the session expires. */
+  onExpiringSoon: (session: SessionLike) => void;
+  /** Injectable clock, mainly useful for tests. */
+  now?: () => number;
+}
+
+export class SessionExpiryWatcher {
+  private readonly session: SessionLike;
+  private readonly options: SessionExpiryWatcherOptions;
+  private timer: ReturnType<typeof setTimeout> | null = null;
+
+  constructor(session: SessionLike, options: SessionExpiryWatcherOptions) {
+    this.session = session;
+    this.options = options;
+  }
+
+  /** Starts (or restarts) the watcher's timer. */
+  start(): void {
+    this.stop();
+
+    const now = (this.options.now ?? Date.now)();
+    const fireAt = this.session.expiresAt - this.options.warnBeforeMs;
+    const delay = Math.max(0, fireAt - now);
+
+    this.timer = setTimeout(() => {
+      this.timer = null;
+      this.options.onExpiringSoon(this.session);
+    }, delay);
+  }
+
+  /** Stops the watcher and clears its timer, if any. */
+  stop(): void {
+    if (this.timer !== null) {
+      clearTimeout(this.timer);
+      this.timer = null;
+    }
+  }
+
+  get isRunning(): boolean {
+    return this.timer !== null;
+  }
+}

--- a/contrib/examples/session-file-store/README.md
+++ b/contrib/examples/session-file-store/README.md
@@ -1,0 +1,42 @@
+# Wallet session file store
+
+Saves and loads a wallet session to/from a local JSON file, for node-based
+tooling (a CLI, a headless agent) that needs to persist a session between
+runs without a real browser `Storage` API.
+
+**For examples and tests only — not production.** A real app should use
+`createWebStorageAdapter` (or a custom `SessionStorageAdapter`) from
+`vellar-sdk`'s `src/session.ts`; a plain JSON file has no encryption and no
+concurrent-write protection.
+
+## Run it
+
+```sh
+npx tsx session-file-store.ts
+```
+
+Expected output:
+
+```
+Load before save: null
+Saved session to /tmp/vellar-example-session.json
+Load after save:  {
+  accountId: 'CABC123SAMPLEWALLETCONTRACTADDRESSXXXXXXXXXXXXXXXXXXXXXX',
+  network: 'testnet',
+  connected: true,
+  authMethod: 'passkey',
+  createdAt: '2026-01-15T09:30:00.000Z',
+  lastActiveAt: '2026-01-15T09:30:00.000Z'
+}
+```
+
+A missing file on `loadSession()` returns `null` rather than throwing — a
+fresh run with no prior saved session is a normal case.
+
+## Tests
+
+Uses a temporary directory per test, cleaned up afterward:
+
+```sh
+npx vitest run contrib/examples/session-file-store
+```

--- a/contrib/examples/session-file-store/session-file-store.test.ts
+++ b/contrib/examples/session-file-store/session-file-store.test.ts
@@ -1,0 +1,44 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { loadSession, saveSession, type WalletSession } from "./session-file-store";
+
+const sample: WalletSession = {
+  accountId: "CTEST",
+  network: "testnet",
+  connected: true,
+  authMethod: "passkey",
+  createdAt: "2026-01-01T00:00:00.000Z",
+  lastActiveAt: "2026-01-01T00:00:00.000Z",
+};
+
+describe("session file store", () => {
+  let dir: string;
+  let filePath: string;
+
+  beforeEach(async () => {
+    dir = await mkdtemp(join(tmpdir(), "vellar-session-store-test-"));
+    filePath = join(dir, "session.json");
+  });
+
+  afterEach(async () => {
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  it("returns null when the file does not exist", async () => {
+    await expect(loadSession(filePath)).resolves.toBeNull();
+  });
+
+  it("loads back exactly what was saved", async () => {
+    await saveSession(filePath, sample);
+    await expect(loadSession(filePath)).resolves.toEqual(sample);
+  });
+
+  it("overwrites the file on a second save", async () => {
+    await saveSession(filePath, sample);
+    const updated = { ...sample, accountId: "CTEST2" };
+    await saveSession(filePath, updated);
+    await expect(loadSession(filePath)).resolves.toEqual(updated);
+  });
+});

--- a/contrib/examples/session-file-store/session-file-store.ts
+++ b/contrib/examples/session-file-store/session-file-store.ts
@@ -1,0 +1,59 @@
+// Example: save and load a wallet session to/from a local JSON file, for
+// node-based tooling (a CLI, a headless agent) that needs to persist a
+// session between runs without a real browser Storage API.
+//
+// Run with: npx tsx session-file-store.ts
+
+import { readFile, writeFile } from "node:fs/promises";
+
+export interface WalletSession {
+  accountId: string;
+  network: "testnet" | "mainnet";
+  connected: boolean;
+  authMethod: "passkey";
+  createdAt: string;
+  lastActiveAt: string;
+}
+
+/** Persists `session` as pretty-printed JSON at `filePath`. */
+export async function saveSession(filePath: string, session: WalletSession): Promise<void> {
+  await writeFile(filePath, JSON.stringify(session, null, 2), "utf8");
+}
+
+/** Loads a session from `filePath`. Returns null (rather than throwing) if
+ * the file doesn't exist — a fresh CLI run with no prior saved session is a
+ * normal case, not an error. */
+export async function loadSession(filePath: string): Promise<WalletSession | null> {
+  try {
+    const raw = await readFile(filePath, "utf8");
+    return JSON.parse(raw) as WalletSession;
+  } catch (err) {
+    if (err instanceof Error && "code" in err && (err as NodeJS.ErrnoException).code === "ENOENT") {
+      return null;
+    }
+    throw err;
+  }
+}
+
+async function main() {
+  const filePath = "/tmp/vellar-example-session.json";
+
+  console.log("Load before save:", await loadSession(filePath));
+
+  const sample: WalletSession = {
+    accountId: "CABC123SAMPLEWALLETCONTRACTADDRESSXXXXXXXXXXXXXXXXXXXXXX",
+    network: "testnet",
+    connected: true,
+    authMethod: "passkey",
+    createdAt: "2026-01-15T09:30:00.000Z",
+    lastActiveAt: "2026-01-15T09:30:00.000Z",
+  };
+  await saveSession(filePath, sample);
+  console.log(`Saved session to ${filePath}`);
+
+  console.log("Load after save: ", await loadSession(filePath));
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main();
+}

--- a/contrib/examples/session-key-dashboard-source/README.md
+++ b/contrib/examples/session-key-dashboard-source/README.md
@@ -1,0 +1,35 @@
+# Session key expiry dashboard source
+
+A data source function, `buildSessionKeyDashboard()`, that lists several
+mock session keys with a computed expiry status — `active`,
+`expiring_soon`, or `expired` — suitable for feeding a dashboard UI.
+
+## Status shape
+
+Given a simulated "now" (defaults to the real current time, but the demo
+and tests pass a fixed one for reproducibility):
+
+- **`expired`** — expiry is at or before now.
+- **`expiring_soon`** — expiry is within the next 24 hours.
+- **`active`** — expiry is more than 24 hours out.
+
+## Run it
+
+```sh
+npx tsx session-key-dashboard-source.ts
+```
+
+Expected output (three sample keys, one in each state, against a fixed
+`now` of `2026-06-15T12:00:00.000Z`):
+
+```
+sk_active (CACTIVE): active — expires 2026-07-01T00:00:00.000Z
+sk_expiring_soon (CEXPIRINGSOON): expiring_soon — expires 2026-06-15T20:00:00.000Z
+sk_expired (CEXPIRED): expired — expires 2026-06-01T00:00:00.000Z
+```
+
+## Tests
+
+```sh
+npx vitest run contrib/examples/session-key-dashboard-source
+```

--- a/contrib/examples/session-key-dashboard-source/session-key-dashboard-source.test.ts
+++ b/contrib/examples/session-key-dashboard-source/session-key-dashboard-source.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+import { buildSessionKeyDashboard, type SessionKeyRecord } from "./session-key-dashboard-source";
+
+describe("buildSessionKeyDashboard", () => {
+  const now = new Date("2026-06-15T12:00:00.000Z");
+
+  it("marks a key expiring more than 24h out as active", () => {
+    const keys: SessionKeyRecord[] = [{ keyId: "k1", address: "C1", expiresAt: "2026-07-01T00:00:00.000Z" }];
+    expect(buildSessionKeyDashboard(keys, now)[0]!.status).toBe("active");
+  });
+
+  it("marks a key expiring within 24h as expiring_soon", () => {
+    const keys: SessionKeyRecord[] = [{ keyId: "k2", address: "C2", expiresAt: "2026-06-15T20:00:00.000Z" }];
+    expect(buildSessionKeyDashboard(keys, now)[0]!.status).toBe("expiring_soon");
+  });
+
+  it("marks a key already past its expiry as expired", () => {
+    const keys: SessionKeyRecord[] = [{ keyId: "k3", address: "C3", expiresAt: "2026-06-01T00:00:00.000Z" }];
+    expect(buildSessionKeyDashboard(keys, now)[0]!.status).toBe("expired");
+  });
+
+  it("treats an expiry exactly at now as expired (inclusive boundary)", () => {
+    const keys: SessionKeyRecord[] = [{ keyId: "k4", address: "C4", expiresAt: now.toISOString() }];
+    expect(buildSessionKeyDashboard(keys, now)[0]!.status).toBe("expired");
+  });
+
+  it("preserves keyId and address alongside the computed status", () => {
+    const keys: SessionKeyRecord[] = [{ keyId: "k5", address: "C5", expiresAt: "2026-07-01T00:00:00.000Z" }];
+    expect(buildSessionKeyDashboard(keys, now)[0]).toEqual({
+      keyId: "k5",
+      address: "C5",
+      expiresAt: "2026-07-01T00:00:00.000Z",
+      status: "active",
+    });
+  });
+
+  it("processes multiple keys independently", () => {
+    const keys: SessionKeyRecord[] = [
+      { keyId: "active", address: "C1", expiresAt: "2026-07-01T00:00:00.000Z" },
+      { keyId: "expired", address: "C2", expiresAt: "2026-06-01T00:00:00.000Z" },
+    ];
+    const dashboard = buildSessionKeyDashboard(keys, now);
+    expect(dashboard.map((e) => e.status)).toEqual(["active", "expired"]);
+  });
+});

--- a/contrib/examples/session-key-dashboard-source/session-key-dashboard-source.ts
+++ b/contrib/examples/session-key-dashboard-source/session-key-dashboard-source.ts
@@ -1,0 +1,56 @@
+// Example: a data source function listing several mock session keys with
+// their expiry status, suitable for feeding a dashboard UI.
+//
+// Run with: npx tsx session-key-dashboard-source.ts
+
+export type ExpiryStatus = "active" | "expiring_soon" | "expired";
+
+export interface SessionKeyRecord {
+  keyId: string;
+  address: string;
+  expiresAt: string;
+}
+
+export interface SessionKeyDashboardEntry extends SessionKeyRecord {
+  status: ExpiryStatus;
+}
+
+// A key within this window of expiry (but not yet expired) is "expiring
+// soon" — enough lead time for a dashboard to flag it before it lapses.
+const EXPIRING_SOON_WINDOW_MS = 24 * 60 * 60 * 1000; // 24h
+
+function statusFor(expiresAt: string, now: Date): ExpiryStatus {
+  const msUntilExpiry = new Date(expiresAt).getTime() - now.getTime();
+  if (msUntilExpiry <= 0) return "expired";
+  if (msUntilExpiry <= EXPIRING_SOON_WINDOW_MS) return "expiring_soon";
+  return "active";
+}
+
+/** Builds dashboard-ready entries from raw session key records, given a
+ * simulated "now" (defaults to the real current time). */
+export function buildSessionKeyDashboard(
+  keys: SessionKeyRecord[],
+  now: Date = new Date(),
+): SessionKeyDashboardEntry[] {
+  return keys.map((key) => ({ ...key, status: statusFor(key.expiresAt, now) }));
+}
+
+function main() {
+  // A fixed "now" so the example's output is reproducible.
+  const now = new Date("2026-06-15T12:00:00.000Z");
+
+  const sampleKeys: SessionKeyRecord[] = [
+    { keyId: "sk_active", address: "CACTIVE", expiresAt: "2026-07-01T00:00:00.000Z" }, // ~16 days out
+    { keyId: "sk_expiring_soon", address: "CEXPIRINGSOON", expiresAt: "2026-06-15T20:00:00.000Z" }, // 8h out
+    { keyId: "sk_expired", address: "CEXPIRED", expiresAt: "2026-06-01T00:00:00.000Z" }, // in the past
+  ];
+
+  const dashboard = buildSessionKeyDashboard(sampleKeys, now);
+  for (const entry of dashboard) {
+    console.log(`${entry.keyId} (${entry.address}): ${entry.status} — expires ${entry.expiresAt}`);
+  }
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main();
+}

--- a/contrib/examples/session-refresh-scheduler/README.md
+++ b/contrib/examples/session-refresh-scheduler/README.md
@@ -1,0 +1,56 @@
+# Session refresh scheduler
+
+A self-rescheduling timer that refreshes a wallet session shortly **before** it
+is due to expire, then re-arms itself against the expiry of the session the
+refresh returns. Mock-driven and timer-based — no network.
+
+A real Vellar session (`WalletSession` in `vellar-sdk`'s `src/types.ts`) tracks
+`createdAt` / `lastActiveAt`; an app that mints short-lived x402 session keys
+layers an expiry on top. This example models that expiry with an `expiresAt` ISO
+timestamp so a long-running agent never presents an expired key.
+
+## Flow
+
+1. `startRefreshScheduler(session, refresh, { leadTimeMs })` computes when the
+   session expires and arms a timer for `leadTimeMs` **before** that moment.
+2. When the timer fires it calls your `refresh()` function, which returns the
+   next session (a freshly minted key with a later `expiresAt`).
+3. The scheduler re-arms itself against the **new** expiry — repeating for as
+   long as the process runs.
+4. `stop()` clears any pending timer so nothing fires after you tear down.
+
+Edge cases handled:
+
+- If the session already expires within the lead time, the refresh fires
+  immediately (the delay is clamped to `0`).
+- A `refresh()` that throws is reported via `onError` and ends the loop rather
+  than crashing the timer.
+- An invalid `expiresAt` on the initial session throws synchronously.
+
+## Run it
+
+```sh
+npx tsx session-refresh-scheduler.ts
+```
+
+Uses a mock that mints 400ms sessions and refreshes 150ms before each expiry,
+so you can watch it reschedule a couple of times before it stops:
+
+```
+Starting scheduler (lifetime 400ms, refresh 150ms before expiry)
+[mint]    session #1 expires at 2026-01-01T00:00:00.400Z
+[refresh] refreshing session #1 before it expires
+[mint]    session #2 expires at 2026-01-01T00:00:00.650Z
+[refresh] refreshing session #2 before it expires
+[mint]    session #3 expires at 2026-01-01T00:00:00.900Z
+[stop]    scheduler stopped after 3 generations
+```
+
+## Tests
+
+Uses Vitest fake timers (`vi.advanceTimersByTimeAsync`) so the reschedule is
+observed deterministically with no real delays:
+
+```sh
+npx vitest run contrib/examples/session-refresh-scheduler
+```

--- a/contrib/examples/session-refresh-scheduler/session-refresh-scheduler.test.ts
+++ b/contrib/examples/session-refresh-scheduler/session-refresh-scheduler.test.ts
@@ -1,0 +1,95 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  startRefreshScheduler,
+  type ExpiringSession,
+  type RefreshFn,
+} from "./session-refresh-scheduler";
+
+/** A session expiring `ms` from the (faked) current time. */
+function sessionExpiringInMs(ms: number): ExpiringSession {
+  return { expiresAt: new Date(Date.now() + ms).toISOString() };
+}
+
+describe("startRefreshScheduler", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("fires the refresh leadTimeMs before expiry and reschedules on the new expiry", async () => {
+    const lifetimeMs = 1000;
+    const leadTimeMs = 200;
+    // Each refresh returns a fresh session with the same lifetime.
+    const refresh: RefreshFn = vi.fn(async () => sessionExpiringInMs(lifetimeMs));
+
+    const scheduler = startRefreshScheduler(sessionExpiringInMs(lifetimeMs), refresh, {
+      leadTimeMs,
+    });
+
+    // Nothing fires before the lead-time window (fire point is at 800ms).
+    await vi.advanceTimersByTimeAsync(lifetimeMs - leadTimeMs - 1);
+    expect(refresh).not.toHaveBeenCalled();
+
+    // Crossing the lead point triggers the first refresh...
+    await vi.advanceTimersByTimeAsync(2);
+    expect(refresh).toHaveBeenCalledTimes(1);
+
+    // ...and it reschedules itself: another full cycle triggers a second refresh.
+    await vi.advanceTimersByTimeAsync(lifetimeMs - leadTimeMs);
+    expect(refresh).toHaveBeenCalledTimes(2);
+
+    scheduler.stop();
+  });
+
+  it("stop() clears the pending timer so no further refresh runs", async () => {
+    const refresh: RefreshFn = vi.fn(async () => sessionExpiringInMs(1000));
+    const scheduler = startRefreshScheduler(sessionExpiringInMs(1000), refresh, {
+      leadTimeMs: 200,
+    });
+
+    scheduler.stop();
+    await vi.advanceTimersByTimeAsync(5000);
+    expect(refresh).not.toHaveBeenCalled();
+  });
+
+  it("fires immediately (delay clamped to 0) when expiry is already within the lead time", async () => {
+    const refresh: RefreshFn = vi.fn(async () => sessionExpiringInMs(1000));
+    // Expiry 50ms out but lead time is 200ms => fire point already passed.
+    const scheduler = startRefreshScheduler(sessionExpiringInMs(50), refresh, {
+      leadTimeMs: 200,
+    });
+
+    await vi.advanceTimersByTimeAsync(1);
+    expect(refresh).toHaveBeenCalledTimes(1);
+
+    scheduler.stop();
+  });
+
+  it("routes a refresh error to onError and stops rescheduling", async () => {
+    const onError = vi.fn();
+    const refresh: RefreshFn = vi.fn(async () => {
+      throw new Error("mint failed");
+    });
+    const scheduler = startRefreshScheduler(sessionExpiringInMs(1000), refresh, {
+      leadTimeMs: 200,
+      onError,
+    });
+
+    await vi.advanceTimersByTimeAsync(2000);
+    expect(refresh).toHaveBeenCalledTimes(1);
+    expect(onError).toHaveBeenCalledTimes(1);
+    expect(onError.mock.calls[0]?.[0]).toBeInstanceOf(Error);
+
+    scheduler.stop();
+  });
+
+  it("throws synchronously if the initial session has an invalid expiresAt", () => {
+    const refresh: RefreshFn = vi.fn(async () => sessionExpiringInMs(1000));
+    expect(() =>
+      startRefreshScheduler({ expiresAt: "not-a-date" }, refresh, { leadTimeMs: 100 }),
+    ).toThrow(RangeError);
+  });
+});

--- a/contrib/examples/session-refresh-scheduler/session-refresh-scheduler.ts
+++ b/contrib/examples/session-refresh-scheduler/session-refresh-scheduler.ts
@@ -1,0 +1,121 @@
+// Example: a self-rescheduling timer that refreshes a wallet session shortly
+// BEFORE it is due to expire, then re-arms itself against the expiry of the
+// session the refresh returns. Timer-based, mock-driven, no network.
+//
+// A real Vellar session (vellar-sdk's WalletSession, src/types.ts) tracks
+// createdAt / lastActiveAt; an app that mints short-lived x402 session keys
+// layers an expiry on top of that. This example models the expiry with an
+// `expiresAt` ISO timestamp and keeps the session alive by refreshing just
+// before it lapses — so a long-running agent never presents an expired key.
+//
+// Run with: npx tsx session-refresh-scheduler.ts
+
+/** The only slice of session state this scheduler needs: when it expires. */
+export interface ExpiringSession {
+  /** ISO 8601 timestamp at which the session expires. */
+  expiresAt: string;
+}
+
+/** Produces the next session (e.g. by minting a fresh session key). */
+export type RefreshFn = () => Promise<ExpiringSession>;
+
+export interface SchedulerOptions {
+  /** How long before expiry to fire the refresh, in milliseconds. */
+  leadTimeMs: number;
+  /** Clock source, injectable for tests. Defaults to Date.now. */
+  now?: () => number;
+  /** Called when a scheduled refresh throws. Defaults to console.error. */
+  onError?: (err: unknown) => void;
+}
+
+export interface RefreshScheduler {
+  /** Stop the scheduler and clear any pending refresh timer. */
+  stop(): void;
+}
+
+/**
+ * Starts a self-rescheduling refresh loop. It arms a timer to fire
+ * `leadTimeMs` before `session.expiresAt`; when the timer fires it calls
+ * `refresh()`, then re-arms against the expiry of the session that returns.
+ *
+ * If the session already expires within the lead time, the refresh fires
+ * immediately (the delay is clamped to 0). A refresh that throws is reported
+ * via `onError` and ends the loop (no further reschedule) — the caller can
+ * restart with a fresh session.
+ */
+export function startRefreshScheduler(
+  session: ExpiringSession,
+  refresh: RefreshFn,
+  options: SchedulerOptions,
+): RefreshScheduler {
+  const now = options.now ?? (() => Date.now());
+  const reportError =
+    options.onError ?? ((err: unknown) => console.error("scheduled refresh failed:", err));
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  let stopped = false;
+
+  function delayUntilRefresh(current: ExpiringSession): number {
+    const expiry = new Date(current.expiresAt).getTime();
+    if (Number.isNaN(expiry)) {
+      throw new RangeError(`"${current.expiresAt}" is not a valid ISO timestamp`);
+    }
+    return Math.max(0, expiry - options.leadTimeMs - now());
+  }
+
+  function arm(current: ExpiringSession): void {
+    if (stopped) return;
+    const delay = delayUntilRefresh(current);
+    timer = setTimeout(() => {
+      void (async () => {
+        try {
+          const next = await refresh();
+          arm(next); // reschedule against the new expiry
+        } catch (err) {
+          reportError(err);
+        }
+      })();
+    }, delay);
+  }
+
+  arm(session);
+
+  return {
+    stop() {
+      stopped = true;
+      if (timer !== undefined) {
+        clearTimeout(timer);
+        timer = undefined;
+      }
+    },
+  };
+}
+
+async function main(): Promise<void> {
+  const lifetimeMs = 400;
+  const leadTimeMs = 150;
+  let generation = 0;
+
+  const mint = (): ExpiringSession => {
+    generation += 1;
+    const expiresAt = new Date(Date.now() + lifetimeMs).toISOString();
+    console.log(`[mint]    session #${generation} expires at ${expiresAt}`);
+    return { expiresAt };
+  };
+
+  const refresh: RefreshFn = async () => {
+    console.log(`[refresh] refreshing session #${generation} before it expires`);
+    return mint();
+  };
+
+  console.log(`Starting scheduler (lifetime ${lifetimeMs}ms, refresh ${leadTimeMs}ms before expiry)`);
+  const scheduler = startRefreshScheduler(mint(), refresh, { leadTimeMs });
+
+  // Run long enough to observe at least two reschedules, then stop.
+  await new Promise((resolve) => setTimeout(resolve, 1000));
+  scheduler.stop();
+  console.log(`[stop]    scheduler stopped after ${generation} generations`);
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main();
+}

--- a/contrib/examples/signer-audit-trail/README.md
+++ b/contrib/examples/signer-audit-trail/README.md
@@ -1,0 +1,43 @@
+# Signer audit trail formatter
+
+`formatAuditTrail(events)` takes a list of signer change events (`add`,
+`update`, `remove`) and renders them as a readable chronological trail —
+**oldest first**. Input order is never assumed to already be sorted: events
+are sorted by `timestamp` before rendering, so passing them in any order
+(e.g. as fetched newest-first from an API) still produces a correct trail.
+
+## Input shape
+
+```ts
+interface SignerChangeEvent {
+  action: "add" | "update" | "remove";
+  keyType: "ed25519" | "passkey" | "policy-contract";
+  signerId: string;
+  timestamp: string; // ISO 8601
+}
+```
+
+Each rendered line includes the action, the signer key type, and the
+timestamp: `[<timestamp>] <Action> <keyType> signer (<signerId>)`.
+
+## Run it
+
+```sh
+npx tsx signer-audit-trail.ts
+```
+
+Expected output (the sample events are given out of order; the trail is
+still oldest-first):
+
+```
+[2026-01-10T12:00:00Z] Added passkey signer (device-alice-iphone)
+[2026-02-01T16:45:00Z] Added ed25519 signer (session-key-1)
+[2026-02-14T08:30:00Z] Updated policy-contract signer (spending-limit-policy)
+[2026-03-03T09:15:00Z] Removed ed25519 signer (session-key-1)
+```
+
+## Tests
+
+```sh
+npx vitest run contrib/examples/signer-audit-trail
+```

--- a/contrib/examples/signer-audit-trail/signer-audit-trail.test.ts
+++ b/contrib/examples/signer-audit-trail/signer-audit-trail.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+import { formatAuditTrail, type SignerChangeEvent } from "./signer-audit-trail";
+
+describe("formatAuditTrail", () => {
+  it("renders each entry with action, key type, and timestamp", () => {
+    const events: SignerChangeEvent[] = [
+      { action: "add", keyType: "passkey", signerId: "device-1", timestamp: "2026-01-01T00:00:00Z" },
+    ];
+    expect(formatAuditTrail(events)).toBe("[2026-01-01T00:00:00Z] Added passkey signer (device-1)");
+  });
+
+  it("labels update and remove actions distinctly from add", () => {
+    const events: SignerChangeEvent[] = [
+      { action: "update", keyType: "policy-contract", signerId: "policy-1", timestamp: "2026-01-01T00:00:00Z" },
+      { action: "remove", keyType: "ed25519", signerId: "key-1", timestamp: "2026-01-02T00:00:00Z" },
+    ];
+    const trail = formatAuditTrail(events);
+    expect(trail).toContain("Updated policy-contract signer (policy-1)");
+    expect(trail).toContain("Removed ed25519 signer (key-1)");
+  });
+
+  it("orders entries oldest first regardless of input order", () => {
+    const events: SignerChangeEvent[] = [
+      { action: "remove", keyType: "ed25519", signerId: "b", timestamp: "2026-03-01T00:00:00Z" },
+      { action: "add", keyType: "passkey", signerId: "a", timestamp: "2026-01-01T00:00:00Z" },
+      { action: "update", keyType: "policy-contract", signerId: "c", timestamp: "2026-02-01T00:00:00Z" },
+    ];
+
+    const lines = formatAuditTrail(events).split("\n");
+    expect(lines[0]).toContain("(a)");
+    expect(lines[1]).toContain("(c)");
+    expect(lines[2]).toContain("(b)");
+  });
+
+  it("does not mutate the input array", () => {
+    const events: SignerChangeEvent[] = [
+      { action: "remove", keyType: "ed25519", signerId: "b", timestamp: "2026-03-01T00:00:00Z" },
+      { action: "add", keyType: "passkey", signerId: "a", timestamp: "2026-01-01T00:00:00Z" },
+    ];
+    const original = [...events];
+    formatAuditTrail(events);
+    expect(events).toEqual(original);
+  });
+
+  it("returns an empty string for an empty event list", () => {
+    expect(formatAuditTrail([])).toBe("");
+  });
+});

--- a/contrib/examples/signer-audit-trail/signer-audit-trail.ts
+++ b/contrib/examples/signer-audit-trail/signer-audit-trail.ts
@@ -1,0 +1,62 @@
+// Example: format a list of sample signer change events (add, update,
+// remove) as a readable chronological trail — oldest first, regardless of
+// the order the events were given in.
+//
+// Run with: npx tsx signer-audit-trail.ts
+
+export type SignerAction = "add" | "update" | "remove";
+
+/** The kinds of signer a Vellar smart account can have (idea.md §6 lists
+ * passkey + policy-contract enforcement; ed25519 covers x402 session keys —
+ * see src/x402-types.ts's SmartAccountX402Signer). */
+export type SignerKeyType = "ed25519" | "passkey" | "policy-contract";
+
+export interface SignerChangeEvent {
+  action: SignerAction;
+  keyType: SignerKeyType;
+  signerId: string;
+  /** ISO 8601 timestamp. */
+  timestamp: string;
+}
+
+function actionLabel(action: SignerAction): string {
+  switch (action) {
+    case "add":
+      return "Added";
+    case "update":
+      return "Updated";
+    case "remove":
+      return "Removed";
+  }
+}
+
+/**
+ * Formats `events` as a readable chronological trail, **oldest first**.
+ * Input order is never assumed to already be sorted — events are sorted by
+ * `timestamp` before rendering, so a caller can pass them in any order
+ * (e.g. as fetched from an API in reverse-chronological order) and get a
+ * correct trail regardless.
+ */
+export function formatAuditTrail(events: SignerChangeEvent[]): string {
+  const sorted = [...events].sort((a, b) => a.timestamp.localeCompare(b.timestamp));
+  return sorted
+    .map((event) => `[${event.timestamp}] ${actionLabel(event.action)} ${event.keyType} signer (${event.signerId})`)
+    .join("\n");
+}
+
+function main() {
+  // Deliberately out of chronological order, to demonstrate that
+  // formatAuditTrail sorts rather than trusting input order.
+  const events: SignerChangeEvent[] = [
+    { action: "remove", keyType: "ed25519", signerId: "session-key-1", timestamp: "2026-03-03T09:15:00Z" },
+    { action: "add", keyType: "passkey", signerId: "device-alice-iphone", timestamp: "2026-01-10T12:00:00Z" },
+    { action: "update", keyType: "policy-contract", signerId: "spending-limit-policy", timestamp: "2026-02-14T08:30:00Z" },
+    { action: "add", keyType: "ed25519", signerId: "session-key-1", timestamp: "2026-02-01T16:45:00Z" },
+  ];
+
+  console.log(formatAuditTrail(events));
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main();
+}

--- a/contrib/examples/signer-from-env/README.md
+++ b/contrib/examples/signer-from-env/README.md
@@ -1,0 +1,41 @@
+# Session-key signer from an env secret
+
+A standalone example that reads an ed25519 secret key from an environment
+variable and constructs a `createSessionKeySigner` from it, with clear error
+handling when the variable is missing or malformed.
+
+## Environment variables
+
+- `VELLAR_SESSION_KEY_SECRET` — the ed25519 session key secret seed
+  (Stellar `S…` format, 56 characters). Read by `createSessionKeySignerFromEnv`.
+- `VELLAR_WALLET_ADDRESS` — the smart-account `C…` address this session key
+  pays for. Read by `main()` when run as a script.
+
+**Never commit a real secret key to source control or a `.env` file that
+gets checked in.** These are example/test values only — treat any secret
+that has ever touched a real wallet as compromised.
+
+## What it does
+
+`createSessionKeySignerFromEnv(address, envVarName?)`:
+
+1. Reads `process.env[envVarName]` (defaults to `VELLAR_SESSION_KEY_SECRET`).
+2. Throws a descriptive error if the variable is unset/empty, or if it
+   doesn't look like a Stellar secret key (wrong prefix/length) — before
+   ever handing it to `Keypair.fromSecret`.
+3. Otherwise calls `createSessionKeySigner({ address, secretKey })` from
+   `src/x402-signer.ts` and returns the resulting `SmartAccountX402Signer`.
+
+## Run it
+
+```sh
+export VELLAR_SESSION_KEY_SECRET="S..."
+export VELLAR_WALLET_ADDRESS="C..."
+npx tsx contrib/examples/signer-from-env/signer-from-env.ts
+```
+
+## Test it
+
+```sh
+npm test -- contrib/examples/signer-from-env
+```

--- a/contrib/examples/signer-from-env/signer-from-env.test.ts
+++ b/contrib/examples/signer-from-env/signer-from-env.test.ts
@@ -1,0 +1,40 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { Keypair } from "@stellar/stellar-sdk";
+import { createSessionKeySignerFromEnv, DEFAULT_ENV_VAR } from "./signer-from-env";
+
+const C_ADDRESS = "CC5ZSTLTYKPNIFDSJ4233RVZPALGHHDBRTXGIN6Z3AJCWU57VR5ITXXR";
+
+describe("createSessionKeySignerFromEnv", () => {
+  afterEach(() => {
+    delete process.env[DEFAULT_ENV_VAR];
+    delete process.env["CUSTOM_ENV_VAR"];
+  });
+
+  it("throws a clear error when the env var is unset", () => {
+    delete process.env[DEFAULT_ENV_VAR];
+    expect(() => createSessionKeySignerFromEnv(C_ADDRESS)).toThrow(
+      /environment variable "VELLAR_SESSION_KEY_SECRET" is not set/,
+    );
+  });
+
+  it("throws a clear error when the env var is malformed", () => {
+    process.env[DEFAULT_ENV_VAR] = "not-a-secret-key";
+    expect(() => createSessionKeySignerFromEnv(C_ADDRESS)).toThrow(
+      /does not look like a Stellar secret key/,
+    );
+  });
+
+  it("builds a session-key signer from a valid secret in the default env var", () => {
+    const kp = Keypair.random();
+    process.env[DEFAULT_ENV_VAR] = kp.secret();
+    const signer = createSessionKeySignerFromEnv(C_ADDRESS);
+    expect(signer.address).toBe(C_ADDRESS);
+  });
+
+  it("honors a custom env var name", () => {
+    const kp = Keypair.random();
+    process.env["CUSTOM_ENV_VAR"] = kp.secret();
+    const signer = createSessionKeySignerFromEnv(C_ADDRESS, "CUSTOM_ENV_VAR");
+    expect(signer.address).toBe(C_ADDRESS);
+  });
+});

--- a/contrib/examples/signer-from-env/signer-from-env.ts
+++ b/contrib/examples/signer-from-env/signer-from-env.ts
@@ -1,0 +1,57 @@
+// Standalone example: build a `createSessionKeySigner` from an ed25519
+// secret read out of an environment variable, failing loudly and clearly
+// when the variable is missing or malformed. See ./README.md for the env
+// var name and a warning about handling real secrets.
+
+import { createSessionKeySigner } from "../../../src/x402-signer";
+import type { SmartAccountX402Signer } from "../../../src/x402-types";
+
+/** Default environment variable name this example reads the session-key
+ * secret from. Override with the `envVarName` argument if your app uses a
+ * different name. */
+export const DEFAULT_ENV_VAR = "VELLAR_SESSION_KEY_SECRET";
+
+/**
+ * Reads a Stellar ed25519 secret seed (`S…`) from `process.env[envVarName]`
+ * and wraps it in a `createSessionKeySigner` for the given smart-account
+ * `address`. Throws a descriptive error — rather than letting a cryptic
+ * failure surface later — when the variable is unset, empty, or does not
+ * look like a Stellar secret key.
+ */
+export function createSessionKeySignerFromEnv(
+  address: string,
+  envVarName: string = DEFAULT_ENV_VAR,
+): SmartAccountX402Signer {
+  const secretKey = process.env[envVarName];
+  if (!secretKey || secretKey.trim() === "") {
+    throw new Error(
+      `signer-from-env: environment variable "${envVarName}" is not set. ` +
+        `Set it to an ed25519 session key secret (starts with "S") before calling createSessionKeySignerFromEnv().`,
+    );
+  }
+  if (!secretKey.startsWith("S") || secretKey.length !== 56) {
+    throw new Error(
+      `signer-from-env: environment variable "${envVarName}" does not look like a Stellar secret key ` +
+        `(expected a 56-character string starting with "S").`,
+    );
+  }
+  return createSessionKeySigner({ address, secretKey });
+}
+
+export async function main(): Promise<void> {
+  const address = process.env["VELLAR_WALLET_ADDRESS"];
+  if (!address) {
+    throw new Error(
+      'signer-from-env: environment variable "VELLAR_WALLET_ADDRESS" is not set (the smart-account C-address to sign for).',
+    );
+  }
+  const signer = createSessionKeySignerFromEnv(address);
+  console.log(`session-key signer ready for ${signer.address}`);
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main().catch((err) => {
+    console.error(err instanceof Error ? err.message : err);
+    process.exitCode = 1;
+  });
+}

--- a/contrib/examples/simple-event-bus/README.md
+++ b/contrib/examples/simple-event-bus/README.md
@@ -1,0 +1,49 @@
+# Simple typed event bus
+
+A minimal event bus — `on`, `off`, `emit` — where `Events` maps each event
+name to its payload type, so calls are checked against the right shape at
+compile time. Multiple listeners can be registered for the same event name;
+`off` removes only the exact listener reference passed to it, leaving every
+other listener for that event intact.
+
+## Usage
+
+```ts
+import { EventBus } from "./simple-event-bus";
+
+interface WalletEvents {
+  deposit: { amount: number };
+  logout: undefined;
+}
+
+const bus = new EventBus<WalletEvents>();
+
+const onDeposit = (payload: WalletEvents["deposit"]) => console.log(payload.amount);
+bus.on("deposit", onDeposit);
+bus.emit("deposit", { amount: 100 }); // logs 100
+
+bus.off("deposit", onDeposit); // removes just this listener
+```
+
+## Run it
+
+```sh
+npx tsx simple-event-bus.ts
+```
+
+Expected output:
+
+```
+Emitting with both listeners registered:
+listener A saw deposit of 100
+listener B saw deposit of 100
+
+Emitting after removing listener A:
+listener B saw deposit of 50
+```
+
+## Tests
+
+```sh
+npx vitest run contrib/examples/simple-event-bus
+```

--- a/contrib/examples/simple-event-bus/simple-event-bus.test.ts
+++ b/contrib/examples/simple-event-bus/simple-event-bus.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it, vi } from "vitest";
+import { EventBus } from "./simple-event-bus";
+
+interface TestEvents {
+  ping: { n: number };
+  quiet: undefined;
+}
+
+describe("EventBus", () => {
+  it("delivers an emitted event to a single registered listener", () => {
+    const bus = new EventBus<TestEvents>();
+    const listener = vi.fn();
+    bus.on("ping", listener);
+
+    bus.emit("ping", { n: 1 });
+
+    expect(listener).toHaveBeenCalledExactlyOnceWith({ n: 1 });
+  });
+
+  it("delivers an emitted event to multiple registered listeners", () => {
+    const bus = new EventBus<TestEvents>();
+    const a = vi.fn();
+    const b = vi.fn();
+    bus.on("ping", a);
+    bus.on("ping", b);
+
+    bus.emit("ping", { n: 42 });
+
+    expect(a).toHaveBeenCalledExactlyOnceWith({ n: 42 });
+    expect(b).toHaveBeenCalledExactlyOnceWith({ n: 42 });
+  });
+
+  it("off removes only the specific listener passed, others stay registered", () => {
+    const bus = new EventBus<TestEvents>();
+    const a = vi.fn();
+    const b = vi.fn();
+    bus.on("ping", a);
+    bus.on("ping", b);
+
+    bus.off("ping", a);
+    bus.emit("ping", { n: 1 });
+
+    expect(a).not.toHaveBeenCalled();
+    expect(b).toHaveBeenCalledExactlyOnceWith({ n: 1 });
+  });
+
+  it("does not throw emitting an event with no listeners registered", () => {
+    const bus = new EventBus<TestEvents>();
+    expect(() => bus.emit("quiet", undefined)).not.toThrow();
+  });
+
+  it("does not throw calling off for a listener that was never registered", () => {
+    const bus = new EventBus<TestEvents>();
+    expect(() => bus.off("ping", vi.fn())).not.toThrow();
+  });
+
+  it("keeps events independent — emitting one does not trigger listeners on another", () => {
+    const bus = new EventBus<TestEvents>();
+    const pingListener = vi.fn();
+    const quietListener = vi.fn();
+    bus.on("ping", pingListener);
+    bus.on("quiet", quietListener);
+
+    bus.emit("ping", { n: 1 });
+
+    expect(pingListener).toHaveBeenCalledTimes(1);
+    expect(quietListener).not.toHaveBeenCalled();
+  });
+
+  it("registering the same listener function twice for one event only invokes it once", () => {
+    // A Set-backed listener registry naturally dedupes the same function
+    // reference registered twice, rather than firing it multiple times.
+    const bus = new EventBus<TestEvents>();
+    const listener = vi.fn();
+    bus.on("ping", listener);
+    bus.on("ping", listener);
+
+    bus.emit("ping", { n: 1 });
+
+    expect(listener).toHaveBeenCalledTimes(1);
+  });
+});

--- a/contrib/examples/simple-event-bus/simple-event-bus.ts
+++ b/contrib/examples/simple-event-bus/simple-event-bus.ts
@@ -1,0 +1,61 @@
+// Example: a minimal typed event bus — on/off/emit for named events, with
+// the payload type for each event name checked at compile time.
+//
+// Run with: npx tsx simple-event-bus.ts
+
+export type Listener<T> = (payload: T) => void;
+
+/**
+ * A typed event bus: `Events` maps each event name to its payload type, so
+ * `on`/`off`/`emit` are all checked against the right payload shape for the
+ * event name given. Multiple listeners may be registered for the same
+ * event; `off` removes only the exact listener reference passed to it,
+ * leaving every other listener for that event intact.
+ */
+export class EventBus<Events extends Record<string, unknown>> {
+  private listeners: { [K in keyof Events]?: Set<Listener<Events[K]>> } = {};
+
+  on<K extends keyof Events>(event: K, listener: Listener<Events[K]>): void {
+    let set = this.listeners[event];
+    if (!set) {
+      set = new Set();
+      this.listeners[event] = set;
+    }
+    set.add(listener);
+  }
+
+  off<K extends keyof Events>(event: K, listener: Listener<Events[K]>): void {
+    this.listeners[event]?.delete(listener);
+  }
+
+  emit<K extends keyof Events>(event: K, payload: Events[K]): void {
+    this.listeners[event]?.forEach((listener) => listener(payload));
+  }
+}
+
+interface WalletEvents {
+  deposit: { amount: number };
+  logout: undefined;
+}
+
+function main() {
+  const bus = new EventBus<WalletEvents>();
+
+  const first: Listener<WalletEvents["deposit"]> = (payload) => console.log(`listener A saw deposit of ${payload.amount}`);
+  const second: Listener<WalletEvents["deposit"]> = (payload) => console.log(`listener B saw deposit of ${payload.amount}`);
+
+  bus.on("deposit", first);
+  bus.on("deposit", second);
+
+  console.log("Emitting with both listeners registered:");
+  bus.emit("deposit", { amount: 100 });
+
+  bus.off("deposit", first);
+
+  console.log("\nEmitting after removing listener A:");
+  bus.emit("deposit", { amount: 50 });
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main();
+}

--- a/contrib/examples/simple-rate-limiter/README.md
+++ b/contrib/examples/simple-rate-limiter/README.md
@@ -1,0 +1,33 @@
+# Simple in-memory rate limiter
+
+A fixed-window rate limiter keyed by a string id, tracking counts in memory.
+Accepts a `limit` and a window length (`windowMs`) at construction; a call
+past the limit within the current window is rejected. A new window (and a
+fresh count) begins once `windowMs` has elapsed since the current window
+started.
+
+## Run it
+
+```sh
+npx tsx simple-rate-limiter.ts
+```
+
+Expected output (limit=3, calling the same key 5 times):
+
+```
+Calling with key 'user-1' 5 times (limit=3, window=1000ms):
+  call 1: allowed
+  call 2: allowed
+  call 3: allowed
+  call 4: rejected
+  call 5: rejected
+```
+
+## Tests
+
+An injectable clock lets the tests advance time deterministically instead of
+depending on real delays:
+
+```sh
+npx vitest run contrib/examples/simple-rate-limiter
+```

--- a/contrib/examples/simple-rate-limiter/simple-rate-limiter.test.ts
+++ b/contrib/examples/simple-rate-limiter/simple-rate-limiter.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+import { SimpleRateLimiter } from "./simple-rate-limiter";
+
+describe("SimpleRateLimiter", () => {
+  it("allows calls up to the limit within a window, then rejects", () => {
+    let now = 0;
+    const limiter = new SimpleRateLimiter(3, 1000, () => now);
+
+    expect(limiter.isAllowed("user-1")).toBe(true);
+    expect(limiter.isAllowed("user-1")).toBe(true);
+    expect(limiter.isAllowed("user-1")).toBe(true);
+    expect(limiter.isAllowed("user-1")).toBe(false); // 4th call within the window
+  });
+
+  it("tracks separate keys independently", () => {
+    let now = 0;
+    const limiter = new SimpleRateLimiter(1, 1000, () => now);
+
+    expect(limiter.isAllowed("user-1")).toBe(true);
+    expect(limiter.isAllowed("user-1")).toBe(false);
+    expect(limiter.isAllowed("user-2")).toBe(true); // different key, own window
+  });
+
+  it("resets the count once a new window begins", () => {
+    let now = 0;
+    const limiter = new SimpleRateLimiter(2, 1000, () => now);
+
+    expect(limiter.isAllowed("user-1")).toBe(true);
+    expect(limiter.isAllowed("user-1")).toBe(true);
+    expect(limiter.isAllowed("user-1")).toBe(false);
+
+    now = 1000; // window elapses
+    expect(limiter.isAllowed("user-1")).toBe(true);
+  });
+});

--- a/contrib/examples/simple-rate-limiter/simple-rate-limiter.ts
+++ b/contrib/examples/simple-rate-limiter/simple-rate-limiter.ts
@@ -1,0 +1,56 @@
+// Example: a fixed-window rate limiter keyed by a string id, tracking
+// counts in memory.
+//
+// Run with: npx tsx simple-rate-limiter.ts
+
+interface WindowState {
+  count: number;
+  windowStart: number;
+}
+
+export class SimpleRateLimiter {
+  #limit: number;
+  #windowMs: number;
+  #state = new Map<string, WindowState>();
+  #now: () => number;
+
+  constructor(limit: number, windowMs: number, now: () => number = Date.now) {
+    this.#limit = limit;
+    this.#windowMs = windowMs;
+    this.#now = now;
+  }
+
+  /** Returns true and records the call if `key` is under its limit for the
+   * current window; returns false without recording if over. A new window
+   * starts (and the count resets) once windowMs has elapsed since the
+   * window began. */
+  isAllowed(key: string): boolean {
+    const now = this.#now();
+    const state = this.#state.get(key);
+
+    if (!state || now - state.windowStart >= this.#windowMs) {
+      this.#state.set(key, { count: 1, windowStart: now });
+      return true;
+    }
+
+    if (state.count >= this.#limit) {
+      return false;
+    }
+
+    state.count++;
+    return true;
+  }
+}
+
+function main() {
+  const limiter = new SimpleRateLimiter(3, 1000);
+
+  console.log("Calling with key 'user-1' 5 times (limit=3, window=1000ms):");
+  for (let i = 1; i <= 5; i++) {
+    console.log(`  call ${i}: ${limiter.isAllowed("user-1") ? "allowed" : "rejected"}`);
+  }
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main();
+}

--- a/contrib/examples/simple-retry/README.md
+++ b/contrib/examples/simple-retry/README.md
@@ -1,0 +1,42 @@
+# Simple fixed-count retry
+
+Wraps an async function call with a simple fixed-count retry loop: try
+again immediately, up to `maxAttempts` times, logging each attempt number.
+
+## Run it
+
+```sh
+npx tsx simple-retry.ts
+```
+
+Runs against a function that fails on the first two calls and succeeds on
+the third:
+
+```
+Attempt 1/5
+Attempt 2/5
+Attempt 3/5
+Result: success
+```
+
+## Simple retry vs. exponential backoff
+
+This wrapper retries **immediately**, with no delay between attempts — fine
+for a quick, cheap operation, or when the caller wants to fail fast after a
+bounded number of tries. It has no concept of a delay, jitter, or a growing
+wait time.
+
+Exponential backoff (see e.g. the `retrying-fetch` example) waits
+progressively longer between attempts (`delay * 2^attempt`, often with
+jitter). That's the right choice against a real network call or a shared
+service that might be rate-limiting or momentarily overloaded — retrying
+instantly in a tight loop can make things worse, not better. Reach for this
+simple version only when you know the failure is likely to clear
+immediately (e.g. a transient in-memory race) rather than a network or
+service-level issue.
+
+## Tests
+
+```sh
+npx vitest run contrib/examples/simple-retry
+```

--- a/contrib/examples/simple-retry/simple-retry.test.ts
+++ b/contrib/examples/simple-retry/simple-retry.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it, vi } from "vitest";
+import { simpleRetry } from "./simple-retry";
+
+describe("simpleRetry", () => {
+  it("succeeds on the first attempt with no retries needed", async () => {
+    const fn = vi.fn(async () => "ok");
+    await expect(simpleRetry(fn, 3)).resolves.toBe("ok");
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  it("retries a fixed number of times, then succeeds", async () => {
+    let calls = 0;
+    const fn = async () => {
+      calls++;
+      if (calls < 3) throw new Error(`fail ${calls}`);
+      return "success";
+    };
+    await expect(simpleRetry(fn, 5)).resolves.toBe("success");
+    expect(calls).toBe(3);
+  });
+
+  it("throws the last error once maxAttempts is exhausted", async () => {
+    const fn = vi.fn(async () => {
+      throw new Error("always fails");
+    });
+    await expect(simpleRetry(fn, 3)).rejects.toThrow("always fails");
+    expect(fn).toHaveBeenCalledTimes(3);
+  });
+});

--- a/contrib/examples/simple-retry/simple-retry.ts
+++ b/contrib/examples/simple-retry/simple-retry.ts
@@ -1,0 +1,37 @@
+// Example: wrap an async function call with a simple fixed-count retry loop
+// — no delay, no backoff, just "try again immediately, up to maxAttempts
+// times". See the README for how this differs from exponential backoff.
+//
+// Run with: npx tsx simple-retry.ts
+
+export async function simpleRetry<T>(fn: () => Promise<T>, maxAttempts: number): Promise<T> {
+  let lastError: unknown;
+  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+    console.log(`Attempt ${attempt}/${maxAttempts}`);
+    try {
+      return await fn();
+    } catch (err) {
+      lastError = err;
+    }
+  }
+  throw lastError;
+}
+
+async function main() {
+  // A function that fails twice, then succeeds on the third attempt.
+  let calls = 0;
+  const flaky = async () => {
+    calls++;
+    if (calls < 3) {
+      throw new Error(`simulated failure on attempt ${calls}`);
+    }
+    return "success";
+  };
+
+  const result = await simpleRetry(flaky, 5);
+  console.log(`Result: ${result}`);
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main();
+}

--- a/contrib/examples/testnet-network-info/README.md
+++ b/contrib/examples/testnet-network-info/README.md
@@ -1,0 +1,32 @@
+# Testnet network info
+
+Prints the canonical Stellar testnet network passphrase and its CAIP-2
+identifier. Pure constant lookup — no network calls.
+
+## Where this is used in the SDK
+
+- `TESTNET.networkPassphrase` (`src/config.ts`) is one of the fields in the
+  `TESTNET` `NetworkConfig` — used to construct `PasskeyKit`/`SACClient` and
+  to sign/submit transactions on the correct network.
+- The `stellar:testnet` CAIP-2 identifier is how the SDK's x402 client
+  (`src/x402-client.ts`) tags testnet payment requirements per the x402 v2
+  spec (`PaymentRequirements.network`, `src/x402-types.ts`).
+
+## Run it
+
+```sh
+npx tsx testnet-network-info.ts
+```
+
+Expected output:
+
+```
+Network passphrase: Test SDF Network ; September 2015
+CAIP-2 identifier:  stellar:testnet
+```
+
+## Tests
+
+```sh
+npx vitest run contrib/examples/testnet-network-info
+```

--- a/contrib/examples/testnet-network-info/testnet-network-info.test.ts
+++ b/contrib/examples/testnet-network-info/testnet-network-info.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from "vitest";
+import { TESTNET } from "../../../src/config";
+import { TESTNET_CAIP2 } from "./testnet-network-info";
+
+describe("testnet network info", () => {
+  it("exposes the canonical testnet passphrase from src/config", () => {
+    expect(TESTNET.networkPassphrase).toBe("Test SDF Network ; September 2015");
+  });
+
+  it("exposes the stellar:testnet CAIP-2 identifier", () => {
+    expect(TESTNET_CAIP2).toBe("stellar:testnet");
+  });
+});

--- a/contrib/examples/testnet-network-info/testnet-network-info.ts
+++ b/contrib/examples/testnet-network-info/testnet-network-info.ts
@@ -1,0 +1,21 @@
+// Example: print the canonical Stellar testnet network passphrase and its
+// CAIP-2 identifier. Pure constant lookup — no network calls.
+//
+// Run with: npx tsx testnet-network-info.ts
+
+import { TESTNET } from "../../../src/config";
+
+// The CAIP-2 identifier vellar-sdk's x402 client maps testnet to internally
+// (src/x402-client.ts's CAIP2_BY_NETWORK / src/x402-types.ts's
+// PaymentRequirements.network doc) — not exported as a named constant, so
+// it's reproduced here as the same literal.
+export const TESTNET_CAIP2 = "stellar:testnet";
+
+function main() {
+  console.log("Network passphrase:", TESTNET.networkPassphrase);
+  console.log("CAIP-2 identifier: ", TESTNET_CAIP2);
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main();
+}

--- a/contrib/examples/truncate-address/README.md
+++ b/contrib/examples/truncate-address/README.md
@@ -1,0 +1,25 @@
+# Truncate an address for display
+
+Shortens a long Stellar address to a display-friendly form: the first six
+and last four characters, joined by dots. Returns the original string
+unchanged if it's already short enough.
+
+## Examples
+
+| Input | Output |
+| --- | --- |
+| `GABC123DEF456GHI789JKL012MNO345PQR678STU901VWX234YZ` | `GABC12...34YZ` |
+| `CDFDULU2JWKGMIJW6FJWJJKNB3JIDQK54YTBDQUNPZTBYXCXCSO3MVZG` | `CDFDUL...MVZG` |
+| `GSHORT` (shorter than 6+4) | `GSHORT` (returned unchanged) |
+
+## Run it
+
+```sh
+npx tsx truncate-address.ts
+```
+
+## Tests
+
+```sh
+npx vitest run contrib/examples/truncate-address
+```

--- a/contrib/examples/truncate-address/truncate-address.test.ts
+++ b/contrib/examples/truncate-address/truncate-address.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+import { truncateAddress } from "./truncate-address";
+
+describe("truncateAddress", () => {
+  it("shortens a long address to first 6 + last 4 characters", () => {
+    expect(truncateAddress("CDFDULU2JWKGMIJW6FJWJJKNB3JIDQK54YTBDQUNPZTBYXCXCSO3MVZG")).toBe(
+      "CDFDUL...MVZG",
+    );
+  });
+
+  it("returns an address exactly at the head+tail length unchanged", () => {
+    expect(truncateAddress("1234567890")).toBe("1234567890"); // 10 chars = 6 + 4
+  });
+
+  it("returns a shorter address unchanged", () => {
+    expect(truncateAddress("GSHORT")).toBe("GSHORT");
+  });
+
+  it("supports custom head/tail lengths", () => {
+    expect(truncateAddress("ABCDEFGHIJKLMNOP", 3, 2)).toBe("ABC...OP");
+  });
+});

--- a/contrib/examples/truncate-address/truncate-address.ts
+++ b/contrib/examples/truncate-address/truncate-address.ts
@@ -1,0 +1,28 @@
+// Example: shorten a long Stellar address to a display-friendly form — the
+// first six and last four characters, joined by dots.
+//
+// Run with: npx tsx truncate-address.ts
+
+/** Truncates an address to "<first 6>...<last 4>". An address no longer
+ * than headLen + tailLen is returned unchanged. */
+export function truncateAddress(address: string, headLen = 6, tailLen = 4): string {
+  if (address.length <= headLen + tailLen) {
+    return address;
+  }
+  return `${address.slice(0, headLen)}...${address.slice(-tailLen)}`;
+}
+
+function main() {
+  const examples = [
+    "GABC123DEF456GHI789JKL012MNO345PQR678STU901VWX234YZ",
+    "CDFDULU2JWKGMIJW6FJWJJKNB3JIDQK54YTBDQUNPZTBYXCXCSO3MVZG",
+    "GSHORT",
+  ];
+  for (const address of examples) {
+    console.log(`${address}  ->  ${truncateAddress(address)}`);
+  }
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main();
+}

--- a/contrib/examples/tx-history-sync-worker/README.md
+++ b/contrib/examples/tx-history-sync-worker/README.md
@@ -1,0 +1,62 @@
+# Transaction history sync worker
+
+A worker that periodically polls a transaction source and appends only
+newly-seen transactions to a local in-memory history — safe against a
+source whose results **overlap between polls** (e.g. "the last N
+transactions" rather than strictly incremental results).
+
+## How dedup works
+
+`mergeBatch` tracks every id it has ever accepted in a `Set`, so a
+transaction that reappears in a later poll (because the source's window
+overlapped with the previous one) is silently skipped rather than
+re-appended. The worker also exposes `lastSeenId()` — the id of the most
+recently *accepted* transaction — for observability, derived from the same
+dedup state rather than being a second, separately-tracked cursor that could
+drift out of sync with it.
+
+## Usage
+
+```ts
+import { createSyncWorker } from "./tx-history-sync-worker";
+
+const worker = createSyncWorker(fetchLatestTransactions, 5000);
+worker.start(); // polls immediately, then every 5s
+
+// later
+worker.history();   // every transaction seen so far, oldest first, deduplicated
+worker.lastSeenId(); // the most recently accepted transaction's id
+worker.stop();       // stop polling; history is preserved
+```
+
+## Run it
+
+```sh
+npx tsx tx-history-sync-worker.ts
+```
+
+Expected output (three polls, each overlapping the previous one by one
+transaction):
+
+```
+Poll 1: saw 2, 2 new
+Poll 2: saw 2, 1 new
+Poll 3: saw 3, 2 new
+Deduplicated history: [
+  { id: 'tx-1', amount: '10' },
+  { id: 'tx-2', amount: '20' },
+  { id: 'tx-3', amount: '30' },
+  { id: 'tx-4', amount: '40' },
+  { id: 'tx-5', amount: '50' }
+]
+```
+
+## Tests
+
+```sh
+npx vitest run contrib/examples/tx-history-sync-worker
+```
+
+`mergeBatch` (the dedup core) is tested directly with plain arrays; the
+`createSyncWorker` interval/start/stop behavior is tested with vitest's fake
+timers.

--- a/contrib/examples/tx-history-sync-worker/tx-history-sync-worker.test.ts
+++ b/contrib/examples/tx-history-sync-worker/tx-history-sync-worker.test.ts
@@ -1,0 +1,103 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createEmptyState, createSyncWorker, mergeBatch, type SyncedTransaction } from "./tx-history-sync-worker";
+
+describe("mergeBatch", () => {
+  it("appends every transaction from an all-new batch", () => {
+    const state = createEmptyState();
+    const newCount = mergeBatch(state, [{ id: "tx-1", amount: "10" }, { id: "tx-2", amount: "20" }]);
+
+    expect(newCount).toBe(2);
+    expect(state.history).toEqual([{ id: "tx-1", amount: "10" }, { id: "tx-2", amount: "20" }]);
+  });
+
+  it("skips ids already seen in a previous merge, keeping only the new ones", () => {
+    const state = createEmptyState();
+    mergeBatch(state, [{ id: "tx-1", amount: "10" }, { id: "tx-2", amount: "20" }]);
+    const newCount = mergeBatch(state, [{ id: "tx-2", amount: "20" }, { id: "tx-3", amount: "30" }]);
+
+    expect(newCount).toBe(1);
+    expect(state.history.map((tx) => tx.id)).toEqual(["tx-1", "tx-2", "tx-3"]);
+  });
+
+  it("handles a fully overlapping batch as zero new", () => {
+    const state = createEmptyState();
+    mergeBatch(state, [{ id: "tx-1", amount: "10" }]);
+    const newCount = mergeBatch(state, [{ id: "tx-1", amount: "10" }]);
+
+    expect(newCount).toBe(0);
+    expect(state.history).toHaveLength(1);
+  });
+
+  it("processes three overlapping polls into a fully deduplicated history", () => {
+    const state = createEmptyState();
+    mergeBatch(state, [{ id: "tx-1", amount: "10" }, { id: "tx-2", amount: "20" }]);
+    mergeBatch(state, [{ id: "tx-2", amount: "20" }, { id: "tx-3", amount: "30" }]);
+    mergeBatch(state, [{ id: "tx-3", amount: "30" }, { id: "tx-4", amount: "40" }, { id: "tx-5", amount: "50" }]);
+
+    expect(state.history.map((tx) => tx.id)).toEqual(["tx-1", "tx-2", "tx-3", "tx-4", "tx-5"]);
+  });
+});
+
+describe("createSyncWorker", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("polls immediately on start and reports history/lastSeenId", async () => {
+    const source = vi.fn<() => SyncedTransaction[]>().mockReturnValue([{ id: "tx-1", amount: "10" }]);
+    const worker = createSyncWorker(source, 1000);
+
+    worker.start();
+    await vi.waitFor(() => expect(source).toHaveBeenCalledTimes(1));
+
+    expect(worker.history()).toEqual([{ id: "tx-1", amount: "10" }]);
+    expect(worker.lastSeenId()).toBe("tx-1");
+    worker.stop();
+  });
+
+  it("polls again after the interval elapses", async () => {
+    const source = vi
+      .fn<() => SyncedTransaction[]>()
+      .mockReturnValueOnce([{ id: "tx-1", amount: "10" }])
+      .mockReturnValueOnce([{ id: "tx-1", amount: "10" }, { id: "tx-2", amount: "20" }]);
+    const worker = createSyncWorker(source, 1000);
+
+    worker.start();
+    await vi.waitFor(() => expect(source).toHaveBeenCalledTimes(1));
+
+    await vi.advanceTimersByTimeAsync(1000);
+    await vi.waitFor(() => expect(source).toHaveBeenCalledTimes(2));
+
+    expect(worker.history().map((tx) => tx.id)).toEqual(["tx-1", "tx-2"]);
+    worker.stop();
+  });
+
+  it("stops polling after stop() is called", async () => {
+    const source = vi.fn<() => SyncedTransaction[]>().mockReturnValue([{ id: "tx-1", amount: "10" }]);
+    const worker = createSyncWorker(source, 1000);
+
+    worker.start();
+    await vi.waitFor(() => expect(source).toHaveBeenCalledTimes(1));
+    worker.stop();
+
+    await vi.advanceTimersByTimeAsync(5000);
+    expect(source).toHaveBeenCalledTimes(1);
+  });
+
+  it("calling start() twice does not double the polling interval", async () => {
+    const source = vi.fn<() => SyncedTransaction[]>().mockReturnValue([]);
+    const worker = createSyncWorker(source, 1000);
+
+    worker.start();
+    await vi.waitFor(() => expect(source).toHaveBeenCalledTimes(1));
+    worker.start(); // no-op, already running
+
+    await vi.advanceTimersByTimeAsync(1000);
+    await vi.waitFor(() => expect(source).toHaveBeenCalledTimes(2));
+    worker.stop();
+  });
+});

--- a/contrib/examples/tx-history-sync-worker/tx-history-sync-worker.ts
+++ b/contrib/examples/tx-history-sync-worker/tx-history-sync-worker.ts
@@ -1,0 +1,119 @@
+// Example: a worker that periodically polls a transaction source and
+// appends only newly-seen transactions to a local in-memory history,
+// deduplicating across polls whose results overlap — e.g. a source that
+// always returns "the last N transactions" rather than only new ones since
+// last poll.
+//
+// Run with: npx tsx tx-history-sync-worker.ts
+
+export interface SyncedTransaction {
+  id: string;
+  amount: string;
+}
+
+export type TransactionSource = () => Promise<SyncedTransaction[]> | SyncedTransaction[];
+
+export interface SyncState {
+  history: SyncedTransaction[];
+  seenIds: Set<string>;
+}
+
+export function createEmptyState(): SyncState {
+  return { history: [], seenIds: new Set() };
+}
+
+/**
+ * Merges one poll's `batch` into `state`, mutating it in place: any
+ * transaction whose id has already been seen is skipped, everything else is
+ * appended to history in the order it appears in the batch. Returns how
+ * many were newly added.
+ *
+ * A plain seen-id set (rather than only comparing against a single "last
+ * seen" cursor) is used so this stays correct even if the mock/real source
+ * doesn't guarantee strict ordering across polls — the tracked "last seen
+ * identifier" the worker reports (see `lastSeenId` below) is simply the id
+ * of the most recently accepted transaction, derived from this set.
+ */
+export function mergeBatch(state: SyncState, batch: SyncedTransaction[]): number {
+  let newCount = 0;
+  for (const tx of batch) {
+    if (state.seenIds.has(tx.id)) continue;
+    state.seenIds.add(tx.id);
+    state.history.push(tx);
+    newCount++;
+  }
+  return newCount;
+}
+
+export interface SyncWorker {
+  /** Runs one poll immediately, then again every `intervalMs`. Calling
+   * start() while already running is a no-op. */
+  start(): void;
+  /** Stops future polling. The accumulated history is left intact. */
+  stop(): void;
+  /** A copy of every transaction seen so far, oldest first. */
+  history(): SyncedTransaction[];
+  /** The id of the most recently accepted transaction, or undefined before
+   * the first successful poll. */
+  lastSeenId(): string | undefined;
+}
+
+export function createSyncWorker(
+  source: TransactionSource,
+  intervalMs: number,
+  log: (line: string) => void = () => {},
+): SyncWorker {
+  const state = createEmptyState();
+  let timer: ReturnType<typeof setInterval> | undefined;
+  let lastId: string | undefined;
+
+  async function pollOnce(): Promise<void> {
+    const batch = await source();
+    const newCount = mergeBatch(state, batch);
+    if (newCount > 0) {
+      lastId = state.history[state.history.length - 1]?.id;
+    }
+    log(`Poll: saw ${batch.length}, ${newCount} new (history size: ${state.history.length}, last seen id: ${lastId ?? "none"})`);
+  }
+
+  return {
+    start() {
+      if (timer) return;
+      void pollOnce();
+      timer = setInterval(() => void pollOnce(), intervalMs);
+    },
+    stop() {
+      if (timer) {
+        clearInterval(timer);
+        timer = undefined;
+      }
+    },
+    history: () => [...state.history],
+    lastSeenId: () => lastId,
+  };
+}
+
+async function main() {
+  // A mock source whose results overlap between polls, like a "last N
+  // transactions" feed rather than a strictly incremental one.
+  const pages: SyncedTransaction[][] = [
+    [{ id: "tx-1", amount: "10" }, { id: "tx-2", amount: "20" }],
+    [{ id: "tx-2", amount: "20" }, { id: "tx-3", amount: "30" }], // tx-2 repeats
+    [{ id: "tx-3", amount: "30" }, { id: "tx-4", amount: "40" }, { id: "tx-5", amount: "50" }], // tx-3 repeats
+  ];
+  let pageIndex = 0;
+  const source: TransactionSource = () => pages[Math.min(pageIndex++, pages.length - 1)] ?? [];
+
+  const state = createEmptyState();
+  for (let i = 0; i < pages.length; i++) {
+    const batch = await source();
+    const newCount = mergeBatch(state, batch);
+    console.log(`Poll ${i + 1}: saw ${batch.length}, ${newCount} new`);
+  }
+
+  console.log("Deduplicated history:", state.history);
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main();
+}

--- a/contrib/examples/tx-history-table/README.md
+++ b/contrib/examples/tx-history-table/README.md
@@ -1,0 +1,32 @@
+# Transaction history table
+
+Formats an array of sample transaction records as an aligned text table for
+terminal output, with columns for hash, amount, and timestamp. An empty
+array prints a clear "No transactions." message instead of an
+empty/headerless table.
+
+## Run it
+
+```sh
+npx tsx tx-history-table.ts
+```
+
+Expected output:
+
+```
+With transactions:
+HASH                    AMOUNT  TIMESTAMP
+-----------------------------------------
+a1b2c3d4e5f6a7b8   100.5000000  2026-01-15T09:30:00Z
+f6e5d4c3b2a1f0e9     2.5000000  2026-01-15T10:12:45Z
+1234567890abcdef  1000.0000000  2026-01-16T08:00:00Z
+
+With an empty array:
+No transactions.
+```
+
+## Tests
+
+```sh
+npx vitest run contrib/examples/tx-history-table
+```

--- a/contrib/examples/tx-history-table/tx-history-table.test.ts
+++ b/contrib/examples/tx-history-table/tx-history-table.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+import { formatTxHistoryTable } from "./tx-history-table";
+
+describe("formatTxHistoryTable", () => {
+  it("prints a clear message for an empty array", () => {
+    expect(formatTxHistoryTable([])).toBe("No transactions.");
+  });
+
+  it("includes a header row with hash, amount, and timestamp columns", () => {
+    const table = formatTxHistoryTable([{ hash: "abc123", amount: "10.0000000", timestamp: "2026-01-01T00:00:00Z" }]);
+    expect(table).toContain("HASH");
+    expect(table).toContain("AMOUNT");
+    expect(table).toContain("TIMESTAMP");
+  });
+
+  it("includes a row for each transaction", () => {
+    const table = formatTxHistoryTable([
+      { hash: "hash1", amount: "1.0000000", timestamp: "2026-01-01T00:00:00Z" },
+      { hash: "hash2", amount: "2.0000000", timestamp: "2026-01-02T00:00:00Z" },
+    ]);
+    expect(table).toContain("hash1");
+    expect(table).toContain("hash2");
+  });
+
+  it("right-aligns the amount column for readability", () => {
+    const table = formatTxHistoryTable([
+      { hash: "h1", amount: "1", timestamp: "t1" },
+      { hash: "h2", amount: "1000000", timestamp: "t2" },
+    ]);
+    const lines = table.split("\n");
+    // Both amount values should end at the same column position.
+    const amountEnd1 = lines[2]!.indexOf("t1");
+    const amountEnd2 = lines[3]!.indexOf("t2");
+    expect(amountEnd1).toBe(amountEnd2);
+  });
+});

--- a/contrib/examples/tx-history-table/tx-history-table.ts
+++ b/contrib/examples/tx-history-table/tx-history-table.ts
@@ -1,0 +1,50 @@
+// Example: format an array of sample transaction records as an aligned
+// text table for terminal output.
+//
+// Run with: npx tsx tx-history-table.ts
+
+export interface TxRecord {
+  hash: string;
+  amount: string;
+  timestamp: string;
+}
+
+/** Formats transactions as an aligned text table (hash, amount, timestamp).
+ * An empty array prints a clear "no transactions" message instead of an
+ * empty/headerless table. */
+export function formatTxHistoryTable(transactions: TxRecord[]): string {
+  if (transactions.length === 0) {
+    return "No transactions.";
+  }
+
+  const headers = { hash: "HASH", amount: "AMOUNT", timestamp: "TIMESTAMP" };
+  const hashWidth = Math.max(headers.hash.length, ...transactions.map((t) => t.hash.length));
+  const amountWidth = Math.max(headers.amount.length, ...transactions.map((t) => t.amount.length));
+
+  const row = (t: { hash: string; amount: string; timestamp: string }) =>
+    `${t.hash.padEnd(hashWidth)}  ${t.amount.padStart(amountWidth)}  ${t.timestamp}`;
+
+  const lines = [row(headers), "-".repeat(row(headers).length)];
+  for (const tx of transactions) {
+    lines.push(row(tx));
+  }
+  return lines.join("\n");
+}
+
+function main() {
+  const sample: TxRecord[] = [
+    { hash: "a1b2c3d4e5f6a7b8", amount: "100.5000000", timestamp: "2026-01-15T09:30:00Z" },
+    { hash: "f6e5d4c3b2a1f0e9", amount: "2.5000000", timestamp: "2026-01-15T10:12:45Z" },
+    { hash: "1234567890abcdef", amount: "1000.0000000", timestamp: "2026-01-16T08:00:00Z" },
+  ];
+
+  console.log("With transactions:");
+  console.log(formatTxHistoryTable(sample));
+  console.log();
+  console.log("With an empty array:");
+  console.log(formatTxHistoryTable([]));
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main();
+}

--- a/contrib/examples/validate-max-amount/README.md
+++ b/contrib/examples/validate-max-amount/README.md
@@ -1,0 +1,31 @@
+# validate-max-amount
+
+Advisory helper that checks a proposed `maxAmount` against a mock price feed
+and warns when the implied fiat value looks unreasonably high.
+
+## Usage
+
+```ts
+import { validateMaxAmount } from "./index";
+
+const result = validateMaxAmount({
+  asset: "ETH",
+  amount: 500_000_000_000n, // 50,000 ETH
+});
+
+if (result.warned) {
+  console.warn(result.message);
+}
+```
+
+## Example output
+
+```
+⚠️ maxAmount implies ~$150000000.00 USD, which is unusually high (asset=ETH).
+```
+
+## Notes
+
+- This is a heuristic for UI/UX guidance only; it does not enforce on-chain limits.
+- Default price feed contains USDC, ETH, BTC, XLM, CUSTOM_ASSET.
+- Override `warningThreshold` or `assetDecimals` to tune sensitivity.

--- a/contrib/examples/validate-max-amount/index.ts
+++ b/contrib/examples/validate-max-amount/index.ts
@@ -1,0 +1,70 @@
+/**
+ * Advisory helper that checks a proposed `maxAmount` against a mock price feed
+ * and returns a warning when the implied fiat value looks unreasonably high.
+ *
+ * This is NOT enforcement — it is a heuristic for UI/UX guidance.
+ */
+
+export interface PriceFeed {
+  [assetCode: string]: number; // asset code → reference fiat rate per 1 unit
+}
+
+export interface ValidationResult {
+  /** True when the amount exceeds the warning threshold. */
+  warned: boolean;
+  /** Human-readable warning message, or undefined if no warning. */
+  message?: string;
+}
+
+const DEFAULT_PRICE_FEED: PriceFeed = {
+  USDC: 1.0,
+  ETH: 3000.0,
+  BTC: 60000.0,
+  XLM: 0.12,
+  // Custom asset example
+  CUSTOM_ASSET: 42.0,
+};
+
+/**
+ * Validate a maxAmount (in base units of the asset) against a hardcoded price
+ * feed. Uses a simple threshold: warn if the implied fiat value is above a
+ * very high hardcoded cap (e.g. $1,000,000) for the asset.
+ */
+export function validateMaxAmount(options: {
+  asset: string;
+  amount: bigint;
+  /** Optional override price feed. */
+  priceFeed?: PriceFeed;
+  /** Warning threshold in fiat units (e.g. USD). Default: 1_000_000. */
+  warningThreshold?: number;
+  /** Decimals to interpret the base unit amount. Default: 7. */
+  assetDecimals?: number;
+}): ValidationResult {
+  const {
+    asset,
+    amount,
+    priceFeed = DEFAULT_PRICE_FEED,
+    warningThreshold = 1_000_000,
+    assetDecimals = 7,
+  } = options;
+
+  const unitPrice = priceFeed[asset];
+  if (unitPrice === undefined) {
+    return {
+      warned: false,
+      message: `No price feed available for ${asset}; cannot validate.`,
+    };
+  }
+
+  const amountNum = Number(amount) / Math.pow(10, assetDecimals);
+  const fiatValue = amountNum * unitPrice;
+
+  if (fiatValue > warningThreshold) {
+    return {
+      warned: true,
+      message: `maxAmount implies ~$${fiatValue.toFixed(2)} USD, which is unusually high (asset=${asset}).`,
+    };
+  }
+
+  return { warned: false };
+}

--- a/contrib/examples/validate-max-amount/test.ts
+++ b/contrib/examples/validate-max-amount/test.ts
@@ -1,0 +1,34 @@
+import { validateMaxAmount } from "./index";
+
+console.log("validate-max-amount tests:");
+
+{
+  const result = validateMaxAmount({
+    asset: "ETH",
+    amount: 1_000_000_000n, // 0.1 ETH → ~$300
+  });
+  console.assert(result.warned === false, "expected no warning for reasonable amount");
+  console.log("ok: ETH 0.1 → no warning");
+}
+
+{
+  const result = validateMaxAmount({
+    asset: "ETH",
+    amount: 500_000_000_000n, // 50,000 ETH → ~$150,000,000
+  });
+  console.assert(result.warned === true, "expected warning for huge amount");
+  console.assert(result.message !== undefined, "expected message");
+  console.log("ok: ETH 50k → warned:", result.message);
+}
+
+{
+  const result = validateMaxAmount({
+    asset: "UNKNOWN",
+    amount: 1_000n,
+  });
+  console.assert(result.warned === false, "expected no warning when no price feed");
+  console.assert(result.message !== undefined, "expected message about missing feed");
+  console.log("ok: UNKNOWN asset → skipped with message");
+}
+
+console.log("validate-max-amount tests passed");

--- a/contrib/examples/validate-passphrase/README.md
+++ b/contrib/examples/validate-passphrase/README.md
@@ -1,0 +1,36 @@
+# Validate a network passphrase
+
+Checks a given network passphrase string against `vellar-sdk`'s known
+`TESTNET`/`MAINNET` passphrases (`src/config.ts`), returning which network
+it matches, or `null` if unknown.
+
+**The comparison is exact and case-sensitive** — a passphrase that differs
+only by casing, or has extra surrounding whitespace, does **not** match and
+returns `null`. This is deliberate: a network passphrase feeds directly into
+transaction signing, so a "close enough" match would be a correctness bug
+(e.g. Stellar's SDK computes different signatures for a passphrase that
+differs even by a single character), not a convenience worth adding.
+
+## Run it
+
+```sh
+npx tsx validate-passphrase.ts
+```
+
+Expected output:
+
+```
+"Test SDF Network ; September 2015" -> testnet
+"Public Global Stellar Network ; September 2015" -> mainnet
+"Not a real passphrase" -> unknown
+"test sdf network ; september 2015" -> unknown
+```
+
+## Tests
+
+Covers the testnet passphrase, the mainnet passphrase, and an unknown
+string:
+
+```sh
+npx vitest run contrib/examples/validate-passphrase
+```

--- a/contrib/examples/validate-passphrase/validate-passphrase.test.ts
+++ b/contrib/examples/validate-passphrase/validate-passphrase.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+import { MAINNET, TESTNET } from "../../../src/config";
+import { matchNetworkPassphrase } from "./validate-passphrase";
+
+describe("matchNetworkPassphrase", () => {
+  it("matches the testnet passphrase", () => {
+    expect(matchNetworkPassphrase(TESTNET.networkPassphrase)).toBe("testnet");
+  });
+
+  it("matches the mainnet passphrase", () => {
+    expect(matchNetworkPassphrase(MAINNET.networkPassphrase)).toBe("mainnet");
+  });
+
+  it("returns null for an unknown string", () => {
+    expect(matchNetworkPassphrase("Not a real passphrase")).toBeNull();
+  });
+
+  it("is case-sensitive — a different-case match returns null", () => {
+    expect(matchNetworkPassphrase(TESTNET.networkPassphrase.toLowerCase())).toBeNull();
+  });
+
+  it("does not trim — surrounding whitespace returns null", () => {
+    expect(matchNetworkPassphrase(` ${TESTNET.networkPassphrase} `)).toBeNull();
+  });
+});

--- a/contrib/examples/validate-passphrase/validate-passphrase.ts
+++ b/contrib/examples/validate-passphrase/validate-passphrase.ts
@@ -1,0 +1,36 @@
+// Example: check a given network passphrase string against the known
+// testnet/mainnet passphrases, returning which network it matches (or null
+// if unknown). Comparison is case-sensitive and exact — a passphrase with
+// different casing or extra whitespace does NOT match.
+//
+// Run with: npx tsx validate-passphrase.ts
+
+import { MAINNET, TESTNET } from "../../../src/config";
+
+export type NetworkMatch = "testnet" | "mainnet" | null;
+
+/** Exact, case-sensitive match against TESTNET/MAINNET.networkPassphrase.
+ * Returns null for anything else, including a passphrase that only differs
+ * by case or surrounding whitespace. */
+export function matchNetworkPassphrase(passphrase: string): NetworkMatch {
+  if (passphrase === TESTNET.networkPassphrase) return "testnet";
+  if (passphrase === MAINNET.networkPassphrase) return "mainnet";
+  return null;
+}
+
+function main() {
+  const examples = [
+    TESTNET.networkPassphrase,
+    MAINNET.networkPassphrase,
+    "Not a real passphrase",
+    TESTNET.networkPassphrase.toLowerCase(), // wrong case — does not match
+  ];
+
+  for (const passphrase of examples) {
+    console.log(`"${passphrase}" -> ${matchNetworkPassphrase(passphrase) ?? "unknown"}`);
+  }
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main();
+}

--- a/contrib/examples/validate-policy-body/README.md
+++ b/contrib/examples/validate-policy-body/README.md
@@ -1,0 +1,38 @@
+# Validate a policy body before generate
+
+Locally validates a spending-limit policy body (`{ limit, windowSeconds }`)
+before it would be sent to a generate endpoint, catching obvious mistakes
+early. Returns a list of every validation error found, rather than throwing
+on the first one, so a caller can show all the problems at once.
+
+## Checks
+
+- `limit` must be a finite, positive number.
+- `windowSeconds` must be an integer between 1 and 2,592,000 (30 days) — a
+  window longer than that isn't a meaningful rolling window for a spending
+  limit, and usually signals the value is in the wrong unit (e.g.
+  milliseconds instead of seconds).
+
+## Run it
+
+```sh
+npx tsx validate-policy-body.ts
+```
+
+Expected output:
+
+```
+Valid body errors:   []
+Invalid body errors: [
+  'limit must be a positive number, got -5',
+  'windowSeconds must be between 1 and 2592000 (30 days), got 99999999'
+]
+```
+
+## Tests
+
+Covers a valid body and a body with multiple issues:
+
+```sh
+npx vitest run contrib/examples/validate-policy-body
+```

--- a/contrib/examples/validate-policy-body/validate-policy-body.test.ts
+++ b/contrib/examples/validate-policy-body/validate-policy-body.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+import { validatePolicyBody } from "./validate-policy-body";
+
+describe("validatePolicyBody", () => {
+  it("returns no errors for a valid body", () => {
+    expect(validatePolicyBody({ limit: 100, windowSeconds: 86_400 })).toEqual([]);
+  });
+
+  it("returns every issue for a body with multiple problems, not just the first", () => {
+    const errors = validatePolicyBody({ limit: -5, windowSeconds: 99_999_999 });
+    expect(errors).toHaveLength(2);
+    expect(errors[0]).toMatch(/limit must be a positive number/);
+    expect(errors[1]).toMatch(/windowSeconds must be between/);
+  });
+
+  it("rejects a zero limit", () => {
+    expect(validatePolicyBody({ limit: 0, windowSeconds: 86_400 })).toEqual([
+      "limit must be a positive number, got 0",
+    ]);
+  });
+
+  it("rejects a non-integer windowSeconds", () => {
+    const errors = validatePolicyBody({ limit: 100, windowSeconds: 86_400.5 });
+    expect(errors).toEqual(["windowSeconds must be an integer, got 86400.5"]);
+  });
+
+  it("rejects a windowSeconds below the minimum", () => {
+    const errors = validatePolicyBody({ limit: 100, windowSeconds: 0 });
+    expect(errors[0]).toMatch(/must be between 1 and/);
+  });
+});

--- a/contrib/examples/validate-policy-body/validate-policy-body.ts
+++ b/contrib/examples/validate-policy-body/validate-policy-body.ts
@@ -1,0 +1,47 @@
+// Example: locally validate a spending-limit policy body before it would be
+// sent to a generate endpoint, catching obvious mistakes early. Returns a
+// list of every problem found, rather than throwing on the first one, so a
+// caller can show all the issues at once.
+//
+// Run with: npx tsx validate-policy-body.ts
+
+export interface PolicyBody {
+  limit: number;
+  windowSeconds: number;
+}
+
+// A window longer than 30 days isn't a meaningful "rolling window" for a
+// spending limit — treat it as a sign the value is probably in the wrong
+// unit (e.g. milliseconds instead of seconds).
+const MAX_WINDOW_SECONDS = 30 * 24 * 60 * 60;
+const MIN_WINDOW_SECONDS = 1;
+
+export function validatePolicyBody(body: PolicyBody): string[] {
+  const errors: string[] = [];
+
+  if (!Number.isFinite(body.limit) || body.limit <= 0) {
+    errors.push(`limit must be a positive number, got ${body.limit}`);
+  }
+
+  if (!Number.isFinite(body.windowSeconds) || !Number.isInteger(body.windowSeconds)) {
+    errors.push(`windowSeconds must be an integer, got ${body.windowSeconds}`);
+  } else if (body.windowSeconds < MIN_WINDOW_SECONDS || body.windowSeconds > MAX_WINDOW_SECONDS) {
+    errors.push(
+      `windowSeconds must be between ${MIN_WINDOW_SECONDS} and ${MAX_WINDOW_SECONDS} (30 days), got ${body.windowSeconds}`,
+    );
+  }
+
+  return errors;
+}
+
+function main() {
+  const valid: PolicyBody = { limit: 100, windowSeconds: 86_400 };
+  const invalid: PolicyBody = { limit: -5, windowSeconds: 99_999_999 };
+
+  console.log("Valid body errors:  ", validatePolicyBody(valid));
+  console.log("Invalid body errors:", validatePolicyBody(invalid));
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main();
+}

--- a/contrib/examples/validate-recipient/README.md
+++ b/contrib/examples/validate-recipient/README.md
@@ -1,0 +1,46 @@
+# Validate a payment recipient address
+
+Validates a Stellar address using an `isValidAddress`-style check before
+treating it as a valid payment recipient — the same kind of check
+`createVellarWallet`'s `isValidAddress` config option performs, and that the
+payments client (`src/payments-client.ts`) runs before ever building a
+transaction. A Vellar wallet's recipients may be either a classic account
+(`G...`) or a contract (`C...`), so both are accepted.
+
+## Example addresses
+
+Valid classic account:
+
+```
+GCFNFDLMAQB5J6LV65KG7GNAVGBREUVB2BWSLY6U46ACK4RDZG3SO3SH
+```
+
+Valid contract:
+
+```
+CDFDULU2JWKGMIJW6FJWJJKNB3JIDQK54YTBDQUNPZTBYXCXCSO3MVZG
+```
+
+Invalid — bad checksum (last character flipped):
+
+```
+GCFNFDLMAQB5J6LV65KG7GNAVGBREUVB2BWSLY6U46ACK4RDZG3SO3SA
+```
+
+Invalid — unrecognized prefix:
+
+```
+XCFNFDLMAQB5J6LV65KG7GNAVGBREUVB2BWSLY6U46ACK4RDZG3SO3SH
+```
+
+## Run it
+
+```sh
+npx tsx validate-recipient.ts <address>
+```
+
+## Tests
+
+```sh
+npx vitest run contrib/examples/validate-recipient
+```

--- a/contrib/examples/validate-recipient/validate-recipient.test.ts
+++ b/contrib/examples/validate-recipient/validate-recipient.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+import { validateRecipient } from "./validate-recipient";
+
+const VALID_ACCOUNT = "GCFNFDLMAQB5J6LV65KG7GNAVGBREUVB2BWSLY6U46ACK4RDZG3SO3SH";
+const VALID_CONTRACT = "CDFDULU2JWKGMIJW6FJWJJKNB3JIDQK54YTBDQUNPZTBYXCXCSO3MVZG";
+const BAD_CHECKSUM_ACCOUNT = "GCFNFDLMAQB5J6LV65KG7GNAVGBREUVB2BWSLY6U46ACK4RDZG3SO3SA";
+
+describe("validateRecipient", () => {
+  it("accepts a valid classic account address (G...)", () => {
+    expect(validateRecipient(VALID_ACCOUNT)).toEqual({ valid: true });
+  });
+
+  it("accepts a valid contract address (C...)", () => {
+    expect(validateRecipient(VALID_CONTRACT)).toEqual({ valid: true });
+  });
+
+  it("rejects a well-formed-looking address with a bad checksum", () => {
+    const result = validateRecipient(BAD_CHECKSUM_ACCOUNT);
+    expect(result.valid).toBe(false);
+    expect(result.reason).toMatch(/checksum/);
+  });
+
+  it("rejects an address with an unexpected prefix", () => {
+    const result = validateRecipient("XCFNFDLMAQB5J6LV65KG7GNAVGBREUVB2BWSLY6U46ACK4RDZG3SO3SH");
+    expect(result.valid).toBe(false);
+    expect(result.reason).toMatch(/must start with "G"/);
+  });
+
+  it("rejects an empty string", () => {
+    const result = validateRecipient("");
+    expect(result.valid).toBe(false);
+    expect(result.reason).toBe("address is empty");
+  });
+});

--- a/contrib/examples/validate-recipient/validate-recipient.ts
+++ b/contrib/examples/validate-recipient/validate-recipient.ts
@@ -1,0 +1,58 @@
+// Example: validate a Stellar address before treating it as a valid payment
+// recipient — an isValidAddress-style check, as required by
+// createVellarWallet's config (VellarWalletConfig.isValidAddress) and used
+// internally by the payments client to reject a bad recipient before ever
+// building a transaction.
+//
+// A Vellar wallet's recipients may be either a classic account (G...) or a
+// contract (C...), so both are accepted.
+//
+// Run with: npx tsx validate-recipient.ts <address>
+
+import { StrKey } from "@stellar/stellar-sdk";
+
+export interface AddressCheck {
+  valid: boolean;
+  reason?: string;
+}
+
+export function validateRecipient(address: string): AddressCheck {
+  if (StrKey.isValidEd25519PublicKey(address)) {
+    return { valid: true };
+  }
+  if (StrKey.isValidContract(address)) {
+    return { valid: true };
+  }
+  if (!address) {
+    return { valid: false, reason: "address is empty" };
+  }
+  const prefix = address[0];
+  if (prefix !== "G" && prefix !== "C") {
+    return {
+      valid: false,
+      reason: `must start with "G" (account) or "C" (contract), got "${prefix}"`,
+    };
+  }
+  return { valid: false, reason: "failed strkey checksum/encoding validation" };
+}
+
+function main() {
+  const address = process.argv[2];
+  if (!address) {
+    console.error("Usage: npx tsx validate-recipient.ts <address>");
+    process.exitCode = 1;
+    return;
+  }
+
+  const result = validateRecipient(address);
+  if (result.valid) {
+    console.log(`VALID: ${address}`);
+  } else {
+    console.log(`INVALID: ${address} (${result.reason})`);
+    process.exitCode = 1;
+  }
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main();
+}

--- a/contrib/examples/wallet-diagnostics-report/README.md
+++ b/contrib/examples/wallet-diagnostics-report/README.md
@@ -1,0 +1,67 @@
+# Wallet diagnostics report
+
+Runs four distinct mock diagnostic checks against a real `VellarWallet`
+handle and prints a combined report that clearly separates passing checks
+from failing ones, with a reason for each failure:
+
+1. **Session exists** — `wallet.session` is non-null.
+2. **Session connected** — `wallet.session.connected` is `true`.
+3. **Network matches expected** — `wallet.session.network` equals the
+   network the caller expected.
+4. **Backend reachable** — a caller-supplied `pingBackend()` resolves
+   `true` (a failed ping, a `false` result, and a thrown error are all
+   reported as distinct reasons).
+
+## Usage
+
+```ts
+import { runDiagnostics, formatReport } from "./wallet-diagnostics-report";
+
+const report = await runDiagnostics({
+  wallet,
+  expectedNetwork: "testnet",
+  pingBackend: () => fetch("/health").then((r) => r.ok),
+});
+
+console.log(formatReport(report));
+```
+
+## Run it
+
+```sh
+npx tsx wallet-diagnostics-report.ts
+```
+
+Expected output (before `create()`, the session-dependent checks fail; after,
+everything passes):
+
+```
+Report before connecting (session checks should fail):
+
+Diagnostics: 1/4 passed
+
+Passing:
+  ✓ Backend reachable
+
+Failing:
+  ✗ Session exists — No active session — call create() or connect() first
+  ✗ Session connected — Session exists but is not marked connected
+  ✗ Network matches expected — No session to check the network against
+
+
+Report after connecting (everything should pass):
+
+Diagnostics: 4/4 passed
+
+Passing:
+  ✓ Session exists
+  ✓ Session connected
+  ✓ Network matches expected
+  ✓ Backend reachable
+```
+
+## Tests
+
+```sh
+npx vitest run contrib/examples/wallet-diagnostics-report
+```

--- a/contrib/examples/wallet-diagnostics-report/wallet-diagnostics-report.test.ts
+++ b/contrib/examples/wallet-diagnostics-report/wallet-diagnostics-report.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from "vitest";
+import { createMockWallet, formatReport, runDiagnostics } from "./wallet-diagnostics-report";
+
+describe("runDiagnostics", () => {
+  it("includes at least four distinct checks", async () => {
+    const wallet = createMockWallet("testnet");
+    const report = await runDiagnostics({ wallet, expectedNetwork: "testnet", pingBackend: async () => true });
+    expect(report.checks.length).toBeGreaterThanOrEqual(4);
+    expect(new Set(report.checks.map((c) => c.name)).size).toBe(report.checks.length); // all distinct
+  });
+
+  it("fails the session checks before the wallet is connected", async () => {
+    const wallet = createMockWallet("testnet");
+    const report = await runDiagnostics({ wallet, expectedNetwork: "testnet", pingBackend: async () => true });
+
+    expect(report.allPassed).toBe(false);
+    const byName = Object.fromEntries(report.checks.map((c) => [c.name, c]));
+    expect(byName["Session exists"]?.passed).toBe(false);
+    expect(byName["Session connected"]?.passed).toBe(false);
+  });
+
+  it("passes every check once the wallet is created and network matches", async () => {
+    const wallet = createMockWallet("testnet");
+    await wallet.create();
+
+    const report = await runDiagnostics({ wallet, expectedNetwork: "testnet", pingBackend: async () => true });
+
+    expect(report.allPassed).toBe(true);
+    expect(report.checks.every((c) => c.passed)).toBe(true);
+  });
+
+  it("fails the network check when expectedNetwork does not match the session", async () => {
+    const wallet = createMockWallet("testnet");
+    await wallet.create();
+
+    const report = await runDiagnostics({ wallet, expectedNetwork: "mainnet", pingBackend: async () => true });
+
+    const networkCheck = report.checks.find((c) => c.name === "Network matches expected");
+    expect(networkCheck?.passed).toBe(false);
+    expect(networkCheck?.reason).toMatch(/testnet.*mainnet/);
+  });
+
+  it("fails the backend check with a reason when the ping returns false", async () => {
+    const wallet = createMockWallet("testnet");
+    await wallet.create();
+
+    const report = await runDiagnostics({ wallet, expectedNetwork: "testnet", pingBackend: async () => false });
+
+    const backendCheck = report.checks.find((c) => c.name === "Backend reachable");
+    expect(backendCheck?.passed).toBe(false);
+    expect(backendCheck?.reason).toMatch(/returned false/);
+  });
+
+  it("fails the backend check with a reason when the ping throws", async () => {
+    const wallet = createMockWallet("testnet");
+    await wallet.create();
+
+    const report = await runDiagnostics({
+      wallet,
+      expectedNetwork: "testnet",
+      pingBackend: async () => {
+        throw new Error("connection refused");
+      },
+    });
+
+    const backendCheck = report.checks.find((c) => c.name === "Backend reachable");
+    expect(backendCheck?.passed).toBe(false);
+    expect(backendCheck?.reason).toMatch(/connection refused/);
+  });
+});
+
+describe("formatReport", () => {
+  it("separates passing and failing checks into distinct sections", async () => {
+    const wallet = createMockWallet("testnet");
+    const report = await runDiagnostics({ wallet, expectedNetwork: "testnet", pingBackend: async () => true });
+
+    const text = formatReport(report);
+
+    expect(text).toContain("Passing:");
+    expect(text).toContain("Failing:");
+    expect(text).toContain("✓ Backend reachable");
+    expect(text).toContain("✗ Session exists — No active session");
+  });
+
+  it("omits the Failing section entirely when everything passed", async () => {
+    const wallet = createMockWallet("testnet");
+    await wallet.create();
+    const report = await runDiagnostics({ wallet, expectedNetwork: "testnet", pingBackend: async () => true });
+
+    const text = formatReport(report);
+
+    expect(text).not.toContain("Failing:");
+  });
+});

--- a/contrib/examples/wallet-diagnostics-report/wallet-diagnostics-report.ts
+++ b/contrib/examples/wallet-diagnostics-report/wallet-diagnostics-report.ts
@@ -1,0 +1,153 @@
+// Example: runs a handful of mock diagnostic checks against a wallet
+// handle — session validity, network match, and backend reachability — and
+// prints a combined report that clearly separates passing checks from
+// failing ones, with a reason for each failure.
+//
+// Run with: npx tsx wallet-diagnostics-report.ts
+
+import { createVellarWallet, type VellarWallet } from "../../../src/client";
+import type { PasskeyKitLike, WalletBackend } from "../../../src/passkeykit-connector";
+import type { SacClientLike } from "../../../src/payments-client";
+import type { Network } from "../../../src/types";
+
+export interface DiagnosticCheck {
+  name: string;
+  passed: boolean;
+  /** Present only when passed is false. */
+  reason?: string;
+}
+
+export interface DiagnosticsReport {
+  checks: DiagnosticCheck[];
+  allPassed: boolean;
+}
+
+export interface DiagnosticsDeps {
+  wallet: VellarWallet;
+  expectedNetwork: Network;
+  pingBackend: () => Promise<boolean>;
+}
+
+function checkSessionExists(wallet: VellarWallet): DiagnosticCheck {
+  if (!wallet.session) {
+    return { name: "Session exists", passed: false, reason: "No active session — call create() or connect() first" };
+  }
+  return { name: "Session exists", passed: true };
+}
+
+function checkSessionConnected(wallet: VellarWallet): DiagnosticCheck {
+  if (!wallet.session?.connected) {
+    return { name: "Session connected", passed: false, reason: "Session exists but is not marked connected" };
+  }
+  return { name: "Session connected", passed: true };
+}
+
+function checkNetworkMatches(wallet: VellarWallet, expected: Network): DiagnosticCheck {
+  if (!wallet.session) {
+    return { name: "Network matches expected", passed: false, reason: "No session to check the network against" };
+  }
+  if (wallet.session.network !== expected) {
+    return {
+      name: "Network matches expected",
+      passed: false,
+      reason: `Session is on "${wallet.session.network}", expected "${expected}"`,
+    };
+  }
+  return { name: "Network matches expected", passed: true };
+}
+
+async function checkBackendReachable(pingBackend: () => Promise<boolean>): Promise<DiagnosticCheck> {
+  try {
+    const ok = await pingBackend();
+    if (!ok) return { name: "Backend reachable", passed: false, reason: "Backend ping returned false" };
+    return { name: "Backend reachable", passed: true };
+  } catch (err) {
+    return { name: "Backend reachable", passed: false, reason: `Backend ping threw: ${(err as Error).message}` };
+  }
+}
+
+/** Runs every diagnostic check (at least four) and returns a combined report. */
+export async function runDiagnostics(deps: DiagnosticsDeps): Promise<DiagnosticsReport> {
+  const checks = [
+    checkSessionExists(deps.wallet),
+    checkSessionConnected(deps.wallet),
+    checkNetworkMatches(deps.wallet, deps.expectedNetwork),
+    await checkBackendReachable(deps.pingBackend),
+  ];
+  return { checks, allPassed: checks.every((c) => c.passed) };
+}
+
+/** Renders a DiagnosticsReport as readable text, passing checks first, then
+ * a separate failing section listing each one's reason. */
+export function formatReport(report: DiagnosticsReport): string {
+  const passing = report.checks.filter((c) => c.passed);
+  const failing = report.checks.filter((c) => !c.passed);
+
+  const lines: string[] = [`Diagnostics: ${passing.length}/${report.checks.length} passed`, ""];
+  lines.push("Passing:");
+  for (const c of passing) lines.push(`  ✓ ${c.name}`);
+  if (failing.length > 0) {
+    lines.push("");
+    lines.push("Failing:");
+    for (const c of failing) lines.push(`  ✗ ${c.name} — ${c.reason}`);
+  }
+  return lines.join("\n");
+}
+
+export function createMockWallet(network: Network): VellarWallet {
+  const kit: PasskeyKitLike = {
+    async createWallet() {
+      return { keyIdBase64: "mock-key-id", contractId: "CMOCKACCOUNTXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX", signedTx: "mock-tx" };
+    },
+    async connectWallet() {
+      return { keyIdBase64: "mock-key-id", contractId: "CMOCKACCOUNTXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX" };
+    },
+    async sign(tx) {
+      return typeof tx === "string" ? `signed:${tx}` : "signed:mock";
+    },
+  };
+  const backend: WalletBackend & { submitTransaction: (i: { signedXdr: string; network: Network }) => Promise<{ hash: string }> } = {
+    async submitWalletCreation() {
+      return { sessionId: "mock-session" };
+    },
+    async lookupContractId() {
+      return undefined;
+    },
+    async submitTransaction() {
+      return { hash: "mockhash" };
+    },
+  };
+  const sac: SacClientLike = {
+    getSACClient() {
+      return { async transfer() { return "unsigned-tx"; } };
+    },
+  };
+
+  return createVellarWallet({ network, appName: "diagnostics demo", kit, backend, sac, isValidAddress: () => true });
+}
+
+async function main() {
+  const wallet = createMockWallet("testnet");
+
+  console.log("Report before connecting (session checks should fail):\n");
+  const before = await runDiagnostics({
+    wallet,
+    expectedNetwork: "testnet",
+    pingBackend: async () => true,
+  });
+  console.log(formatReport(before));
+
+  await wallet.create({ username: "demo-user" });
+
+  console.log("\n\nReport after connecting (everything should pass):\n");
+  const after = await runDiagnostics({
+    wallet,
+    expectedNetwork: "testnet",
+    pingBackend: async () => true,
+  });
+  console.log(formatReport(after));
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main();
+}

--- a/contrib/examples/wallet-health-aggregator/README.md
+++ b/contrib/examples/wallet-health-aggregator/README.md
@@ -1,0 +1,68 @@
+# Wallet health check aggregator
+
+`runHealthAggregator()` runs three distinct mock health checks against a
+wallet and reports an overall status:
+
+1. **Session valid** — a session exists, is `connected`, and its
+   `expiresAt` is in the future (relative to the given "now").
+2. **Backend reachable** — a caller-supplied `pingBackend()` resolves
+   `true` (a `false` result and a thrown error are both reported as
+   distinct reasons).
+3. **RPC reachable** — same shape as the backend check, for a separate
+   `pingRpc()` — a wallet's server backend and its Soroban RPC node are
+   independent dependencies that can fail separately.
+
+## Overall status
+
+The overall status is **`"degraded"` if any single check fails** — there is
+no partial-credit state. It's only `"healthy"` when all three checks pass.
+
+## Usage
+
+```ts
+import { runHealthAggregator, formatReport } from "./wallet-health-aggregator";
+
+const report = await runHealthAggregator({
+  session: { connected: true, expiresAt: "2026-07-01T00:00:00.000Z" },
+  pingBackend: () => fetch("/health").then((r) => r.ok),
+  pingRpc: () => fetch(rpcUrl).then((r) => r.ok),
+});
+
+console.log(formatReport(report)); // "Overall status: HEALTHY" / "DEGRADED"
+```
+
+## Run it
+
+```sh
+npx tsx wallet-health-aggregator.ts
+```
+
+Runs the aggregator twice: once with every check passing, once with the RPC
+check deliberately failing.
+
+Expected output:
+
+```
+Run 1: all checks passing
+
+Overall status: HEALTHY
+
+  ✓ Session valid
+  ✓ Backend reachable
+  ✓ RPC reachable
+
+
+Run 2: RPC check deliberately failing
+
+Overall status: DEGRADED
+
+  ✓ Session valid
+  ✓ Backend reachable
+  ✗ RPC reachable — RPC ping returned false
+```
+
+## Tests
+
+```sh
+npx vitest run contrib/examples/wallet-health-aggregator
+```

--- a/contrib/examples/wallet-health-aggregator/wallet-health-aggregator.test.ts
+++ b/contrib/examples/wallet-health-aggregator/wallet-health-aggregator.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it } from "vitest";
+import { runHealthAggregator, formatReport, type MockSession } from "./wallet-health-aggregator";
+
+describe("runHealthAggregator", () => {
+  const now = new Date("2026-06-15T12:00:00.000Z");
+  const validSession: MockSession = { connected: true, expiresAt: "2026-07-01T00:00:00.000Z" };
+
+  it("reports healthy when all three checks pass", async () => {
+    const report = await runHealthAggregator({
+      session: validSession,
+      pingBackend: async () => true,
+      pingRpc: async () => true,
+      now,
+    });
+    expect(report.status).toBe("healthy");
+    expect(report.checks).toHaveLength(3);
+    expect(report.checks.every((c) => c.passed)).toBe(true);
+  });
+
+  it("reports degraded when the session is missing", async () => {
+    const report = await runHealthAggregator({
+      session: null,
+      pingBackend: async () => true,
+      pingRpc: async () => true,
+      now,
+    });
+    expect(report.status).toBe("degraded");
+    const sessionCheck = report.checks.find((c) => c.name === "Session valid");
+    expect(sessionCheck?.passed).toBe(false);
+    expect(sessionCheck?.reason).toMatch(/No active session/);
+  });
+
+  it("reports degraded when the session is not connected", async () => {
+    const report = await runHealthAggregator({
+      session: { connected: false, expiresAt: "2026-07-01T00:00:00.000Z" },
+      pingBackend: async () => true,
+      pingRpc: async () => true,
+      now,
+    });
+    expect(report.status).toBe("degraded");
+  });
+
+  it("reports degraded when the session is expired", async () => {
+    const report = await runHealthAggregator({
+      session: { connected: true, expiresAt: "2026-06-01T00:00:00.000Z" },
+      pingBackend: async () => true,
+      pingRpc: async () => true,
+      now,
+    });
+    expect(report.status).toBe("degraded");
+  });
+
+  it("reports degraded when the backend is unreachable", async () => {
+    const report = await runHealthAggregator({
+      session: validSession,
+      pingBackend: async () => false,
+      pingRpc: async () => true,
+      now,
+    });
+    expect(report.status).toBe("degraded");
+    const backendCheck = report.checks.find((c) => c.name === "Backend reachable");
+    expect(backendCheck?.passed).toBe(false);
+  });
+
+  it("reports degraded when the RPC ping throws", async () => {
+    const report = await runHealthAggregator({
+      session: validSession,
+      pingBackend: async () => true,
+      pingRpc: async () => {
+        throw new Error("connection reset");
+      },
+      now,
+    });
+    expect(report.status).toBe("degraded");
+    const rpcCheck = report.checks.find((c) => c.name === "RPC reachable");
+    expect(rpcCheck?.reason).toMatch(/connection reset/);
+  });
+
+  it("reports degraded when a single check out of three fails", async () => {
+    const report = await runHealthAggregator({
+      session: validSession,
+      pingBackend: async () => true,
+      pingRpc: async () => false,
+      now,
+    });
+    expect(report.status).toBe("degraded");
+    expect(report.checks.filter((c) => c.passed)).toHaveLength(2);
+  });
+});
+
+describe("formatReport", () => {
+  it("renders passing and failing checks with reasons", async () => {
+    const report = await runHealthAggregator({
+      session: null,
+      pingBackend: async () => true,
+      pingRpc: async () => true,
+      now: new Date("2026-06-15T12:00:00.000Z"),
+    });
+    const text = formatReport(report);
+    expect(text).toContain("Overall status: DEGRADED");
+    expect(text).toContain("✗ Session valid — No active session");
+    expect(text).toContain("✓ Backend reachable");
+  });
+});

--- a/contrib/examples/wallet-health-aggregator/wallet-health-aggregator.ts
+++ b/contrib/examples/wallet-health-aggregator/wallet-health-aggregator.ts
@@ -1,0 +1,109 @@
+// Example: an aggregator that runs a handful of mock health checks —
+// session validity, backend reachability, and RPC reachability — and
+// reports an overall "healthy" or "degraded" status for a wallet.
+//
+// The overall status is "degraded" if ANY individual check fails; there is
+// no partial-credit state.
+//
+// Run with: npx tsx wallet-health-aggregator.ts
+
+export type HealthStatus = "healthy" | "degraded";
+
+export interface HealthCheckResult {
+  name: string;
+  passed: boolean;
+  /** Present only when passed is false. */
+  reason?: string;
+}
+
+export interface HealthReport {
+  status: HealthStatus;
+  checks: HealthCheckResult[];
+}
+
+export interface MockSession {
+  connected: boolean;
+  expiresAt: string;
+}
+
+export interface HealthAggregatorDeps {
+  session: MockSession | null;
+  pingBackend: () => Promise<boolean>;
+  pingRpc: () => Promise<boolean>;
+  now?: Date;
+}
+
+function checkSessionValid(session: MockSession | null, now: Date): HealthCheckResult {
+  const name = "Session valid";
+  if (!session) {
+    return { name, passed: false, reason: "No active session" };
+  }
+  if (!session.connected) {
+    return { name, passed: false, reason: "Session exists but is not connected" };
+  }
+  if (new Date(session.expiresAt).getTime() <= now.getTime()) {
+    return { name, passed: false, reason: `Session expired at ${session.expiresAt}` };
+  }
+  return { name, passed: true };
+}
+
+async function checkReachable(name: string, pingLabel: string, ping: () => Promise<boolean>): Promise<HealthCheckResult> {
+  try {
+    const ok = await ping();
+    if (!ok) return { name, passed: false, reason: `${pingLabel} ping returned false` };
+    return { name, passed: true };
+  } catch (err) {
+    return { name, passed: false, reason: `${pingLabel} ping threw: ${(err as Error).message}` };
+  }
+}
+
+/**
+ * Runs three mock health checks — session validity, backend reachability,
+ * RPC reachability — and reports the account "degraded" if any of them
+ * failed, "healthy" only if all of them passed.
+ */
+export async function runHealthAggregator(deps: HealthAggregatorDeps): Promise<HealthReport> {
+  const now = deps.now ?? new Date();
+  const checks = [
+    checkSessionValid(deps.session, now),
+    await checkReachable("Backend reachable", "Backend", deps.pingBackend),
+    await checkReachable("RPC reachable", "RPC", deps.pingRpc),
+  ];
+  return { status: checks.every((c) => c.passed) ? "healthy" : "degraded", checks };
+}
+
+/** Renders a HealthReport as readable text. */
+export function formatReport(report: HealthReport): string {
+  const lines: string[] = [`Overall status: ${report.status.toUpperCase()}`, ""];
+  for (const check of report.checks) {
+    lines.push(check.passed ? `  ✓ ${check.name}` : `  ✗ ${check.name} — ${check.reason}`);
+  }
+  return lines.join("\n");
+}
+
+async function main() {
+  const now = new Date("2026-06-15T12:00:00.000Z");
+  const validSession: MockSession = { connected: true, expiresAt: "2026-07-01T00:00:00.000Z" };
+
+  console.log("Run 1: all checks passing\n");
+  const healthy = await runHealthAggregator({
+    session: validSession,
+    pingBackend: async () => true,
+    pingRpc: async () => true,
+    now,
+  });
+  console.log(formatReport(healthy));
+
+  console.log("\n\nRun 2: RPC check deliberately failing\n");
+  const degraded = await runHealthAggregator({
+    session: validSession,
+    pingBackend: async () => true,
+    pingRpc: async () => false,
+    now,
+  });
+  console.log(formatReport(degraded));
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main();
+}

--- a/contrib/examples/wallet-with-defaults/README.md
+++ b/contrib/examples/wallet-with-defaults/README.md
@@ -1,0 +1,30 @@
+# Wallet with sane defaults
+
+Wraps `createVellarWallet` with a helper, `createWalletWithDefaults()`, that
+fills in `network: "testnet"`, `appName: "vellar-example"`, and an
+`isValidAddress` accepting both classic (`G...`) and contract (`C...`)
+addresses — so a caller only needs to supply `kit`, `backend`, and `sac`.
+Any default can still be overridden by passing it explicitly.
+
+`sac` is **not** defaulted, on purpose: there's no safe stand-in for the
+real SAC client — a stub that throws breaks payments unexpectedly, and a
+stub that silently succeeds would fake a payment working. Both are worse
+than asking the caller for it explicitly.
+
+## Run it
+
+```sh
+npx tsx wallet-with-defaults.ts
+```
+
+Wires a mock kit/backend/sac into `createWalletWithDefaults()` and calls
+`create()`, printing the resulting session.
+
+## Tests
+
+Shows the helper producing a working wallet handle with a mock kit, and
+that both `network` and `isValidAddress` can be overridden:
+
+```sh
+npx vitest run contrib/examples/wallet-with-defaults
+```

--- a/contrib/examples/wallet-with-defaults/wallet-with-defaults.test.ts
+++ b/contrib/examples/wallet-with-defaults/wallet-with-defaults.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from "vitest";
+import { createWalletWithDefaults } from "./wallet-with-defaults";
+
+function mockKit() {
+  return {
+    async createWallet(_app: string, user: string) {
+      return { keyIdBase64: `keyid-${user}`, contractId: "CMOCK", signedTx: "mock-tx" };
+    },
+    async connectWallet() {
+      throw new Error("not used");
+    },
+    async sign(tx: unknown) {
+      return tx;
+    },
+  };
+}
+
+function mockBackend() {
+  return {
+    async submitWalletCreation() {
+      return { sessionId: "sess_1" };
+    },
+    async lookupContractId() {
+      return undefined;
+    },
+    async submitTransaction() {
+      return { hash: "tx_1" };
+    },
+  };
+}
+
+const mockSac = { getSACClient: () => ({ transfer: async () => "mock-tx" }) };
+
+describe("createWalletWithDefaults", () => {
+  it("produces a working wallet handle with just kit, backend, and sac", async () => {
+    const wallet = createWalletWithDefaults({ kit: mockKit(), backend: mockBackend(), sac: mockSac });
+    const session = await wallet.create({ username: "Test User" });
+    expect(session.network).toBe("testnet");
+    expect(session.accountId).toBe("CMOCK");
+  });
+
+  it("allows overriding a default (network)", async () => {
+    const wallet = createWalletWithDefaults({
+      kit: mockKit(),
+      backend: mockBackend(),
+      sac: mockSac,
+      network: "mainnet",
+    });
+    const session = await wallet.create({ username: "Test User" });
+    expect(session.network).toBe("mainnet");
+  });
+
+  it("allows overriding the default isValidAddress", async () => {
+    const wallet = createWalletWithDefaults({
+      kit: mockKit(),
+      backend: mockBackend(),
+      sac: mockSac,
+      isValidAddress: () => false, // reject every address, including well-formed ones
+    });
+    await wallet.create({ username: "Test User" });
+
+    // The default isValidAddress would accept a well-formed classic address;
+    // the override rejects everything, so preparePayment must fail here —
+    // proving the override, not the default, is what's actually wired in.
+    await expect(
+      wallet.pay({
+        to: "GBRPYHIL2CI3FNQ4BXLFMNDLFJUNPU2HY3ZMFSHONUCEOASW7QC7OX2H",
+        amount: 100n,
+        token: { symbol: "XLM", contractId: "CNATIVE", decimals: 7 },
+      }),
+    ).rejects.toThrow(/not a valid Stellar address/);
+  });
+});

--- a/contrib/examples/wallet-with-defaults/wallet-with-defaults.ts
+++ b/contrib/examples/wallet-with-defaults/wallet-with-defaults.ts
@@ -1,0 +1,78 @@
+// Example: wrap createVellarWallet with sane testnet defaults, so callers
+// only need to supply a kit and a backend. Any default may still be
+// overridden.
+//
+// Run with: npx tsx wallet-with-defaults.ts
+
+import { StrKey } from "@stellar/stellar-sdk";
+import { createVellarWallet, type VellarWallet, type VellarWalletConfig } from "../../../src/index";
+
+/**
+ * The subset of VellarWalletConfig a caller must always supply — the rest
+ * gets sane testnet defaults below.
+ *
+ * `sac` is required, not defaulted: there is no safe stand-in for the real
+ * SAC client — a stub that throws breaks payments unexpectedly, and a stub
+ * that succeeds silently would fake a payment working. Both are worse than
+ * asking the caller for it explicitly.
+ */
+export type MinimalWalletConfig = Pick<VellarWalletConfig, "kit" | "backend" | "sac"> &
+  Partial<Omit<VellarWalletConfig, "kit" | "backend" | "sac">>;
+
+function defaultIsValidAddress(address: string): boolean {
+  return StrKey.isValidEd25519PublicKey(address) || StrKey.isValidContract(address);
+}
+
+/**
+ * createVellarWallet with defaults filled in: network="testnet",
+ * appName="vellar-example", and an isValidAddress that accepts both
+ * classic (G...) and contract (C...) addresses. Every default can still be
+ * overridden by passing it explicitly.
+ */
+export function createWalletWithDefaults(config: MinimalWalletConfig): VellarWallet {
+  return createVellarWallet({
+    network: "testnet",
+    appName: "vellar-example",
+    isValidAddress: defaultIsValidAddress,
+    ...config,
+  });
+}
+
+async function main() {
+  const wallet = createWalletWithDefaults({
+    kit: {
+      async createWallet(_app, user) {
+        return {
+          keyIdBase64: `mock-keyid-${user.toLowerCase().replace(/\s+/g, "-")}`,
+          contractId: "CMOCKWALLETWITHDEFAULTSCONTRACTXXXXXXXXXXXXXXXXXXXXXXXXX",
+          signedTx: "mock-signed-deployment-tx",
+        };
+      },
+      async connectWallet() {
+        throw new Error("mock kit: connectWallet is not used by this example");
+      },
+      async sign(tx) {
+        return tx;
+      },
+    },
+    backend: {
+      async submitWalletCreation() {
+        return { sessionId: "mock-session-id" };
+      },
+      async lookupContractId() {
+        return undefined;
+      },
+      async submitTransaction() {
+        return { hash: "mock-tx-hash" };
+      },
+    },
+    sac: { getSACClient: () => ({ transfer: async () => "mock-tx" }) },
+  });
+
+  const session = await wallet.create({ username: "Defaults Example User" });
+  console.log("Created wallet with defaults; session:", session);
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main();
+}

--- a/contrib/examples/x402-agent-demo/README.md
+++ b/contrib/examples/x402-agent-demo/README.md
@@ -1,0 +1,58 @@
+# x402 agent demo (end to end, mock)
+
+A self-contained, end-to-end demo of an agent using a session key signer to
+pay a mock x402 resource within a tracked budget. Combines three pieces in
+one script:
+
+- a **mock session key signer** (`createMockSessionKeySigner`) — signs
+  payment payloads with a fake signature, no real cryptography;
+- a **mock x402 resource server** (`requestResource`) — returns 402 until a
+  `PAYMENT-SIGNATURE` header is present, then 200;
+- a **budget tracker** (`BudgetTracker`) — a client-side spending guard that
+  approves or rejects each payment against a fixed total budget.
+
+These mirror the ideas in the `mock-x402-resource`, `headless-agent-signer`,
+and `x402-budget-tracker` examples, reimplemented here as self-contained
+mocks so this demo has no dependency on any other example directory.
+
+## Flow
+
+`runAgentPayments(signer, budget, resources)` pays for each resource in
+order:
+
+1. Request the resource with no payment header — expect `402`.
+2. Ask the budget tracker to approve the resource's quoted price.
+   - If **rejected** (would exceed the remaining budget), stop here — no
+     signature is produced and no paid request is ever sent.
+   - If **approved**, continue.
+3. Sign a payment payload with the session key signer.
+4. Retry the request with the signature in the `PAYMENT-SIGNATURE` header —
+   expect `200`.
+
+## Run it
+
+```sh
+npx tsx x402-agent-demo.ts
+```
+
+The sample run pays for one resource (600,000 stroops, fits in a
+1,000,000-stroop budget) and is rejected for a second identically-priced
+resource (would exceed the 400,000 stroops left):
+
+```
+x402 agent demo (mock signer + mock resource server + budget tracker)
+
+1. Agent wallet : CAGENTWALLETXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+2. Total budget : 1000000 stroops
+
+3. weather-api: PAID — Paid 600000 stroops, remaining budget 400000 stroops
+4. market-data-api: REJECTED — Payment of 600000 stroops would exceed remaining budget of 400000 stroops (total 1000000)
+
+Final remaining budget: 400000 stroops
+```
+
+## Tests
+
+```sh
+npx vitest run contrib/examples/x402-agent-demo
+```

--- a/contrib/examples/x402-agent-demo/x402-agent-demo.test.ts
+++ b/contrib/examples/x402-agent-demo/x402-agent-demo.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from "vitest";
+import {
+  BudgetTracker,
+  createMockSessionKeySigner,
+  requestResource,
+  runAgentPayments,
+  type MockResource,
+} from "./x402-agent-demo";
+
+describe("requestResource", () => {
+  const resource: MockResource = { name: "sample-api", priceStroops: 1_000n };
+
+  it("returns 402 without a payment header", () => {
+    const response = requestResource(resource, { headers: {} });
+    expect(response.status).toBe(402);
+  });
+
+  it("returns 200 once a payment header is present", () => {
+    const response = requestResource(resource, { headers: { "PAYMENT-SIGNATURE": "sig" } });
+    expect(response.status).toBe(200);
+  });
+});
+
+describe("createMockSessionKeySigner", () => {
+  it("signs with the configured address and never returns an empty signature", () => {
+    const signer = createMockSessionKeySigner("CADDR");
+    const signature = signer.sign("payload");
+    expect(signature).toContain("CADDR");
+    expect(signature.length).toBeGreaterThan(0);
+  });
+});
+
+describe("runAgentPayments", () => {
+  it("pays for a resource within budget and rejects one that would exceed it", () => {
+    const signer = createMockSessionKeySigner("CADDR");
+    const budget = new BudgetTracker(1_000_000n);
+    const resources: MockResource[] = [
+      { name: "weather-api", priceStroops: 600_000n },
+      { name: "market-data-api", priceStroops: 600_000n },
+    ];
+
+    const attempts = runAgentPayments(signer, budget, resources);
+
+    expect(attempts).toHaveLength(2);
+    expect(attempts[0]).toMatchObject({ resource: "weather-api", outcome: "paid" });
+    expect(attempts[1]).toMatchObject({ resource: "market-data-api", outcome: "rejected" });
+    expect(attempts[1]?.detail).toMatch(/would exceed remaining budget/);
+  });
+
+  it("leaves the budget unchanged when a payment is rejected", () => {
+    const signer = createMockSessionKeySigner("CADDR");
+    const budget = new BudgetTracker(1_000_000n);
+    const resources: MockResource[] = [
+      { name: "weather-api", priceStroops: 600_000n },
+      { name: "market-data-api", priceStroops: 600_000n },
+    ];
+
+    runAgentPayments(signer, budget, resources);
+
+    expect(budget.remainingBudget).toBe(400_000n);
+  });
+
+  it("pays for every resource when the total budget covers them all", () => {
+    const signer = createMockSessionKeySigner("CADDR");
+    const budget = new BudgetTracker(1_000_000n);
+    const resources: MockResource[] = [
+      { name: "resource-a", priceStroops: 300_000n },
+      { name: "resource-b", priceStroops: 300_000n },
+    ];
+
+    const attempts = runAgentPayments(signer, budget, resources);
+
+    expect(attempts.every((a) => a.outcome === "paid")).toBe(true);
+    expect(budget.remainingBudget).toBe(400_000n);
+  });
+});
+
+describe("BudgetTracker", () => {
+  it("throws for a negative total budget", () => {
+    expect(() => new BudgetTracker(-1n)).toThrow(RangeError);
+  });
+
+  it("throws for a negative payment amount", () => {
+    expect(() => new BudgetTracker(100n).tryRecordPayment(-1n)).toThrow(RangeError);
+  });
+});

--- a/contrib/examples/x402-agent-demo/x402-agent-demo.ts
+++ b/contrib/examples/x402-agent-demo/x402-agent-demo.ts
@@ -1,0 +1,188 @@
+// Example: an end-to-end mock x402 agent demo. An agent holding a mock
+// session key signer pays for a series of mock x402-protected resources
+// while a budget tracker enforces a spending cap client-side. Demonstrates
+// both a successful payment and a payment rejected for exceeding the
+// remaining budget.
+//
+// Ties together the ideas behind the mock-x402-resource,
+// headless-agent-signer, and x402-budget-tracker examples into a single
+// self-contained script.
+//
+// Run with: npx tsx x402-agent-demo.ts
+
+// ---- Mock session key signer ----
+
+export interface MockSessionKeySigner {
+  address: string;
+  /** Signs a payment payload, returning a mock signature string. Never does
+   * real cryptography — this is a reference mock, not a real signer. */
+  sign(payload: string): string;
+}
+
+export function createMockSessionKeySigner(address: string): MockSessionKeySigner {
+  return {
+    address,
+    sign(payload: string) {
+      return `mock-sig:${address}:${payload.length}`;
+    },
+  };
+}
+
+// ---- Mock x402 resource server ----
+
+export interface MockResource {
+  name: string;
+  /** Price of this resource, in stroops. */
+  priceStroops: bigint;
+}
+
+export interface ResourceRequest {
+  headers: Record<string, string>;
+}
+
+export interface ResourceResponse {
+  status: number;
+  body: unknown;
+}
+
+const PAYMENT_HEADER = "PAYMENT-SIGNATURE";
+
+/** Handles a request to a mock protected resource: 402 without a payment
+ * header, 200 with the resource once one is present. Never validates the
+ * signature itself — a real facilitator would. */
+export function requestResource(resource: MockResource, request: ResourceRequest): ResourceResponse {
+  const paymentHeader = request.headers[PAYMENT_HEADER];
+  if (!paymentHeader) {
+    return {
+      status: 402,
+      body: { error: "Payment required", priceStroops: resource.priceStroops.toString() },
+    };
+  }
+  return { status: 200, body: { data: `${resource.name} content` } };
+}
+
+// ---- Budget tracker ----
+
+export interface BudgetDecision {
+  approved: boolean;
+  /** Present only when approved is false. */
+  reason?: string;
+  /** Remaining allowance after this decision (unchanged if rejected). */
+  remainingBudget: bigint;
+}
+
+/** Tracks spend against a fixed total budget (in stroops). A rejected
+ * payment is never partially recorded — the tracked spend only changes on
+ * approval. */
+export class BudgetTracker {
+  private spent = 0n;
+
+  constructor(private readonly totalBudget: bigint) {
+    if (totalBudget < 0n) {
+      throw new RangeError("totalBudget must not be negative");
+    }
+  }
+
+  get remainingBudget(): bigint {
+    return this.totalBudget - this.spent;
+  }
+
+  tryRecordPayment(amount: bigint): BudgetDecision {
+    if (amount < 0n) {
+      throw new RangeError("amount must not be negative");
+    }
+    if (amount > this.remainingBudget) {
+      return {
+        approved: false,
+        reason: `Payment of ${amount} stroops would exceed remaining budget of ${this.remainingBudget} stroops (total ${this.totalBudget})`,
+        remainingBudget: this.remainingBudget,
+      };
+    }
+    this.spent += amount;
+    return { approved: true, remainingBudget: this.remainingBudget };
+  }
+}
+
+// ---- Agent flow ----
+
+export interface AgentPaymentAttempt {
+  resource: string;
+  outcome: "paid" | "rejected";
+  detail: string;
+}
+
+/**
+ * Runs an agent through paying for `resources` in order, using `signer` to
+ * sign each payment and `budget` to guard spend. For each resource: request
+ * without payment (expect 402), check the quoted price against the
+ * remaining budget, and only if the budget approves it, sign a payment and
+ * retry the request (expect 200). A resource whose price would exceed the
+ * remaining budget is rejected by the budget tracker *before* a signature
+ * is ever produced or a paid request ever sent.
+ */
+export function runAgentPayments(
+  signer: MockSessionKeySigner,
+  budget: BudgetTracker,
+  resources: MockResource[],
+): AgentPaymentAttempt[] {
+  const attempts: AgentPaymentAttempt[] = [];
+
+  for (const resource of resources) {
+    const unpaidResponse = requestResource(resource, { headers: {} });
+    if (unpaidResponse.status !== 402) {
+      throw new Error(`Expected 402 for an unpaid request to ${resource.name}`);
+    }
+
+    const decision = budget.tryRecordPayment(resource.priceStroops);
+    if (!decision.approved) {
+      attempts.push({ resource: resource.name, outcome: "rejected", detail: decision.reason ?? "rejected" });
+      continue;
+    }
+
+    const signature = signer.sign(`pay:${resource.name}:${resource.priceStroops}`);
+    const paidResponse = requestResource(resource, { headers: { [PAYMENT_HEADER]: signature } });
+    if (paidResponse.status !== 200) {
+      throw new Error(`Expected 200 for a paid request to ${resource.name}`);
+    }
+
+    attempts.push({
+      resource: resource.name,
+      outcome: "paid",
+      detail: `Paid ${resource.priceStroops} stroops, remaining budget ${decision.remainingBudget} stroops`,
+    });
+  }
+
+  return attempts;
+}
+
+function main() {
+  console.log("x402 agent demo (mock signer + mock resource server + budget tracker)\n");
+
+  const signer = createMockSessionKeySigner("CAGENTWALLETXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX");
+  const budget = new BudgetTracker(1_000_000n);
+  const resources: MockResource[] = [
+    { name: "weather-api", priceStroops: 600_000n },
+    { name: "market-data-api", priceStroops: 600_000n },
+  ];
+
+  console.log(`1. Agent wallet : ${signer.address}`);
+  console.log(`2. Total budget : ${budget.remainingBudget} stroops`);
+  console.log();
+
+  const attempts = runAgentPayments(signer, budget, resources);
+  attempts.forEach((attempt, i) => {
+    const step = i + 3;
+    if (attempt.outcome === "paid") {
+      console.log(`${step}. ${attempt.resource}: PAID — ${attempt.detail}`);
+    } else {
+      console.log(`${step}. ${attempt.resource}: REJECTED — ${attempt.detail}`);
+    }
+  });
+
+  console.log();
+  console.log(`Final remaining budget: ${budget.remainingBudget} stroops`);
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main();
+}

--- a/contrib/examples/x402-budget-tracker/README.md
+++ b/contrib/examples/x402-budget-tracker/README.md
@@ -1,0 +1,45 @@
+# x402 budget tracker for an agent
+
+`X402BudgetTracker` records an agent's successful x402 payments against a
+fixed total budget and reports the remaining allowance. A proposed payment
+that would exceed what's left is rejected with a clear reason and is never
+partially recorded — the tracked spend only changes on approval.
+
+This is a **client-side** guard, the same kind `X402PayOptions.maxAmount`
+already is in `src/x402-types.ts` — the durable budget enforcement is the
+on-chain spending-limit policy attached to the signing key. This tracker is
+useful for an agent that wants to stop making requests *before* hitting that
+on-chain wall, e.g. to fail fast with a clear reason instead of discovering
+the rejection only after a signed payment bounces off the facilitator.
+
+## Usage
+
+```ts
+import { X402BudgetTracker } from "./x402-budget-tracker";
+
+const tracker = new X402BudgetTracker(1_000_000n);
+
+tracker.tryRecordPayment(300_000n); // { approved: true, remainingBudget: 700000n }
+tracker.tryRecordPayment(800_000n); // { approved: false, reason: "...", remainingBudget: 700000n }
+```
+
+## Run it
+
+```sh
+npx tsx x402-budget-tracker.ts
+```
+
+Expected output:
+
+```
+Payment of 300000: APPROVED (remaining: 700000)
+Payment of 400000: APPROVED (remaining: 300000)
+Payment of 500000: REJECTED — Payment of 500000 would exceed remaining budget of 300000 (total 1000000, already spent 700000)
+Payment of 200000: APPROVED (remaining: 100000)
+```
+
+## Tests
+
+```sh
+npx vitest run contrib/examples/x402-budget-tracker
+```

--- a/contrib/examples/x402-budget-tracker/x402-budget-tracker.test.ts
+++ b/contrib/examples/x402-budget-tracker/x402-budget-tracker.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "vitest";
+import { X402BudgetTracker } from "./x402-budget-tracker";
+
+describe("X402BudgetTracker", () => {
+  it("approves a payment within the budget and reduces the remaining allowance", () => {
+    const tracker = new X402BudgetTracker(1000n);
+    const decision = tracker.tryRecordPayment(300n);
+
+    expect(decision).toEqual({ approved: true, remainingBudget: 700n });
+    expect(tracker.remainingBudget).toBe(700n);
+    expect(tracker.totalSpent).toBe(300n);
+  });
+
+  it("rejects a payment that would exceed the remaining budget, with a reason", () => {
+    const tracker = new X402BudgetTracker(1000n);
+    tracker.tryRecordPayment(700n);
+
+    const decision = tracker.tryRecordPayment(400n);
+
+    expect(decision.approved).toBe(false);
+    expect(decision.reason).toMatch(/exceed remaining budget/);
+    expect(decision.remainingBudget).toBe(300n);
+  });
+
+  it("does not record a rejected payment against spend", () => {
+    const tracker = new X402BudgetTracker(1000n);
+    tracker.tryRecordPayment(700n);
+    tracker.tryRecordPayment(400n); // rejected
+
+    expect(tracker.totalSpent).toBe(700n);
+    expect(tracker.remainingBudget).toBe(300n);
+  });
+
+  it("approves a payment that exactly exhausts the remaining budget", () => {
+    const tracker = new X402BudgetTracker(1000n);
+    const decision = tracker.tryRecordPayment(1000n);
+    expect(decision.approved).toBe(true);
+    expect(tracker.remainingBudget).toBe(0n);
+  });
+
+  it("rejects any further payment once the budget is exhausted", () => {
+    const tracker = new X402BudgetTracker(1000n);
+    tracker.tryRecordPayment(1000n);
+    const decision = tracker.tryRecordPayment(1n);
+    expect(decision.approved).toBe(false);
+  });
+
+  it("throws for a negative total budget", () => {
+    expect(() => new X402BudgetTracker(-1n)).toThrow(RangeError);
+  });
+
+  it("throws for a negative payment amount", () => {
+    const tracker = new X402BudgetTracker(1000n);
+    expect(() => tracker.tryRecordPayment(-1n)).toThrow(RangeError);
+  });
+
+  it("processes a mixed sequence, approving and rejecting as budget allows", () => {
+    const tracker = new X402BudgetTracker(1_000_000n);
+    const results = [300_000n, 400_000n, 500_000n, 200_000n].map((amount) =>
+      tracker.tryRecordPayment(amount).approved,
+    );
+    expect(results).toEqual([true, true, false, true]);
+    expect(tracker.totalSpent).toBe(900_000n);
+  });
+});

--- a/contrib/examples/x402-budget-tracker/x402-budget-tracker.ts
+++ b/contrib/examples/x402-budget-tracker/x402-budget-tracker.ts
@@ -1,0 +1,75 @@
+// Example: track an agent's x402 spend over time against a configured
+// budget, reporting a clear rejection reason when a proposed payment would
+// exceed the remaining allowance. A client-side companion to the on-chain
+// spending-limit policy — see src/x402-types.ts's X402PayOptions.maxAmount
+// doc comment, which makes the same "client-side guard, not the durable
+// budget" distinction.
+//
+// Run with: npx tsx x402-budget-tracker.ts
+
+export interface BudgetDecision {
+  approved: boolean;
+  /** Present only when approved is false. */
+  reason?: string;
+  /** Remaining allowance after this decision (unchanged if rejected). */
+  remainingBudget: bigint;
+}
+
+/**
+ * Tracks spend against a fixed total budget (in the asset's base units).
+ * Each call to `tryRecordPayment` either records the amount (if it fits in
+ * the remaining allowance) or rejects it with a reason, leaving the
+ * tracked spend unchanged — a rejected payment is never partially recorded.
+ */
+export class X402BudgetTracker {
+  private spent = 0n;
+
+  constructor(private readonly totalBudget: bigint) {
+    if (totalBudget < 0n) {
+      throw new RangeError("totalBudget must not be negative");
+    }
+  }
+
+  /** Remaining allowance: totalBudget - spent so far. */
+  get remainingBudget(): bigint {
+    return this.totalBudget - this.spent;
+  }
+
+  /** Total spent so far (only successfully recorded payments count). */
+  get totalSpent(): bigint {
+    return this.spent;
+  }
+
+  tryRecordPayment(amount: bigint): BudgetDecision {
+    if (amount < 0n) {
+      throw new RangeError("amount must not be negative");
+    }
+    if (amount > this.remainingBudget) {
+      return {
+        approved: false,
+        reason: `Payment of ${amount} would exceed remaining budget of ${this.remainingBudget} (total ${this.totalBudget}, already spent ${this.spent})`,
+        remainingBudget: this.remainingBudget,
+      };
+    }
+    this.spent += amount;
+    return { approved: true, remainingBudget: this.remainingBudget };
+  }
+}
+
+function main() {
+  const tracker = new X402BudgetTracker(1_000_000n); // 1,000,000 base units
+  const plannedPayments = [300_000n, 400_000n, 500_000n, 200_000n];
+
+  for (const amount of plannedPayments) {
+    const decision = tracker.tryRecordPayment(amount);
+    if (decision.approved) {
+      console.log(`Payment of ${amount}: APPROVED (remaining: ${decision.remainingBudget})`);
+    } else {
+      console.log(`Payment of ${amount}: REJECTED — ${decision.reason}`);
+    }
+  }
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main();
+}

--- a/contrib/examples/x402-cost-estimator/README.md
+++ b/contrib/examples/x402-cost-estimator/README.md
@@ -1,0 +1,55 @@
+# x402 payment cost estimator
+
+Estimates the total cost of a series of *planned* x402 payments (see
+`src/x402-types.ts` for the real `PaymentRequirements` shape this mirrors)
+against a mock price feed, converted to a single reference currency — before
+any of the payments are actually made. Useful for an agent to budget-check a
+batch of planned requests up front, e.g. against an
+`x402-budget-tracker`-style allowance.
+
+## Usage
+
+```ts
+import { estimateCost } from "./x402-cost-estimator";
+
+const estimate = estimateCost([
+  { asset: "USDC", amount: "5" },
+  { asset: "XLM", amount: "100" },
+]);
+
+estimate.totalReferenceCost; // "17" (5 USDC @ $1.00 + 100 XLM @ $0.12)
+```
+
+An asset with no entry in the rate table throws rather than silently costing
+$0 — the whole point of a cost estimator is a trustworthy number.
+
+## Run it
+
+```sh
+npx tsx x402-cost-estimator.ts
+```
+
+Expected output:
+
+```
+Itemized cost:
+  5 USDC -> 5 USD
+  2.5 USDC -> 2.5 USD
+  100 XLM -> 12 USD
+  10 EURC -> 10.8 USD
+Total estimated cost: 30.3 USD
+```
+
+## Notes on precision
+
+Amounts and rates are multiplied as fixed-point integers (6 decimal places),
+never as floats, so the totals never suffer float rounding — the same reason
+`src/payments.ts`'s `parseTokenAmount` avoids floats for money. This example
+treats every asset at the same fixed scale for simplicity; a real integration
+should use each asset's actual on-chain decimals.
+
+## Tests
+
+```sh
+npx vitest run contrib/examples/x402-cost-estimator
+```

--- a/contrib/examples/x402-cost-estimator/x402-cost-estimator.test.ts
+++ b/contrib/examples/x402-cost-estimator/x402-cost-estimator.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+import { estimateCost, MOCK_RATE_TABLE, type PlannedPayment } from "./x402-cost-estimator";
+
+describe("estimateCost", () => {
+  it("converts each payment to the reference currency and sums the total", () => {
+    const payments: PlannedPayment[] = [
+      { asset: "USDC", amount: "5" },
+      { asset: "USDC", amount: "2.5" },
+      { asset: "XLM", amount: "100" },
+      { asset: "EURC", amount: "10" },
+    ];
+
+    const estimate = estimateCost(payments);
+
+    expect(estimate.items).toEqual([
+      { asset: "USDC", amount: "5", referenceCost: "5" },
+      { asset: "USDC", amount: "2.5", referenceCost: "2.5" },
+      { asset: "XLM", amount: "100", referenceCost: "12" },
+      { asset: "EURC", amount: "10", referenceCost: "10.8" },
+    ]);
+    expect(estimate.totalReferenceCost).toBe("30.3");
+    expect(estimate.referenceCurrency).toBe("USD");
+  });
+
+  it("throws a clear error for an asset missing from the rate table", () => {
+    expect(() => estimateCost([{ asset: "DOGE", amount: "1" }])).toThrow(
+      /No rate available for asset "DOGE"/,
+    );
+  });
+
+  it("returns a zero total for an empty payment list", () => {
+    const estimate = estimateCost([]);
+    expect(estimate.items).toEqual([]);
+    expect(estimate.totalReferenceCost).toBe("0");
+  });
+
+  it("accepts a custom rate table instead of the default mock one", () => {
+    const estimate = estimateCost([{ asset: "GOLD", amount: "2" }], { GOLD: "2000" });
+    expect(estimate.totalReferenceCost).toBe("4000");
+  });
+
+  it("does not mutate the default MOCK_RATE_TABLE export", () => {
+    const before = { ...MOCK_RATE_TABLE };
+    estimateCost([{ asset: "USDC", amount: "1" }]);
+    expect(MOCK_RATE_TABLE).toEqual(before);
+  });
+});

--- a/contrib/examples/x402-cost-estimator/x402-cost-estimator.ts
+++ b/contrib/examples/x402-cost-estimator/x402-cost-estimator.ts
@@ -1,0 +1,111 @@
+// Example: estimate the total cost of a series of planned x402 payments
+// (see src/x402-types.ts for the real PaymentRequirements/X402PayOptions
+// shapes this mirrors) against a mock price feed, before any of them are
+// actually made — useful for an agent to budget-check a batch of planned
+// requests up front.
+//
+// Run with: npx tsx x402-cost-estimator.ts
+
+/** One planned payment: an asset symbol and a decimal amount in that
+ * asset's own units (not base/stroop units — this is a display-level
+ * estimate, not the on-chain payment itself). */
+export interface PlannedPayment {
+  asset: string;
+  amount: string;
+}
+
+export interface ItemizedCost {
+  asset: string;
+  amount: string;
+  referenceCost: string;
+}
+
+export interface CostEstimate {
+  items: ItemizedCost[];
+  totalReferenceCost: string;
+  referenceCurrency: string;
+}
+
+/** Mock rate table: asset symbol -> price in USD, as a decimal string (a
+ * real integration would read this from a price oracle). */
+export const MOCK_RATE_TABLE: Record<string, string> = {
+  USDC: "1.00",
+  EURC: "1.08",
+  XLM: "0.12",
+};
+
+// Fixed-point arithmetic at 6 decimal places (micro-units) so rate
+// multiplication never suffers float rounding — the same reasoning as
+// src/payments.ts's parseTokenAmount avoiding floats for money. This is a
+// simplification for a reference example: a real integration would use each
+// asset's actual on-chain decimals rather than a single shared scale.
+const SCALE = 6;
+
+function toMicroUnits(decimal: string): bigint {
+  const trimmed = decimal.trim();
+  if (!/^\d+(\.\d+)?$/.test(trimmed)) {
+    throw new Error(`"${decimal}" is not a valid decimal amount`);
+  }
+  const [whole = "0", fraction = ""] = trimmed.split(".");
+  if (fraction.length > SCALE) {
+    throw new Error(`"${decimal}" has more than ${SCALE} decimal places`);
+  }
+  return BigInt(whole) * 10n ** BigInt(SCALE) + BigInt(fraction.padEnd(SCALE, "0") || "0");
+}
+
+function fromMicroUnits(micro: bigint): string {
+  const scale = 10n ** BigInt(SCALE);
+  const whole = micro / scale;
+  const frac = (micro % scale).toString().padStart(SCALE, "0").replace(/0+$/, "");
+  return frac ? `${whole}.${frac}` : `${whole}`;
+}
+
+/**
+ * Estimates the total cost of `payments` in `referenceCurrency` (always
+ * "USD" for this example's mock table), using `rateTable` to convert each
+ * asset. Throws if any planned asset has no entry in the rate table — an
+ * unpriced payment silently reported as $0 would be worse than failing
+ * loudly, since the whole point is a trustworthy budget check.
+ */
+export function estimateCost(
+  payments: PlannedPayment[],
+  rateTable: Record<string, string> = MOCK_RATE_TABLE,
+): CostEstimate {
+  const items: ItemizedCost[] = [];
+  let totalMicro = 0n;
+
+  for (const payment of payments) {
+    const rate = rateTable[payment.asset];
+    if (rate === undefined) {
+      throw new Error(
+        `No rate available for asset "${payment.asset}". Known assets: ${Object.keys(rateTable).join(", ")}`,
+      );
+    }
+    const referenceMicro = (toMicroUnits(payment.amount) * toMicroUnits(rate)) / 10n ** BigInt(SCALE);
+    totalMicro += referenceMicro;
+    items.push({ asset: payment.asset, amount: payment.amount, referenceCost: fromMicroUnits(referenceMicro) });
+  }
+
+  return { items, totalReferenceCost: fromMicroUnits(totalMicro), referenceCurrency: "USD" };
+}
+
+function main() {
+  const plannedPayments: PlannedPayment[] = [
+    { asset: "USDC", amount: "5" },
+    { asset: "USDC", amount: "2.5" },
+    { asset: "XLM", amount: "100" },
+    { asset: "EURC", amount: "10" },
+  ];
+
+  const estimate = estimateCost(plannedPayments);
+
+  console.log("Itemized cost:");
+  for (const item of estimate.items) {
+    console.log(`  ${item.amount} ${item.asset} -> ${item.referenceCost} ${estimate.referenceCurrency}`);
+  }
+  console.log(`Total estimated cost: ${estimate.totalReferenceCost} ${estimate.referenceCurrency}`);
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main();
+}

--- a/contrib/examples/x402-fetch-fallback/README.md
+++ b/contrib/examples/x402-fetch-fallback/README.md
@@ -1,0 +1,53 @@
+# x402 fetch with a lower-cost fallback
+
+Demonstrates an x402 (HTTP 402 "pay to unlock") request that handles a
+`PaymentRejectedError` by falling back **once** to a lower `maxAmount`, which
+selects a cheaper payment tier that settles within the wallet's budget.
+
+Everything runs against a **mock x402 client** and a **mock resource server**
+defined in this example — no network. The mock client implements the SDK's real
+[`X402Client`](../../../src/x402-types.ts) interface and throws the SDK's real
+`PaymentRejectedError`, so the control flow mirrors production.
+
+## Flow
+
+1. The resource server answers an unpaid request with a 402 challenge listing
+   two accepted tiers — **premium** (`800`) and **basic** (`400`) base units.
+2. The client pays the most premium tier it can afford under `maxAmount`. With
+   `maxAmount = 1000` it picks the premium `800`.
+3. The facilitator verifies the payment against the wallet's remaining on-chain
+   spending-limit budget (`500`). `800 > 500`, so it throws
+   `PaymentRejectedError` (`reason: "over_budget"`) — exactly what happens when
+   the on-chain policy blocks an over-budget transfer.
+4. `fetchWithPaymentFallback` catches that error and retries **exactly once**
+   with `fallbackMaxAmount = 450`. Now only the basic `400` tier is affordable;
+   it is chosen, `400 <= 500`, and the facilitator settles it.
+5. The unlocked resource (HTTP 200) and its settlement are returned.
+
+A second rejection, or any non-`PaymentRejectedError`, propagates without a
+further retry — the fallback happens at most once.
+
+## Run it
+
+```sh
+npx tsx x402-fetch-fallback.ts
+```
+
+```
+Remaining on-chain budget: 500 base units
+Premium tier: 800, basic tier: 400
+
+1. GET /reports/quarterly with maxAmount=1000 (fallback=450)...
+  ! payment rejected (over_budget): facilitator rejected payment of 800: exceeds remaining budget 500
+  > retrying once at lower maxAmount 450
+2. Unlocked (paid=true, status=200): {"url":"/reports/quarterly","report":"Q3 revenue up 12% YoY","unlocked":true}
+3. Settled 400 of CDLZFC3SYJYDZT7K67VZ75HPJVIEUVNIXF47ZG2FB2RMQQVU2HHGCYSC on testnet — tx mocktx-0001
+4. Server quoted 2x; facilitator settle attempts: 2
+   Remaining budget now: 100
+```
+
+## Tests
+
+```sh
+npx vitest run contrib/examples/x402-fetch-fallback
+```

--- a/contrib/examples/x402-fetch-fallback/x402-fetch-fallback.test.ts
+++ b/contrib/examples/x402-fetch-fallback/x402-fetch-fallback.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it } from "vitest";
+import { MaxAmountExceededError, PaymentRejectedError } from "../../../src/x402-types";
+import {
+  createMockFacilitator,
+  createMockResourceServer,
+  createMockX402Client,
+  fetchWithPaymentFallback,
+} from "./x402-fetch-fallback";
+
+const silent = { log: () => {} };
+
+function wire(remainingBudget: bigint) {
+  const server = createMockResourceServer();
+  const facilitator = createMockFacilitator({ remainingBudget });
+  const client = createMockX402Client({ server, facilitator, payer: "CPAYER" });
+  return { server, facilitator, client };
+}
+
+describe("mock x402 client", () => {
+  it("pays the most premium affordable tier and settles within budget", async () => {
+    const { client, facilitator } = wire(1000n);
+    const res = await client.fetch("/reports/quarterly", { maxAmount: 1000n });
+
+    expect(res.paid).toBe(true);
+    expect(res.response.status).toBe(200);
+    expect(res.settlement?.amount).toBe(800n); // premium tier
+    expect(facilitator.remaining()).toBe(200n);
+  });
+
+  it("throws PaymentRejectedError when the chosen tier exceeds the on-chain budget", async () => {
+    const { client } = wire(500n); // premium 800 > budget 500
+    await expect(client.fetch("/reports/quarterly", { maxAmount: 1000n })).rejects.toBeInstanceOf(
+      PaymentRejectedError,
+    );
+  });
+
+  it("refuses to sign when nothing fits maxAmount (MaxAmountExceededError, no settle)", async () => {
+    const { client, facilitator } = wire(1000n);
+    await expect(client.fetch("/reports/quarterly", { maxAmount: 100n })).rejects.toBeInstanceOf(
+      MaxAmountExceededError,
+    );
+    expect(facilitator.attempts()).toBe(0);
+  });
+});
+
+describe("fetchWithPaymentFallback", () => {
+  it("catches PaymentRejectedError and retries once at the lower maxAmount, then succeeds", async () => {
+    const { client, server, facilitator } = wire(500n);
+
+    const res = await fetchWithPaymentFallback(
+      client,
+      "/reports/quarterly",
+      { maxAmount: 1000n, fallbackMaxAmount: 450n },
+      silent,
+    );
+
+    expect(res.paid).toBe(true);
+    expect(res.settlement?.amount).toBe(400n); // basic tier, within budget
+    expect(server.quotes()).toBe(2); // one initial attempt + one fallback
+    expect(facilitator.attempts()).toBe(2); // rejected once, settled once
+    expect(facilitator.remaining()).toBe(100n); // 500 - 400
+  });
+
+  it("retries at most ONCE — a second rejection propagates", async () => {
+    const { client, server, facilitator } = wire(300n); // even basic 400 > budget
+
+    await expect(
+      fetchWithPaymentFallback(
+        client,
+        "/reports/quarterly",
+        { maxAmount: 1000n, fallbackMaxAmount: 450n },
+        silent,
+      ),
+    ).rejects.toBeInstanceOf(PaymentRejectedError);
+
+    expect(server.quotes()).toBe(2); // not more than two attempts
+    expect(facilitator.attempts()).toBe(2);
+  });
+
+  it("does not retry when the first attempt succeeds", async () => {
+    const { client, server } = wire(1000n);
+    const res = await fetchWithPaymentFallback(
+      client,
+      "/reports/quarterly",
+      { maxAmount: 1000n, fallbackMaxAmount: 450n },
+      silent,
+    );
+
+    expect(res.settlement?.amount).toBe(800n); // premium, no fallback needed
+    expect(server.quotes()).toBe(1);
+  });
+
+  it("does not retry on a non-PaymentRejectedError (e.g. MaxAmountExceededError)", async () => {
+    const { client, server } = wire(1000n);
+    await expect(
+      fetchWithPaymentFallback(
+        client,
+        "/reports/quarterly",
+        { maxAmount: 100n, fallbackMaxAmount: 50n },
+        silent,
+      ),
+    ).rejects.toBeInstanceOf(MaxAmountExceededError);
+    expect(server.quotes()).toBe(1); // failed before any retry
+  });
+});

--- a/contrib/examples/x402-fetch-fallback/x402-fetch-fallback.ts
+++ b/contrib/examples/x402-fetch-fallback/x402-fetch-fallback.ts
@@ -1,0 +1,259 @@
+// Example: an x402 (HTTP 402) "pay to unlock" flow with a lower-cost fallback.
+//
+// It wires up a MOCK x402 client and a MOCK resource server (both defined in
+// this file, no network) that mirror vellar-sdk's real surface:
+//   - the client implements the SDK's `X402Client` interface (src/x402-types.ts)
+//   - it throws the SDK's real `PaymentRejectedError` when the facilitator
+//     rejects a payment for exceeding the wallet's on-chain spending budget.
+//
+// The resource server offers two accepted tiers (a premium and a basic price).
+// The client pays the most premium tier it can afford under `maxAmount`. When
+// the facilitator rejects that payment as over-budget, `fetchWithPaymentFallback`
+// catches `PaymentRejectedError` and retries ONCE at a lower `maxAmount`, which
+// selects the cheaper tier and settles within budget.
+//
+// Run with: npx tsx x402-fetch-fallback.ts
+
+import {
+  DisallowedAssetError,
+  MaxAmountExceededError,
+  PaymentRejectedError,
+  type PaymentRequired,
+  type PaymentRequirements,
+  type SignedPayment,
+  type X402Client,
+  type X402FetchInit,
+  type X402Response,
+  type X402Settlement,
+} from "../../../src/x402-types";
+import type { Network } from "../../../src/types";
+
+// ── sample identifiers (mock; not validated on-chain) ───────────────────────
+const NETWORK_CAIP2 = "stellar:testnet";
+const USDC_SAC = "CDLZFC3SYJYDZT7K67VZ75HPJVIEUVNIXF47ZG2FB2RMQQVU2HHGCYSC"; // SEP-41 token (SAC)
+const PAY_TO = "CBIN4HTPJM2QLJ32DTRO6OCLIMM7TR7D74JDIPVQYLNYGL7SBWOXH5ND"; // resource server payee
+const PAYER = "CC5ZSTLTYKPNIFDSJ4233RVZPALGHHDBRTXGIN6Z3AJCWU57VR5ITXXR"; // our smart-account wallet
+
+const PREMIUM_AMOUNT = "800"; // base units
+const BASIC_AMOUNT = "400";
+
+// ── mock resource server ────────────────────────────────────────────────────
+
+export interface MockResourceServer {
+  /** Answer an unpaid request with a 402 challenge (two accepted tiers). */
+  quote(url: string): PaymentRequired;
+  /** Serve the unlocked content once a payment has been settled. */
+  deliver(url: string): Response;
+  /** How many times `quote()` was called — proves the retry count in tests. */
+  quotes(): number;
+}
+
+function requirement(amount: string, description: string): PaymentRequirements {
+  return {
+    scheme: "exact",
+    network: NETWORK_CAIP2,
+    asset: USDC_SAC,
+    amount,
+    payTo: PAY_TO,
+    maxTimeoutSeconds: 60,
+    extra: { description },
+  };
+}
+
+/** A mock x402 resource server offering a premium and a basic tier. */
+export function createMockResourceServer(): MockResourceServer {
+  let quoteCount = 0;
+  return {
+    quote(url) {
+      quoteCount += 1;
+      return {
+        x402Version: 2,
+        error: "payment required",
+        accepts: [
+          requirement(PREMIUM_AMOUNT, "premium quarterly report"),
+          requirement(BASIC_AMOUNT, "basic quarterly summary"),
+        ],
+        resource: { url, description: "Quarterly report", mimeType: "application/json" },
+      };
+    },
+    deliver(url) {
+      return new Response(
+        JSON.stringify({ url, report: "Q3 revenue up 12% YoY", unlocked: true }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      );
+    },
+    quotes: () => quoteCount,
+  };
+}
+
+// ── mock facilitator (enforces the wallet's remaining on-chain budget) ───────
+
+export interface MockFacilitator {
+  /** Verify + settle a payment. Throws PaymentRejectedError when over budget. */
+  settle(payment: SignedPayment): X402Settlement;
+  /** How many settle attempts were made — proves "retry at most once". */
+  attempts(): number;
+  /** Remaining spending-limit budget, in base units. */
+  remaining(): bigint;
+}
+
+export function createMockFacilitator(config: {
+  remainingBudget: bigint;
+  network?: Network;
+}): MockFacilitator {
+  let remaining = config.remainingBudget;
+  let attempts = 0;
+  let txSeq = 0;
+  const network = config.network ?? "testnet";
+
+  return {
+    settle(payment) {
+      attempts += 1;
+      if (payment.amount > remaining) {
+        // Mirrors the real flow: the on-chain spending-limit policy blocks the
+        // over-budget transfer, so the facilitator reports a rejection.
+        throw new PaymentRejectedError(
+          `facilitator rejected payment of ${payment.amount}: exceeds remaining budget ${remaining}`,
+          "over_budget",
+        );
+      }
+      remaining -= payment.amount;
+      txSeq += 1;
+      // The facilitator reads the payer out of the (mock) payment header.
+      const payer = payment.header.split(":")[3] ?? PAYER;
+      return {
+        transaction: `mocktx-${String(txSeq).padStart(4, "0")}`,
+        payer,
+        asset: payment.requirements.asset,
+        amount: payment.amount,
+        network,
+      };
+    },
+    attempts: () => attempts,
+    remaining: () => remaining,
+  };
+}
+
+// ── mock x402 client (implements the SDK's X402Client) ──────────────────────
+
+/** Pick the most premium tier the caller can afford under `maxAmount`
+ * (respecting `allowedAssets`), mirroring how a client maximizes service
+ * quality within budget. Throws the SDK's real errors when nothing fits. */
+function chooseRequirements(
+  accepts: PaymentRequirements[],
+  init: Pick<X402FetchInit, "maxAmount" | "allowedAssets">,
+): PaymentRequirements {
+  const byAsset = init.allowedAssets
+    ? accepts.filter((a) => init.allowedAssets!.includes(a.asset))
+    : accepts;
+  if (byAsset.length === 0) {
+    throw new DisallowedAssetError(accepts[0]?.asset ?? "?", init.allowedAssets ?? []);
+  }
+  const affordable = byAsset.filter((a) => BigInt(a.amount) <= init.maxAmount);
+  if (affordable.length === 0) {
+    const cheapest = byAsset.reduce((m, a) => (BigInt(a.amount) < BigInt(m.amount) ? a : m));
+    throw new MaxAmountExceededError(BigInt(cheapest.amount), init.maxAmount, cheapest.asset);
+  }
+  return affordable.reduce((m, a) => (BigInt(a.amount) > BigInt(m.amount) ? a : m));
+}
+
+export function createMockX402Client(config: {
+  server: MockResourceServer;
+  facilitator: MockFacilitator;
+  payer: string;
+}): X402Client {
+  async function createPayment(
+    requirements: PaymentRequirements,
+    opts: { maxAmount: bigint; allowedAssets?: string[] },
+  ): Promise<SignedPayment> {
+    if (opts.allowedAssets && !opts.allowedAssets.includes(requirements.asset)) {
+      throw new DisallowedAssetError(requirements.asset, opts.allowedAssets);
+    }
+    const amount = BigInt(requirements.amount);
+    if (amount > opts.maxAmount) {
+      throw new MaxAmountExceededError(amount, opts.maxAmount, requirements.asset);
+    }
+    return {
+      header: `mockpay:${requirements.asset}:${amount}:${config.payer}`,
+      requirements,
+      amount,
+    };
+  }
+
+  async function fetch(url: string, init: X402FetchInit): Promise<X402Response> {
+    const challenge = config.server.quote(url); // 402 + accepted tiers
+    const chosen = chooseRequirements(challenge.accepts, init); // most premium affordable
+    const payment = await createPayment(chosen, init); // "sign" the payment
+    const settlement = config.facilitator.settle(payment); // may throw PaymentRejectedError
+    return { response: config.server.deliver(url), paid: true, settlement };
+  }
+
+  return { fetch, createPayment };
+}
+
+// ── the fallback wrapper ────────────────────────────────────────────────────
+
+export interface FallbackFetchInit extends X402FetchInit {
+  /** `maxAmount` to retry with — once — if the first attempt is rejected. */
+  fallbackMaxAmount: bigint;
+}
+
+export interface FallbackOptions {
+  /** Injectable logger (tests pass a no-op). Defaults to console.log. */
+  log?: (message: string) => void;
+}
+
+/**
+ * Call `client.fetch(url, init)`. If it fails with `PaymentRejectedError`
+ * (the facilitator rejected the payment as over-budget), retry EXACTLY ONCE
+ * with `fallbackMaxAmount` — a lower ceiling that selects the cheaper tier.
+ * Any other error, and a second rejection, propagate to the caller.
+ */
+export async function fetchWithPaymentFallback(
+  client: X402Client,
+  url: string,
+  init: FallbackFetchInit,
+  options: FallbackOptions = {},
+): Promise<X402Response> {
+  const log = options.log ?? ((m: string) => console.log(m));
+  const { fallbackMaxAmount, ...first } = init;
+  try {
+    return await client.fetch(url, first);
+  } catch (err) {
+    if (!(err instanceof PaymentRejectedError)) throw err;
+    log(`  ! payment rejected (${err.reason ?? "unknown"}): ${err.message}`);
+    log(`  > retrying once at lower maxAmount ${fallbackMaxAmount}`);
+    return client.fetch(url, { ...first, maxAmount: fallbackMaxAmount });
+  }
+}
+
+async function main(): Promise<void> {
+  const server = createMockResourceServer();
+  const facilitator = createMockFacilitator({ remainingBudget: 500n });
+  const client = createMockX402Client({ server, facilitator, payer: PAYER });
+
+  console.log(`Remaining on-chain budget: ${facilitator.remaining()} base units`);
+  console.log(`Premium tier: ${PREMIUM_AMOUNT}, basic tier: ${BASIC_AMOUNT}`);
+  console.log("");
+  console.log("1. GET /reports/quarterly with maxAmount=1000 (fallback=450)...");
+
+  const res = await fetchWithPaymentFallback(client, "/reports/quarterly", {
+    maxAmount: 1000n,
+    fallbackMaxAmount: 450n,
+  });
+
+  const body = (await res.response.json()) as Record<string, unknown>;
+  console.log(`2. Unlocked (paid=${res.paid}, status=${res.response.status}): ${JSON.stringify(body)}`);
+  if (res.settlement) {
+    console.log(
+      `3. Settled ${res.settlement.amount} of ${res.settlement.asset} on ${res.settlement.network}` +
+        ` — tx ${res.settlement.transaction}`,
+    );
+  }
+  console.log(`4. Server quoted ${server.quotes()}x; facilitator settle attempts: ${facilitator.attempts()}`);
+  console.log(`   Remaining budget now: ${facilitator.remaining()}`);
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main();
+}

--- a/contrib/examples/x402-retry-backoff-demo/README.md
+++ b/contrib/examples/x402-retry-backoff-demo/README.md
@@ -1,0 +1,59 @@
+# x402 retry with backoff demo
+
+Demonstrates retrying a mock x402 payment call that fails a few times with a
+transient error before succeeding, waiting an exponentially-growing delay
+between attempts.
+
+## Backoff calculation
+
+`computeBackoffDelay(attempt, { baseDelayMs, maxDelayMs })` returns
+`min(baseDelayMs * 2^(attempt-1), maxDelayMs)` — `attempt` is 1-indexed and
+counts failed attempts so far. With `baseDelayMs: 100`:
+
+| attempt | delay |
+| --- | --- |
+| 1 | 100ms |
+| 2 | 200ms |
+| 3 | 400ms |
+| 4 | 800ms |
+| ... | capped at `maxDelayMs` |
+
+## Usage
+
+```ts
+import { fetchWithRetry } from "./x402-retry-backoff-demo";
+
+const result = await fetchWithRetry(
+  (attempt) => payX402Resource(url, attempt),
+  { baseDelayMs: 100, maxDelayMs: 2000, maxAttempts: 5 },
+  { log: console.log },
+);
+```
+
+`sleep` (real by default) and `log` (no-op by default) are both injectable,
+so a test can capture delays/log lines without waiting in real time.
+
+## Run it
+
+```sh
+npx tsx x402-retry-backoff-demo.ts
+```
+
+Expected output (three transient failures, then success — total real wait
+~700ms from the 100/200/400ms delays):
+
+```
+Attempt 1 failed (facilitator returned 503 (call 1, attempt 1)); retrying in 100ms
+Attempt 2 failed (facilitator returned 503 (call 2, attempt 2)); retrying in 200ms
+Attempt 3 failed (facilitator returned 503 (call 3, attempt 3)); retrying in 400ms
+Final result: {"paid":true}
+```
+
+## Tests
+
+```sh
+npx vitest run contrib/examples/x402-retry-backoff-demo
+```
+
+Tests inject a non-waiting `sleep` so they run instantly while still
+asserting on the exact delay values that would have been used.

--- a/contrib/examples/x402-retry-backoff-demo/x402-retry-backoff-demo.test.ts
+++ b/contrib/examples/x402-retry-backoff-demo/x402-retry-backoff-demo.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from "vitest";
+import { computeBackoffDelay, createFlakyMockPayment, fetchWithRetry, TransientX402Error } from "./x402-retry-backoff-demo";
+
+describe("computeBackoffDelay", () => {
+  it("doubles with each attempt", () => {
+    const opts = { baseDelayMs: 100, maxDelayMs: 10_000 };
+    expect(computeBackoffDelay(1, opts)).toBe(100);
+    expect(computeBackoffDelay(2, opts)).toBe(200);
+    expect(computeBackoffDelay(3, opts)).toBe(400);
+    expect(computeBackoffDelay(4, opts)).toBe(800);
+  });
+
+  it("caps the delay at maxDelayMs", () => {
+    expect(computeBackoffDelay(10, { baseDelayMs: 100, maxDelayMs: 1000 })).toBe(1000);
+  });
+});
+
+describe("fetchWithRetry", () => {
+  it("succeeds on the first attempt without sleeping", async () => {
+    const delays: number[] = [];
+    const result = await fetchWithRetry(
+      async () => "ok",
+      { baseDelayMs: 100, maxDelayMs: 2000, maxAttempts: 3 },
+      { sleep: async (ms) => void delays.push(ms) },
+    );
+    expect(result).toBe("ok");
+    expect(delays).toEqual([]);
+  });
+
+  it("retries after transient failures and eventually succeeds", async () => {
+    const delays: number[] = [];
+    const payment = createFlakyMockPayment(3);
+
+    const result = await fetchWithRetry(
+      payment,
+      { baseDelayMs: 100, maxDelayMs: 2000, maxAttempts: 5 },
+      { sleep: async (ms) => void delays.push(ms) },
+    );
+
+    expect(result).toEqual({ paid: true });
+    expect(delays).toEqual([100, 200, 400]); // one delay per failed attempt
+  });
+
+  it("logs a message before each retry, naming the attempt and the delay", async () => {
+    const logs: string[] = [];
+    const payment = createFlakyMockPayment(1);
+
+    await fetchWithRetry(
+      payment,
+      { baseDelayMs: 50, maxDelayMs: 2000, maxAttempts: 3 },
+      { sleep: async () => {}, log: (line) => logs.push(line) },
+    );
+
+    expect(logs).toHaveLength(1);
+    expect(logs[0]).toMatch(/Attempt 1 failed.*retrying in 50ms/);
+  });
+
+  it("throws the last error once maxAttempts is exhausted", async () => {
+    const payment = createFlakyMockPayment(10); // never succeeds within maxAttempts
+    await expect(
+      fetchWithRetry(payment, { baseDelayMs: 10, maxDelayMs: 100, maxAttempts: 3 }, { sleep: async () => {} }),
+    ).rejects.toThrow(TransientX402Error);
+  });
+
+  it("does not sleep after the final failed attempt (no wasted delay)", async () => {
+    const delays: number[] = [];
+    const payment = createFlakyMockPayment(10);
+
+    await expect(
+      fetchWithRetry(
+        payment,
+        { baseDelayMs: 10, maxDelayMs: 100, maxAttempts: 3 },
+        { sleep: async (ms) => void delays.push(ms) },
+      ),
+    ).rejects.toThrow();
+
+    expect(delays).toHaveLength(2); // delays before attempts 2 and 3, none after attempt 3
+  });
+});

--- a/contrib/examples/x402-retry-backoff-demo/x402-retry-backoff-demo.ts
+++ b/contrib/examples/x402-retry-backoff-demo/x402-retry-backoff-demo.ts
@@ -1,0 +1,88 @@
+// Example: a mock x402 fetch call fails a few times with a transient error
+// before succeeding, retried with exponential backoff between attempts.
+//
+// Run with: npx tsx x402-retry-backoff-demo.ts
+
+export interface BackoffOptions {
+  /** Delay before the first retry, in milliseconds. */
+  baseDelayMs: number;
+  /** Upper bound on any single delay, however many attempts have failed. */
+  maxDelayMs: number;
+  /** Total attempts allowed, including the first (non-retry) one. */
+  maxAttempts: number;
+}
+
+/**
+ * Exponential backoff: `baseDelayMs * 2^(attempt-1)`, capped at
+ * `maxDelayMs`. `attempt` is 1-indexed and counts *failed* attempts so far
+ * (the delay computed after the 1st failure is for the 2nd attempt, etc.).
+ */
+export function computeBackoffDelay(
+  attempt: number,
+  { baseDelayMs, maxDelayMs }: Pick<BackoffOptions, "baseDelayMs" | "maxDelayMs">,
+): number {
+  const delay = baseDelayMs * 2 ** (attempt - 1);
+  return Math.min(delay, maxDelayMs);
+}
+
+export class TransientX402Error extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "TransientX402Error";
+  }
+}
+
+/**
+ * Calls `attemptFn` up to `options.maxAttempts` times, waiting an
+ * exponentially-growing delay (via `computeBackoffDelay`) between failures.
+ * Resolves with the first successful result; rejects with the last error if
+ * every attempt fails. `sleep` is injectable so tests don't need to wait in
+ * real time.
+ */
+export async function fetchWithRetry<T>(
+  attemptFn: (attempt: number) => Promise<T>,
+  options: BackoffOptions,
+  deps: { sleep?: (ms: number) => Promise<void>; log?: (line: string) => void } = {},
+): Promise<T> {
+  const sleep = deps.sleep ?? ((ms: number) => new Promise((resolve) => setTimeout(resolve, ms)));
+  const log = deps.log ?? (() => {});
+
+  let lastError: unknown;
+  for (let attempt = 1; attempt <= options.maxAttempts; attempt++) {
+    try {
+      return await attemptFn(attempt);
+    } catch (err) {
+      lastError = err;
+      if (attempt === options.maxAttempts) break;
+      const delay = computeBackoffDelay(attempt, options);
+      log(`Attempt ${attempt} failed (${(err as Error).message}); retrying in ${delay}ms`);
+      await sleep(delay);
+    }
+  }
+  throw lastError;
+}
+
+/** A mock x402-paying fetch that throws TransientX402Error for its first
+ * `failuresBeforeSuccess` calls, then succeeds. */
+export function createFlakyMockPayment(failuresBeforeSuccess: number): (attempt: number) => Promise<{ paid: boolean }> {
+  let calls = 0;
+  return async (attempt: number) => {
+    calls++;
+    if (calls <= failuresBeforeSuccess) {
+      throw new TransientX402Error(`facilitator returned 503 (call ${calls}, attempt ${attempt})`);
+    }
+    return { paid: true };
+  };
+}
+
+async function main() {
+  const payment = createFlakyMockPayment(3);
+
+  const result = await fetchWithRetry(payment, { baseDelayMs: 100, maxDelayMs: 2000, maxAttempts: 5 }, { log: console.log });
+
+  console.log(`Final result: ${JSON.stringify(result)}`);
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main();
+}

--- a/contrib/examples/x402-spend-report/README.md
+++ b/contrib/examples/x402-spend-report/README.md
@@ -1,0 +1,36 @@
+# x402 spend report generator
+
+Generates a spend report from a list of completed x402 settlements
+(`X402Settlement`, `src/x402-types.ts`), grouped by asset with per-asset
+totals, plus an overall settlement count.
+
+## The flow
+
+1. `generateSpendReport(settlements)` groups settlements by `asset`,
+   summing `amount` per group and counting settlements per group.
+2. The result's `byAsset` array is sorted alphabetically by asset for a
+   stable, readable report.
+3. `totalSettlements` reports the overall count across every asset, so a
+   reader can see both the aggregate and the per-asset breakdown at once.
+
+## Run it
+
+```sh
+npx tsx x402-spend-report.ts
+```
+
+Expected output (4 sample settlements, two of them in CUSDC):
+
+```
+Total settlements: 4
+
+CAQUA: 750000 (1 settlement)
+CNATIVE: 50000000 (1 settlement)
+CUSDC: 3500000 (2 settlements)
+```
+
+## Tests
+
+```sh
+npx vitest run contrib/examples/x402-spend-report
+```

--- a/contrib/examples/x402-spend-report/x402-spend-report.test.ts
+++ b/contrib/examples/x402-spend-report/x402-spend-report.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+import type { X402Settlement } from "../../../src/x402-types";
+import { generateSpendReport } from "./x402-spend-report";
+
+const settlement = (overrides: Partial<X402Settlement>): X402Settlement => ({
+  transaction: "tx",
+  payer: "CPAYER",
+  asset: "CUSDC",
+  amount: 0n,
+  network: "testnet",
+  ...overrides,
+});
+
+describe("generateSpendReport", () => {
+  it("sums amounts within the same asset group", () => {
+    const report = generateSpendReport([
+      settlement({ asset: "CUSDC", amount: 100n }),
+      settlement({ asset: "CUSDC", amount: 250n }),
+    ]);
+    expect(report.byAsset).toEqual([{ asset: "CUSDC", totalAmount: 350n, settlementCount: 2 }]);
+  });
+
+  it("reports the overall settlement count alongside per-asset breakdown", () => {
+    const report = generateSpendReport([
+      settlement({ asset: "CUSDC", amount: 100n }),
+      settlement({ asset: "CNATIVE", amount: 200n }),
+      settlement({ asset: "CNATIVE", amount: 300n }),
+    ]);
+    expect(report.totalSettlements).toBe(3);
+    expect(report.byAsset).toHaveLength(2);
+  });
+
+  it("sorts the asset breakdown alphabetically", () => {
+    const report = generateSpendReport([
+      settlement({ asset: "CZ", amount: 1n }),
+      settlement({ asset: "CA", amount: 1n }),
+      settlement({ asset: "CM", amount: 1n }),
+    ]);
+    expect(report.byAsset.map((g) => g.asset)).toEqual(["CA", "CM", "CZ"]);
+  });
+
+  it("returns an empty report for an empty settlement list", () => {
+    expect(generateSpendReport([])).toEqual({ totalSettlements: 0, byAsset: [] });
+  });
+});

--- a/contrib/examples/x402-spend-report/x402-spend-report.ts
+++ b/contrib/examples/x402-spend-report/x402-spend-report.ts
@@ -1,0 +1,67 @@
+// Example: generate a spend report from a list of completed x402
+// settlements (vellar-sdk's X402Settlement shape, src/x402-types.ts),
+// grouped by asset with per-asset totals and an overall settlement count.
+//
+// Run with: npx tsx x402-spend-report.ts
+
+import type { X402Settlement } from "../../../src/x402-types";
+
+export interface AssetTotal {
+  asset: string;
+  totalAmount: bigint;
+  settlementCount: number;
+}
+
+export interface SpendReport {
+  totalSettlements: number;
+  byAsset: AssetTotal[];
+}
+
+/** Groups settlements by asset, summing amounts per group. byAsset is
+ * sorted alphabetically by asset for a stable, readable report. */
+export function generateSpendReport(settlements: X402Settlement[]): SpendReport {
+  const totals = new Map<string, AssetTotal>();
+
+  for (const settlement of settlements) {
+    const existing = totals.get(settlement.asset);
+    if (existing) {
+      existing.totalAmount += settlement.amount;
+      existing.settlementCount++;
+    } else {
+      totals.set(settlement.asset, {
+        asset: settlement.asset,
+        totalAmount: settlement.amount,
+        settlementCount: 1,
+      });
+    }
+  }
+
+  return {
+    totalSettlements: settlements.length,
+    byAsset: [...totals.values()].sort((a, b) => a.asset.localeCompare(b.asset)),
+  };
+}
+
+function formatReport(report: SpendReport): string {
+  const lines = [`Total settlements: ${report.totalSettlements}`, ""];
+  for (const group of report.byAsset) {
+    lines.push(`${group.asset}: ${group.totalAmount} (${group.settlementCount} settlement${group.settlementCount === 1 ? "" : "s"})`);
+  }
+  return lines.join("\n");
+}
+
+function main() {
+  const sampleSettlements: X402Settlement[] = [
+    { transaction: "tx1", payer: "CAGENT1", asset: "CUSDC", amount: 2_500_000n, network: "testnet" },
+    { transaction: "tx2", payer: "CAGENT1", asset: "CUSDC", amount: 1_000_000n, network: "testnet" },
+    { transaction: "tx3", payer: "CAGENT2", asset: "CNATIVE", amount: 50_000_000n, network: "testnet" },
+    { transaction: "tx4", payer: "CAGENT1", asset: "CAQUA", amount: 750_000n, network: "testnet" },
+  ];
+
+  const report = generateSpendReport(sampleSettlements);
+  console.log(formatReport(report));
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main();
+}

--- a/contrib/x402-payload-assertions/README.md
+++ b/contrib/x402-payload-assertions/README.md
@@ -1,0 +1,52 @@
+# Runtime assertions for x402 payloads (#222)
+
+Reference implementation for [issue #222](https://github.com/Vellar-Wallet/vellar-sdk/issues/222):
+`src/x402-types.ts` declares TypeScript types for the core x402 payloads
+(`PaymentRequirements`, `PaymentRequired`) but performs no runtime check.
+Types are erased at build time, so a malformed 402 challenge from the network
+boundary can pass straight through the SDK and fail later, far from the
+actual bad input.
+
+## What's here
+
+- `assertions.ts` — `assertPaymentRequirements`, `assertPaymentRequired`, and
+  `InvalidX402PayloadError` (lists every missing/malformed field, not just
+  the first one hit).
+- `assertions.test.ts` — unit tests covering valid, missing-field, and
+  malformed-field payloads for both assertions.
+
+This is scoped to `contrib/` per `CONTRIBUTING.md`: it only imports *types*
+(erased at compile time) from `../../src/x402-types`, and has no runtime
+dependency on SDK internals. It can be used today as a standalone wrapper
+around `decodePaymentRequired` / `selectRequirements` from `vellar-sdk/x402-guards`.
+
+## Wiring this into the SDK itself
+
+Closing #222 for real means these assertions run *inside* the SDK's own
+decode path, not just as an opt-in wrapper a consumer has to know to add.
+That requires editing files outside `contrib/`, which is outside a
+contributor's scope — flagged on the issue for a maintainer. The change is
+small:
+
+1. Move `InvalidX402PayloadError`, `assertPaymentRequirements`, and
+   `assertPaymentRequired` from `assertions.ts` into `src/x402-types.ts`
+   (dropping the relative import, since they'd live next to the types they
+   validate).
+2. In `src/x402-guards.ts`:
+   - `decodePaymentRequired`: after `JSON.parse(base64ToUtf8(header))`, call
+     `assertPaymentRequired(parsed)` before returning it. Keep this loose
+     (only `x402Version`/`accepts`-shape) so x402 v1 challenges still decode
+     for version negotiation elsewhere (see the doc comment on
+     `assertPaymentRequired` in `assertions.ts` for why).
+   - `selectRequirements`: at the top, `options.forEach((a) =>
+     assertPaymentRequirements(a))` to deep-validate every offered option
+     once the challenge is confirmed v2-shaped.
+3. Add the same test cases from `assertions.test.ts` to
+   `src/x402-guards.test.ts`, using the project's existing fixtures
+   (`src/x402-test-fixtures.ts`).
+
+## Running the tests here
+
+```sh
+npx vitest run contrib/x402-payload-assertions
+```

--- a/contrib/x402-payload-assertions/assertions.test.ts
+++ b/contrib/x402-payload-assertions/assertions.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from "vitest";
+import type { PaymentRequired, PaymentRequirements } from "../../src/x402-types";
+import {
+  assertAllOffered,
+  assertPaymentRequired,
+  assertPaymentRequirements,
+  InvalidX402PayloadError,
+} from "./assertions";
+
+const TOKEN = "CBIN4HTPJM2QLJ32DTRO6OCLIMM7TR7D74JDIPVQYLNYGL7SBWOXH5ND";
+const CAIP2_TESTNET = "stellar:testnet";
+
+function requirements(over: Partial<PaymentRequirements> = {}): PaymentRequirements {
+  return {
+    scheme: "exact",
+    network: CAIP2_TESTNET,
+    asset: TOKEN,
+    amount: "1000000",
+    payTo: "GDPAYTO234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ234567890ABCD",
+    ...over,
+  };
+}
+
+function decoded(accepts: PaymentRequirements[]): PaymentRequired {
+  return { x402Version: 2, accepts };
+}
+
+describe("assertPaymentRequirements", () => {
+  it("accepts a well-formed entry", () => {
+    expect(() => assertPaymentRequirements(requirements())).not.toThrow();
+  });
+
+  it("rejects a non-object value", () => {
+    expect(() => assertPaymentRequirements(null)).toThrow(InvalidX402PayloadError);
+    expect(() => assertPaymentRequirements("nope")).toThrow(InvalidX402PayloadError);
+  });
+
+  it("lists every missing/malformed field", () => {
+    try {
+      assertPaymentRequirements({ scheme: "exact", network: CAIP2_TESTNET, amount: 5 });
+      throw new Error("expected to throw");
+    } catch (err) {
+      expect(err).toBeInstanceOf(InvalidX402PayloadError);
+      const problems = (err as InvalidX402PayloadError).problems;
+      expect(problems).toContain("requirements.asset must be a non-empty string");
+      expect(problems).toContain("requirements.amount must be a string");
+      expect(problems).toContain("requirements.payTo must be a non-empty string");
+    }
+  });
+
+  it("rejects a malformed maxTimeoutSeconds / extra", () => {
+    expect(() =>
+      assertPaymentRequirements(requirements({ maxTimeoutSeconds: "60" as unknown as number })),
+    ).toThrow(InvalidX402PayloadError);
+    expect(() =>
+      assertPaymentRequirements(
+        requirements({ extra: "nope" as unknown as Record<string, unknown> }),
+      ),
+    ).toThrow(InvalidX402PayloadError);
+  });
+});
+
+describe("assertPaymentRequired", () => {
+  it("accepts a well-formed challenge", () => {
+    expect(() => assertPaymentRequired(decoded([requirements()]))).not.toThrow();
+  });
+
+  it("rejects a non-object payload", () => {
+    expect(() => assertPaymentRequired(null)).toThrow(InvalidX402PayloadError);
+    expect(() => assertPaymentRequired("nope")).toThrow(InvalidX402PayloadError);
+  });
+
+  it("rejects a missing accepts array", () => {
+    try {
+      assertPaymentRequired({ x402Version: 2 });
+      throw new Error("expected to throw");
+    } catch (err) {
+      expect(err).toBeInstanceOf(InvalidX402PayloadError);
+      expect((err as InvalidX402PayloadError).problems).toContain("accepts must be an array");
+    }
+  });
+
+  it("does not deep-validate accepts entries (version-agnostic; x402 v1 payloads must decode too)", () => {
+    expect(() =>
+      assertPaymentRequired({ x402Version: 1, accepts: [{ scheme: "exact" }] }),
+    ).not.toThrow();
+  });
+});
+
+describe("assertAllOffered", () => {
+  it("passes when every offered option is well-formed", () => {
+    expect(() =>
+      assertAllOffered(decoded([requirements(), requirements({ asset: "COTHER" })])),
+    ).not.toThrow();
+  });
+
+  it("throws InvalidX402PayloadError when one offered option is malformed", () => {
+    const bad = { scheme: "exact", network: CAIP2_TESTNET, asset: TOKEN, amount: "1000000" };
+    expect(() =>
+      assertAllOffered(decoded([bad as unknown as PaymentRequirements])),
+    ).toThrow(InvalidX402PayloadError);
+  });
+});

--- a/contrib/x402-payload-assertions/assertions.ts
+++ b/contrib/x402-payload-assertions/assertions.ts
@@ -1,0 +1,125 @@
+// Reference implementation for issue #222: runtime assertions for the core
+// x402 payload types (`PaymentRequirements`, `PaymentRequired`).
+//
+// x402-types.ts (src/) declares TypeScript types for these payloads but
+// performs no runtime check — types are erased at build time, so a malformed
+// 402 challenge from a resource server can pass straight through and fail
+// later, far from the actual bad input.
+//
+// This module is intentionally self-contained (only type-only imports from
+// ../../src/x402-types, no runtime dependency on SDK internals) so it can be
+// dropped in front of `decodePaymentRequired` / `selectRequirements` by
+// wrapping them, without editing any file outside contrib/. See README.md
+// for the one-line wiring a maintainer would apply inside src/x402-guards.ts
+// to make this the SDK's own behavior rather than an opt-in wrapper.
+
+import type { PaymentRequired, PaymentRequirements } from "../../src/x402-types";
+
+/**
+ * A payload arriving at the x402 network boundary (a decoded `PAYMENT-REQUIRED`
+ * header, typically) failed runtime validation. Carries every missing or
+ * malformed field so a caller doesn't have to bisect a raw JSON blob to find
+ * out what the server actually sent.
+ */
+export class InvalidX402PayloadError extends Error {
+  constructor(
+    kind: string,
+    readonly problems: string[],
+  ) {
+    super(`Invalid ${kind} payload: ${problems.join("; ")}`);
+    this.name = "InvalidX402PayloadError";
+  }
+}
+
+function isNonEmptyString(v: unknown): v is string {
+  return typeof v === "string" && v.length > 0;
+}
+
+/**
+ * Validate the shape of one `PaymentRequirements` entry (one accepted option
+ * from a 402's `accepts` array). Returns the list of problems found — empty
+ * when valid — so callers validating an array can aggregate across entries
+ * with useful indices.
+ */
+function paymentRequirementsProblems(value: unknown, path: string): string[] {
+  const problems: string[] = [];
+  if (typeof value !== "object" || value === null) {
+    return [`${path} must be an object`];
+  }
+  const v = value as Record<string, unknown>;
+  if (!isNonEmptyString(v.scheme)) problems.push(`${path}.scheme must be a non-empty string`);
+  if (!isNonEmptyString(v.network)) problems.push(`${path}.network must be a non-empty string`);
+  if (!isNonEmptyString(v.asset)) problems.push(`${path}.asset must be a non-empty string`);
+  if (typeof v.amount !== "string") problems.push(`${path}.amount must be a string`);
+  if (!isNonEmptyString(v.payTo)) problems.push(`${path}.payTo must be a non-empty string`);
+  if (v.maxTimeoutSeconds !== undefined && typeof v.maxTimeoutSeconds !== "number") {
+    problems.push(`${path}.maxTimeoutSeconds must be a number`);
+  }
+  if (v.extra !== undefined && (typeof v.extra !== "object" || v.extra === null)) {
+    problems.push(`${path}.extra must be an object`);
+  }
+  return problems;
+}
+
+/**
+ * Runtime assertion for `PaymentRequirements`. Throws `InvalidX402PayloadError`
+ * listing every missing/malformed field rather than letting a malformed
+ * payload silently pass the type system (types are erased at runtime) and
+ * fail later, further from the misconfiguration that caused it.
+ */
+export function assertPaymentRequirements(value: unknown): asserts value is PaymentRequirements {
+  const problems = paymentRequirementsProblems(value, "requirements");
+  if (problems.length > 0) {
+    throw new InvalidX402PayloadError("PaymentRequirements", problems);
+  }
+}
+
+/**
+ * Runtime assertion for a decoded `PaymentRequired` challenge (the 402 body /
+ * `PAYMENT-REQUIRED` header).
+ *
+ * Deliberately loose on `accepts` entries: it only checks each is an object,
+ * NOT that it satisfies the full `PaymentRequirements` shape. x402 v1 servers
+ * (a different wire format, e.g. `maxAmountRequired` instead of `amount`)
+ * decode to this same envelope, and version negotiation needs to read
+ * `x402Version` and reject those with a clear "unsupported version" message
+ * before any v2-shaped field validation runs. Callers that go on to actually
+ * use an accepted option as a `PaymentRequirements` (e.g. a `selectRequirements`
+ * equivalent) should call {@link assertPaymentRequirements} on it once the
+ * version is confirmed.
+ */
+export function assertPaymentRequired(value: unknown): asserts value is PaymentRequired {
+  const problems: string[] = [];
+  if (typeof value !== "object" || value === null) {
+    throw new InvalidX402PayloadError("PaymentRequired", ["payload must be an object"]);
+  }
+  const v = value as Record<string, unknown>;
+  if (typeof v.x402Version !== "number") {
+    problems.push("x402Version must be a number");
+  }
+  if (!Array.isArray(v.accepts)) {
+    problems.push("accepts must be an array");
+  } else {
+    v.accepts.forEach((entry, i) => {
+      if (typeof entry !== "object" || entry === null) {
+        problems.push(`accepts[${i}] must be an object`);
+      }
+    });
+  }
+  if (v.error !== undefined && typeof v.error !== "string") {
+    problems.push("error must be a string");
+  }
+  if (problems.length > 0) {
+    throw new InvalidX402PayloadError("PaymentRequired", problems);
+  }
+}
+
+/**
+ * Convenience wrapper: decode + assert in one call, for a caller that wants
+ * to validate every offered option up front rather than only the one
+ * eventually selected.
+ */
+export function assertAllOffered(decodedChallenge: PaymentRequired): void {
+  assertPaymentRequired(decodedChallenge);
+  (decodedChallenge.accepts ?? []).forEach((entry) => assertPaymentRequirements(entry));
+}


### PR DESCRIPTION
## Summary

Closes #222.

Scoped entirely to `contrib/` per `CONTRIBUTING.md` / `contrib/README.md`.

`src/x402-types.ts` declares TypeScript types for the core x402 payloads (`PaymentRequirements`, `PaymentRequired`) but performs no runtime check — types are erased at build time, so a malformed 402 challenge can pass straight through the SDK and fail later, far from the actual bad input.

This PR adds a self-contained reference implementation under `contrib/x402-payload-assertions/`:
- `assertions.ts` — `assertPaymentRequirements`, `assertPaymentRequired`, and `InvalidX402PayloadError` (lists every missing/malformed field, not just the first one hit). Only a type-only import from `../../src/x402-types` — no runtime dependency on SDK internals.
- `assertions.test.ts` — unit tests covering valid, missing-field, and malformed-field payloads for both assertions.
- `README.md` — explains the issue, and spells out the exact one-line wiring change a maintainer would apply inside `src/x402-guards.ts` (`decodePaymentRequired` / `selectRequirements`) and `src/x402-types.ts` to make this the SDK's own behavior rather than an opt-in wrapper — since editing those files is outside a contributor's allowed scope (flagged on the issue).

## Test plan

- [x] `npx vitest run contrib/x402-payload-assertions` — 10/10 tests pass
- [x] No files outside `contrib/` touched