### PR TITLE
Add cursor pagination for balances-rpc history queries

### DIFF
--- a/contrib/examples/balance-history-pagination/README.md
+++ b/contrib/examples/balance-history-pagination/README.md
@@ -1,0 +1,94 @@
+# Balance history, paginated by cursor
+
+`vellar-sdk/rpc`'s `createRpcBalanceReader()` answers "what's the balance
+right now" — it has no notion of history, and pulling a wallet's whole
+transfer log in one call doesn't scale for wallets with long histories
+([#205](https://github.com/Vellar-Wallet/vellar-sdk/issues/205)). This adds
+a `getBalanceHistory` query with cursor-based pagination: `after` / `limit`
+in, `next_cursor` out — the same shape a REST list endpoint would use — with
+a capped default and max page size.
+
+## Why this lives in `contrib/`, not `src/`
+
+Per [CONTRIBUTING.md](../../../CONTRIBUTING.md) and
+[contrib/README.md](../../README.md), external contributor PRs may only
+touch files under `contrib/`. This is built as a self-contained module on
+top of `vellar-sdk/rpc`'s existing public exports (`RpcBalanceReaderOptions`)
+rather than editing `src/balances-rpc.ts` directly, so it doesn't need that
+exception.
+
+## How pagination works
+
+Soroban RPC's own `getEvents` already has cursor pagination built in — a
+response carries a `cursor` string that resumes exactly where that call left
+off. `queryBalanceHistory` wraps it with:
+
+- A **bounded page size**: `limit` defaults to `DEFAULT_BALANCE_HISTORY_LIMIT`
+  (20) and is capped at `MAX_BALANCE_HISTORY_LIMIT` (100) — a caller asking
+  for more just gets the cap, not an error.
+- A **`next_cursor` the caller doesn't have to compute**: it's the RPC's own
+  cursor, echoed back once a page has at least one entry, and `null` once a
+  page comes back empty (the stop signal for a paging loop).
+- **Both transfer directions**: a holder's history includes transfers where
+  they're the sender *or* the recipient. Soroban RPC's topic filters can't
+  express "this position OR that position" in one filter, so this issues two
+  filters (holder-as-sender, holder-as-recipient) that get OR'd together by
+  `getEvents`.
+
+```ts
+import { queryBalanceHistory, createBalanceHistoryReader } from "./balance-history";
+
+const reader = createBalanceHistoryReader({ rpcUrl, networkPassphrase });
+
+// First page: start from a known ledger.
+let page = await reader.getBalanceHistory(tokenContractId, holder, { startLedger, limit: 25 });
+console.log(page.entries);
+
+// Next page: resume from where the last one left off.
+while (page.next_cursor) {
+  page = await reader.getBalanceHistory(tokenContractId, holder, { after: page.next_cursor, limit: 25 });
+  console.log(page.entries);
+}
+```
+
+`startLedger` is required for the first page — Soroban RPC's `getEvents` has
+no "just give me the latest" mode, it always needs either a starting ledger
+or a resume cursor. A real caller typically gets this from
+`server.getLatestLedger()` minus however far back it wants to look (see
+`main()` in `balance-history.ts` for a worked example), or by persisting the
+last cursor it saw between requests.
+
+`queryBalanceHistory` takes a narrow `BalanceHistorySource` (just
+`getEvents`) rather than a full `rpc.Server`, so it's directly unit-testable
+with a fake — no live RPC round trip needed. `createBalanceHistoryReader`
+wraps a real `rpc.Server` for actual use, mirroring
+`createRpcBalanceReader`'s shape.
+
+## Run it
+
+```sh
+npx tsx balance-history.ts <accountId> <tokenContractId> [startLedger]
+```
+
+Without `startLedger`, it defaults to roughly the last 1000 ledgers on
+testnet — enough for a quick demo, not a real retention-window calculation.
+
+## Tests
+
+```sh
+npx vitest run contrib/examples/balance-history-pagination
+```
+
+Covers:
+
+- **First page** — `startLedger` given, entries decoded (from/to/amount/
+  ledger/etc.), `next_cursor` returned from the RPC response.
+- **Middle page** — resuming with `after`, request built with `cursor`
+  instead of `startLedger`.
+- **Empty result** — `next_cursor` is `null` when a page has no entries.
+- Default and capped `limit` (including rejecting a non-positive or
+  non-integer one).
+- Requiring `startLedger` or `after`, with `after` taking priority when
+  both are given.
+- Both transfer-direction filters being sent, and a malformed event
+  producing a descriptive error instead of a silent bad decode.

--- a/contrib/examples/balance-history-pagination/balance-history.test.ts
+++ b/contrib/examples/balance-history-pagination/balance-history.test.ts
@@ -1,0 +1,165 @@
+import { Address, Keypair, nativeToScVal, rpc } from "@stellar/stellar-sdk";
+import { describe, expect, it, vi } from "vitest";
+import {
+  createBalanceHistoryReader,
+  DEFAULT_BALANCE_HISTORY_LIMIT,
+  MAX_BALANCE_HISTORY_LIMIT,
+  queryBalanceHistory,
+  type BalanceHistorySource,
+} from "./balance-history";
+
+const TOKEN = "CDLZFC3SYJYDZT7K67VZ75HPJVIEUVNIXF47ZG2FB2RMQQVU2HHGCYSC";
+const HOLDER = Keypair.random().publicKey();
+const OTHER = Keypair.random().publicKey();
+
+function transferEvent(opts: { id: string; from: string; to: string; amount: bigint; ledger?: number }): rpc.Api.EventResponse {
+  return {
+    id: opts.id,
+    type: "contract",
+    ledger: opts.ledger ?? 100,
+    ledgerClosedAt: "2026-08-28T00:00:00Z",
+    transactionIndex: 1,
+    operationIndex: 0,
+    inSuccessfulContractCall: true,
+    txHash: `hash-${opts.id}`,
+    topic: [
+      nativeToScVal("transfer", { type: "symbol" }),
+      new Address(opts.from).toScVal(),
+      new Address(opts.to).toScVal(),
+    ],
+    value: nativeToScVal(opts.amount, { type: "i128" }),
+  };
+}
+
+function eventsResponse(events: rpc.Api.EventResponse[], cursor: string): rpc.Api.GetEventsResponse {
+  return {
+    events,
+    cursor,
+    latestLedger: 1000,
+    oldestLedger: 1,
+    latestLedgerCloseTime: "2026-08-28T00:00:00Z",
+    oldestLedgerCloseTime: "2026-08-01T00:00:00Z",
+  };
+}
+
+describe("queryBalanceHistory", () => {
+  it("fetches a first page from startLedger and returns a next_cursor", async () => {
+    const source: BalanceHistorySource = {
+      getEvents: vi
+        .fn()
+        .mockResolvedValue(
+          eventsResponse(
+            [
+              transferEvent({ id: "e1", from: HOLDER, to: OTHER, amount: 100n, ledger: 10 }),
+              transferEvent({ id: "e2", from: OTHER, to: HOLDER, amount: 50n, ledger: 11 }),
+            ],
+            "cursor-page-1",
+          ),
+        ),
+    };
+
+    const page = await queryBalanceHistory(source, TOKEN, HOLDER, { startLedger: 5 });
+
+    expect(page.entries).toEqual([
+      { cursor: "e1", from: HOLDER, to: OTHER, amount: 100n, ledger: 10, ledgerClosedAt: "2026-08-28T00:00:00Z", txHash: "hash-e1" },
+      { cursor: "e2", from: OTHER, to: HOLDER, amount: 50n, ledger: 11, ledgerClosedAt: "2026-08-28T00:00:00Z", txHash: "hash-e2" },
+    ]);
+    expect(page.next_cursor).toBe("cursor-page-1");
+
+    expect(source.getEvents).toHaveBeenCalledWith(
+      expect.objectContaining({ startLedger: 5, limit: DEFAULT_BALANCE_HISTORY_LIMIT }),
+    );
+    const request = (source.getEvents as ReturnType<typeof vi.fn>).mock.calls[0]![0];
+    // Both transfer directions are covered by two OR'd filters.
+    expect(request.filters).toHaveLength(2);
+    expect(request.filters[0].topics[0][1]).not.toBe("*");
+    expect(request.filters[0].topics[0][2]).toBe("*");
+    expect(request.filters[1].topics[0][1]).toBe("*");
+    expect(request.filters[1].topics[0][2]).not.toBe("*");
+  });
+
+  it("fetches a middle page by resuming from a previous next_cursor", async () => {
+    const source: BalanceHistorySource = {
+      getEvents: vi
+        .fn()
+        .mockResolvedValue(
+          eventsResponse(
+            [transferEvent({ id: "e3", from: HOLDER, to: OTHER, amount: 25n, ledger: 20 })],
+            "cursor-page-2",
+          ),
+        ),
+    };
+
+    const page = await queryBalanceHistory(source, TOKEN, HOLDER, { after: "cursor-page-1", limit: 5 });
+
+    expect(page.entries).toHaveLength(1);
+    expect(page.next_cursor).toBe("cursor-page-2");
+    expect(source.getEvents).toHaveBeenCalledWith(
+      expect.objectContaining({ cursor: "cursor-page-1", limit: 5 }),
+    );
+  });
+
+  it("returns an empty page with a null next_cursor when nothing matches", async () => {
+    const source: BalanceHistorySource = {
+      getEvents: vi.fn().mockResolvedValue(eventsResponse([], "cursor-unused")),
+    };
+
+    const page = await queryBalanceHistory(source, TOKEN, HOLDER, { startLedger: 5 });
+
+    expect(page.entries).toEqual([]);
+    expect(page.next_cursor).toBeNull();
+  });
+
+  it("defaults limit to DEFAULT_BALANCE_HISTORY_LIMIT when omitted", async () => {
+    const source: BalanceHistorySource = { getEvents: vi.fn().mockResolvedValue(eventsResponse([], "c")) };
+    await queryBalanceHistory(source, TOKEN, HOLDER, { startLedger: 1 });
+    expect(source.getEvents).toHaveBeenCalledWith(expect.objectContaining({ limit: DEFAULT_BALANCE_HISTORY_LIMIT }));
+  });
+
+  it("caps a requested limit at MAX_BALANCE_HISTORY_LIMIT instead of rejecting it", async () => {
+    const source: BalanceHistorySource = { getEvents: vi.fn().mockResolvedValue(eventsResponse([], "c")) };
+    await queryBalanceHistory(source, TOKEN, HOLDER, { startLedger: 1, limit: 5000 });
+    expect(source.getEvents).toHaveBeenCalledWith(expect.objectContaining({ limit: MAX_BALANCE_HISTORY_LIMIT }));
+  });
+
+  it("rejects a non-positive or non-integer limit without calling the source", async () => {
+    const source: BalanceHistorySource = { getEvents: vi.fn() };
+    await expect(queryBalanceHistory(source, TOKEN, HOLDER, { startLedger: 1, limit: 0 })).rejects.toThrow(RangeError);
+    await expect(queryBalanceHistory(source, TOKEN, HOLDER, { startLedger: 1, limit: -3 })).rejects.toThrow(RangeError);
+    await expect(queryBalanceHistory(source, TOKEN, HOLDER, { startLedger: 1, limit: 1.5 })).rejects.toThrow(RangeError);
+    expect(source.getEvents).not.toHaveBeenCalled();
+  });
+
+  it("requires either startLedger or after", async () => {
+    const source: BalanceHistorySource = { getEvents: vi.fn() };
+    await expect(queryBalanceHistory(source, TOKEN, HOLDER)).rejects.toThrow(RangeError);
+    expect(source.getEvents).not.toHaveBeenCalled();
+  });
+
+  it("prefers after over startLedger when both are given", async () => {
+    const source: BalanceHistorySource = { getEvents: vi.fn().mockResolvedValue(eventsResponse([], "c")) };
+    await queryBalanceHistory(source, TOKEN, HOLDER, { startLedger: 1, after: "resume-here" });
+    const request = (source.getEvents as ReturnType<typeof vi.fn>).mock.calls[0]![0];
+    expect(request.cursor).toBe("resume-here");
+    expect(request.startLedger).toBeUndefined();
+  });
+
+  it("throws a descriptive error for a malformed transfer event", async () => {
+    const badEvent = transferEvent({ id: "e1", from: HOLDER, to: OTHER, amount: 1n });
+    badEvent.topic = [badEvent.topic[0]!]; // drop from/to
+    const source: BalanceHistorySource = {
+      getEvents: vi.fn().mockResolvedValue(eventsResponse([badEvent], "c")),
+    };
+    await expect(queryBalanceHistory(source, TOKEN, HOLDER, { startLedger: 1 })).rejects.toThrow(/malformed transfer event/);
+  });
+});
+
+describe("createBalanceHistoryReader", () => {
+  it("returns an object exposing getBalanceHistory without making a network call", () => {
+    const reader = createBalanceHistoryReader({
+      rpcUrl: "https://rpc.example.invalid",
+      networkPassphrase: "Test SDF Network ; September 2015",
+    });
+    expect(typeof reader.getBalanceHistory).toBe("function");
+  });
+});

--- a/contrib/examples/balance-history-pagination/balance-history.ts
+++ b/contrib/examples/balance-history-pagination/balance-history.ts
@@ -1,0 +1,198 @@
+// Example: cursor-paginated balance-history queries against Soroban RPC.
+//
+// vellar-sdk/rpc's createRpcBalanceReader() answers "what's the balance
+// right now" — it has no notion of history. Building a history view means
+// walking a SEP-41 token's `transfer` events for a holder, and a wallet with
+// a long history can't pull that whole log in one RPC call. This wraps
+// Soroban RPC's getEvents in a small `after`/`limit` → `next_cursor` page
+// contract (the shape a REST list endpoint would use), with a capped
+// default and max page size, so callers page through history in bounded
+// chunks instead of one unbounded fetch.
+//
+// Soroban RPC's own getEvents cursor already IS this: a `getEvents`
+// response carries a `cursor` string that resumes exactly where that call
+// left off. This module just gives it a bounded, self-describing page
+// shape and enforces the page-size cap the SDK doesn't have an opinion on
+// today.
+//
+// Run with: npx tsx balance-history.ts <accountId> <tokenContractId> [startLedger]
+
+import { Address, nativeToScVal, rpc, scValToBigInt } from "@stellar/stellar-sdk";
+import { TESTNET } from "../../../src/config";
+import type { RpcBalanceReaderOptions } from "../../../src/rpc";
+
+/** Page size when `limit` is omitted from a query. */
+export const DEFAULT_BALANCE_HISTORY_LIMIT = 20;
+/** Hard ceiling on page size — a caller-supplied `limit` above this is capped, not rejected. */
+export const MAX_BALANCE_HISTORY_LIMIT = 100;
+
+export interface BalanceHistoryEntry {
+  /** This event's own cursor. Passing it as `after` resumes just past it. */
+  cursor: string;
+  from: string;
+  to: string;
+  /** Raw token units transferred (e.g. stroops for XLM), always positive. */
+  amount: bigint;
+  ledger: number;
+  ledgerClosedAt: string;
+  txHash: string;
+}
+
+export interface BalanceHistoryPage {
+  entries: BalanceHistoryEntry[];
+  /** Cursor for the next page. Null once a page comes back empty — that's the stop signal. */
+  next_cursor: string | null;
+}
+
+export interface BalanceHistoryQuery {
+  /**
+   * Ledger to start scanning from (inclusive). Required for the first page —
+   * Soroban RPC's getEvents has no "just give me the latest" mode, it always
+   * needs either a starting ledger or a cursor from a prior call. Ignored
+   * once `after` is set.
+   */
+  startLedger?: number;
+  /** Resume from a previous page's `next_cursor`. Takes priority over `startLedger`. */
+  after?: string;
+  /** Page size, capped at MAX_BALANCE_HISTORY_LIMIT. Defaults to DEFAULT_BALANCE_HISTORY_LIMIT. */
+  limit?: number;
+}
+
+/**
+ * The slice of `rpc.Server` this needs. Narrowed to one method so tests can
+ * inject a fake instead of a real Server (and a real Server structurally
+ * satisfies it, no adapter needed).
+ */
+export interface BalanceHistorySource {
+  getEvents(request: rpc.Api.GetEventsRequest): Promise<rpc.Api.GetEventsResponse>;
+}
+
+function clampLimit(limit: number | undefined): number {
+  if (limit === undefined) return DEFAULT_BALANCE_HISTORY_LIMIT;
+  if (!Number.isInteger(limit) || limit < 1) {
+    throw new RangeError(`limit must be a positive integer, got ${limit}`);
+  }
+  return Math.min(limit, MAX_BALANCE_HISTORY_LIMIT);
+}
+
+/**
+ * Two filters, OR'd together by getEvents: `holder` as sender, and `holder`
+ * as recipient. That's the only way to cover both directions of a
+ * `transfer(from, to)` event, since a single filter's topic wildcards can't
+ * express "this position OR that position".
+ */
+function transferFilters(tokenContractId: string, holder: string): rpc.Api.EventFilter[] {
+  const transferTopic = nativeToScVal("transfer", { type: "symbol" }).toXDR("base64");
+  const holderTopic = new Address(holder).toScVal().toXDR("base64");
+  return [
+    { type: "contract", contractIds: [tokenContractId], topics: [[transferTopic, holderTopic, "*"]] },
+    { type: "contract", contractIds: [tokenContractId], topics: [[transferTopic, "*", holderTopic]] },
+  ];
+}
+
+/** Decodes a SEP-41 `transfer(from: Address, to: Address, amount: i128)` event. */
+function decodeTransferEvent(event: rpc.Api.EventResponse): BalanceHistoryEntry {
+  const [, fromTopic, toTopic] = event.topic;
+  if (!fromTopic || !toTopic) {
+    throw new Error(
+      `malformed transfer event ${event.id}: expected topics (symbol, from, to), got ${event.topic.length}`,
+    );
+  }
+  return {
+    cursor: event.id,
+    from: Address.fromScVal(fromTopic).toString(),
+    to: Address.fromScVal(toTopic).toString(),
+    amount: scValToBigInt(event.value),
+    ledger: event.ledger,
+    ledgerClosedAt: event.ledgerClosedAt,
+    txHash: event.txHash,
+  };
+}
+
+/**
+ * Fetches one page of `transfer` events into or out of `holder` for
+ * `tokenContractId`.
+ *
+ * - First page: pass `startLedger` (omit `after`).
+ * - Later pages: pass `after: previousPage.next_cursor`.
+ * - Stop once a page comes back with `next_cursor: null`.
+ */
+export async function queryBalanceHistory(
+  source: BalanceHistorySource,
+  tokenContractId: string,
+  holder: string,
+  query: BalanceHistoryQuery = {},
+): Promise<BalanceHistoryPage> {
+  const limit = clampLimit(query.limit);
+  const filters = transferFilters(tokenContractId, holder);
+
+  let response: rpc.Api.GetEventsResponse;
+  if (query.after !== undefined) {
+    response = await source.getEvents({ filters, cursor: query.after, limit });
+  } else if (query.startLedger !== undefined) {
+    response = await source.getEvents({ filters, startLedger: query.startLedger, limit });
+  } else {
+    throw new RangeError("queryBalanceHistory: pass `startLedger` for the first page, or `after` to resume one");
+  }
+
+  const entries = response.events.map(decodeTransferEvent);
+  return { entries, next_cursor: entries.length > 0 ? response.cursor : null };
+}
+
+/** Wraps a real `rpc.Server` so callers don't have to construct one themselves. */
+export function createBalanceHistoryReader(options: RpcBalanceReaderOptions): {
+  getBalanceHistory(
+    tokenContractId: string,
+    holder: string,
+    query?: BalanceHistoryQuery,
+  ): Promise<BalanceHistoryPage>;
+} {
+  const server = new rpc.Server(options.rpcUrl);
+  return {
+    getBalanceHistory: (tokenContractId, holder, query) =>
+      queryBalanceHistory(server, tokenContractId, holder, query),
+  };
+}
+
+async function main() {
+  const [accountId, tokenContractId, startLedgerArg] = process.argv.slice(2);
+  if (!accountId || !tokenContractId) {
+    console.error("Usage: npx tsx balance-history.ts <accountId> <tokenContractId> [startLedger]");
+    process.exitCode = 1;
+    return;
+  }
+
+  const server = new rpc.Server(TESTNET.rpcUrl);
+  // Demo default: recent ledgers only, since RPC providers only retain a
+  // limited event window (often far short of Soroban's own 7-day cap) — a
+  // real caller should track and pass its own startLedger.
+  const startLedger = startLedgerArg
+    ? Number(startLedgerArg)
+    : (await server.getLatestLedger()).sequence - 1000;
+
+  try {
+    let cursor: string | undefined;
+    let page = 1;
+    for (;;) {
+      const result = await queryBalanceHistory(server, tokenContractId, accountId, {
+        startLedger: cursor ? undefined : startLedger,
+        after: cursor,
+        limit: 20,
+      });
+      console.log(`Page ${page}: ${result.entries.length} transfer(s)`);
+      for (const entry of result.entries) {
+        console.log(`  ledger ${entry.ledger}  ${entry.from} -> ${entry.to}  amount=${entry.amount}`);
+      }
+      if (!result.next_cursor) break;
+      cursor = result.next_cursor;
+      page++;
+    }
+  } catch (err) {
+    console.error(`Error reading balance history: ${err instanceof Error ? err.message : String(err)}`);
+    process.exitCode = 1;
+  }
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main();
+}


### PR DESCRIPTION
Closes #205

## Summary

Balance history queries built on Soroban RPC's transfer-event log have no pagination today, which won't scale for wallets with long histories. This adds cursor-based pagination (`after` / `limit` in, `next_cursor` out) with a capped default and max page size.

## Why this is in `contrib/`, not `src/balances-rpc.ts`

The issue names `balances-rpc.ts`, but this repo's contribution rules (`CONTRIBUTING.md`, `contrib/README.md`, and the `close-prs-outside-contrib` bot) restrict non-collaborator PRs to files under `contrib/` — a PR touching `src/` gets auto-closed. `contrib/README.md` explicitly covers this case: build a self-contained reference implementation that doesn't require editing `src/` directly. So this is implemented as a standalone module layered on top of `vellar-sdk/rpc`'s existing public exports (`RpcBalanceReaderOptions`), rather than modifying `balances-rpc.ts` itself. No `src/` files were changed.

## What's implemented

New self-contained module: `contrib/examples/balance-history-pagination/`

- **`balance-history.ts`**
  - `queryBalanceHistory(source, tokenContractId, holder, query)` — fetches one page of SEP-41 `transfer` events into/out of `holder` for a token contract, via Soroban RPC's `getEvents`. Takes a narrow `BalanceHistorySource` (just `getEvents`) so it's unit-testable without a live RPC call.
  - `BalanceHistoryQuery`: `{ startLedger?, after?, limit? }` — `startLedger` for the first page (Soroban RPC's `getEvents` always needs either a starting ledger or a resume cursor, there's no "give me the latest" mode), `after` to resume from a previous page's cursor (takes priority over `startLedger` if both are given).
  - `BalanceHistoryPage`: `{ entries, next_cursor }` — `next_cursor` is the RPC's own cursor, echoed back once a page has at least one entry, and `null` once a page comes back empty (the stop signal for a paging loop).
  - `DEFAULT_BALANCE_HISTORY_LIMIT` (20) and `MAX_BALANCE_HISTORY_LIMIT` (100) — a requested `limit` above the max is silently capped, not rejected; a non-positive or non-integer `limit` throws `RangeError`.
  - `createBalanceHistoryReader(options)` — wraps a real `rpc.Server`, mirroring `createRpcBalanceReader`'s shape, for actual (non-test) use.
  - Holder history covers both transfer directions (as sender and as recipient) via two `getEvents` filters OR'd together, since a single filter's topic wildcards can't express "this position OR that position".
  - A runnable `main()` CLI demo (`npx tsx balance-history.ts <accountId> <tokenContractId> [startLedger]`) that pages through history end to end.

- **`balance-history.test.ts`** — 10 unit tests against an injected fake `BalanceHistorySource`:
  - First page (`startLedger` given): entries decoded correctly (from/to/amount/ledger/ledgerClosedAt/txHash), `next_cursor` returned from the RPC response, request built with `startLedger` + default limit, both direction filters present.
  - Middle page: resuming with `after`, request built with `cursor` instead of `startLedger`.
  - Empty result: `next_cursor` is `null` when no entries match.
  - Default limit applied when omitted; a requested limit above the cap is clamped to `MAX_BALANCE_HISTORY_LIMIT`.
  - A non-positive or non-integer `limit` throws `RangeError` without calling the source.
  - Neither `startLedger` nor `after` given throws `RangeError`.
  - `after` takes priority over `startLedger` when both are given.
  - A malformed transfer event (missing topics) throws a descriptive error instead of decoding garbage.
  - `createBalanceHistoryReader` returns an object exposing `getBalanceHistory`, without making a network call.

- **`README.md`** — explains the pagination contract, why the module lives in `contrib/`, usage, and what the tests cover.

## Implementation details

- Cursor pagination is a thin, bounded wrapper around Soroban RPC's own `getEvents` cursor (`Api.GetEventsRequest`/`GetEventsResponse`) — `getEvents` already resumes exactly where a previous call left off via its `cursor` field; this just enforces a page-size cap and gives it a `{ entries, next_cursor }` shape.
- `transfer` events are decoded per the SEP-41 token event shape: `topics = (Symbol("transfer"), from: Address, to: Address)`, `data = amount: i128`, using `nativeToScVal`/`Address`/`scValToBigInt` from `@stellar/stellar-sdk` (already a dependency, same helpers `src/balances-rpc.ts` uses).
- Scoped to `transfer` events specifically (the primary signal for balance history) rather than also covering `mint`/`burn`/`clawback`, to keep the implementation correct and testable rather than guessing at less-certain event shapes.

## How to test

```sh
npm install
npx vitest run contrib/examples/balance-history-pagination
npm test             # full suite — confirms nothing else broke
```

To typecheck the new files directly (the root `tsconfig.json`'s `include` is scoped to `src/`, matching every other `contrib/` example, so `npm run typecheck` alone won't cover these files):

```sh
npx tsc --noEmit --strict --target ES2022 --module ESNext --moduleResolution Bundler \
  --esModuleInterop --skipLibCheck --noUncheckedIndexedAccess --verbatimModuleSyntax \
  contrib/examples/balance-history-pagination/balance-history.ts \
  contrib/examples/balance-history-pagination/balance-history.test.ts
```

All 10 new tests pass; the full suite is unchanged (pre-existing failures in unrelated `contrib/` examples are environment-only — they need a browser WebAuthn API not available in this sandbox — and are present on `dev` before this change too).
