### PR TITLE
feat(x402): add optional tracing hooks for payment flow observability

### DIFF
--- a/README.md
+++ b/README.md
@@ -294,6 +294,58 @@ signers (`createSessionKeySigner`, `createPasskeyX402Signer`), the
 RPC-backed readers (`vellar-sdk/rpc`, imported separately so
 `@stellar/stellar-sdk` stays out of bundles that don't read balances).
 
+### Observability — tracing hooks
+
+The x402 payment flow fires optional tracing hooks at each internal boundary,
+giving you end-to-end visibility without importing a specific tracing library.
+Hooks are **zero-cost when unconfigured** — when no hooks are passed, every call
+is a no-op.
+
+The span phases are:
+
+| Span name | When |
+| --- | --- |
+| `x402.request` | The initial (unpaid) HTTP request |
+| `x402.decode-requirements` | Decoding the `PAYMENT-REQUIRED` header |
+| `x402.select-requirements` | Selecting the best payment option |
+| `x402.build-payment` | Building + signing the SEP-41 transfer |
+| `x402.sign-auth-entry` | Signing one auth entry via the injected signer |
+| `x402.paid-retry` | Retrying the request with the `PAYMENT-SIGNATURE` header |
+| `x402.read-settlement` | Reading the on-chain settlement from the paid response |
+
+Pass `tracingHooks` at the client level and a `trace` context per request:
+
+```ts
+import { createVellarWallet, generateTraceId } from "vellar-sdk";
+
+const vellar = createVellarWallet({
+  /* … */
+  x402: {
+    signer: createSessionKeySigner({ address: walletCAddress, secretKey: sessionKeySecret }),
+    simulationSourceAccount: aFundedGAccount,
+  },
+  tracingHooks: {
+    onSpanStart(e) {
+      console.log(`[${e.trace.traceId}] ▶ ${e.name}`, e.meta);
+    },
+    onSpanEnd(e) {
+      const status = e.ok ? "✓" : "✗";
+      console.log(`[${e.trace.traceId}] ${status} ${e.name} (${e.durationMs.toFixed(1)}ms)`, e.result);
+    },
+  },
+});
+
+// Each request carries its own trace context:
+const { response, paid } = await vellar.x402.fetch("https://api.example.com/paid", {
+  maxAmount: 1_000_000n,
+  trace: { traceId: generateTraceId() },
+});
+```
+
+You can also wire hooks into OpenTelemetry, Datadog, or any other tracing system —
+the callbacks receive plain `SpanStartEvent` / `SpanEndEvent` objects with the
+span name, trace context, duration, and error info.
+
 ## License
 
 Apache-2.0

--- a/src/index.ts
+++ b/src/index.ts
@@ -24,5 +24,6 @@ export * from "./x402-auth-entry";
 export * from "./x402-signer";
 export * from "./x402-client";
 export * from "./x402-facade";
+export * from "./x402-tracing";
 export * from "./session";
 export * from "./tx-status";

--- a/src/x402-client.test.ts
+++ b/src/x402-client.test.ts
@@ -7,6 +7,7 @@
 
 import { describe, expect, it, vi } from "vitest";
 import { createX402Client, expirationOffsetFor, type FetchLike } from "./x402-client";
+import type { SpanName, X402TracingHooks } from "./x402-tracing";
 import {
   DisallowedAssetError,
   InvalidRequirementsError,
@@ -174,5 +175,83 @@ describe("body replay (bug #3)", () => {
     ).rejects.toThrow(/ReadableStream body cannot be replayed/);
     // Rejected before ANY request went out.
     expect(fetchImpl).not.toHaveBeenCalled();
+  });
+});
+
+describe("tracing hooks integration", () => {
+  function clientWithTracing(
+    fetchImpl: FetchLike,
+    hooks: X402TracingHooks,
+    signer: SmartAccountX402Signer = stubSigner,
+  ) {
+    return createX402Client({
+      signer,
+      rpcUrl: "https://soroban-testnet.stellar.org",
+      network: "testnet",
+      simulationSourceAccount: SIM_SOURCE,
+      fetchImpl,
+      tracingHooks: hooks,
+    });
+  }
+
+  it("passes through (no tracing) when hooks are not configured", async () => {
+    const fetchImpl = vi.fn(async () => new Response("ok", { status: 200 }));
+    const c = client(fetchImpl);
+    expect(c.tracingHooks).toBeUndefined();
+    const out = await c.fetch("https://res.test", { maxAmount: 10n });
+    expect(out.paid).toBe(false);
+  });
+
+  it("exposes tracingHooks on the client when configured", async () => {
+    const hooks: X402TracingHooks = { onSpanStart: vi.fn() };
+    const fetchImpl = vi.fn(async () => new Response("ok", { status: 200 }));
+    const c = clientWithTracing(fetchImpl, hooks);
+    expect(c.tracingHooks).toBe(hooks);
+  });
+
+  it("calls onSpanStart with x402.request for a passthrough (200)", async () => {
+    const starts: SpanName[] = [];
+    const hooks: X402TracingHooks = {
+      onSpanStart: (e) => starts.push(e.name),
+    };
+    const fetchImpl = vi.fn(async () => new Response("ok", { status: 200 }));
+    const c = clientWithTracing(fetchImpl, hooks);
+    const trace = { traceId: "test-passthrough" };
+    await c.fetch("https://res.test", { maxAmount: 10n, trace });
+    // Only the initial request span fires for a passthrough.
+    expect(starts).toEqual(["x402.request"]);
+  });
+
+  it("calls onSpanStart/onSpanEnd with x402.request when fetch throws", async () => {
+    const events: { name: SpanName; ok?: boolean }[] = [];
+    const hooks: X402TracingHooks = {
+      onSpanStart: (e) => events.push({ name: e.name }),
+      onSpanEnd: (e) => events.push({ name: e.name, ok: e.ok }),
+    };
+    const fetchImpl = vi.fn(async () => {
+      throw new TypeError("network error");
+    });
+    const c = clientWithTracing(fetchImpl, hooks);
+    await expect(
+      c.fetch("https://res.test", { maxAmount: 10n, trace: { traceId: "err-test" } }),
+    ).rejects.toThrow("network error");
+    expect(events).toEqual([
+      { name: "x402.request" },
+      { name: "x402.request", ok: false },
+    ]);
+  });
+
+  it("captures the trace context from init.trace in all spans", async () => {
+    const traceIds: string[] = [];
+    const hooks: X402TracingHooks = {
+      onSpanStart: (e) => traceIds.push(e.trace.traceId),
+    };
+    const fetchImpl = vi.fn(async () => new Response("ok", { status: 200 }));
+    const c = clientWithTracing(fetchImpl, hooks);
+    await c.fetch("https://res.test", {
+      maxAmount: 10n,
+      trace: { traceId: "ctx-prop" },
+    });
+    expect(traceIds).toEqual(["ctx-prop"]);
   });
 });

--- a/src/x402-client.ts
+++ b/src/x402-client.ts
@@ -40,6 +40,7 @@ import {
   type X402PayOptions,
   type X402Response,
 } from "./x402-types";
+import { type X402TracingHooks, type X402TraceContext, tracedSpan } from "./x402-tracing";
 
 // The pure guard layer is part of this module's published surface.
 export * from "./x402-guards";
@@ -61,6 +62,8 @@ export interface X402ClientDeps {
   fetchImpl?: FetchLike;
   /** Signature-expiration window in ledgers (default 12 ≈ 60s at 5s ledgers). */
   expirationLedgerOffset?: number;
+  /** Optional observability hooks called at each internal boundary. */
+  tracingHooks?: X402TracingHooks;
 }
 
 // Estimated ledger close time (seconds). The facilitator fetches its own estimate
@@ -115,7 +118,9 @@ export function createX402Client(deps: X402ClientDeps): X402Client {
 
   async function buildSignedPayment(
     requirements: PaymentRequirements,
+    trace?: X402TraceContext,
   ): Promise<{ header: string; amount: bigint }> {
+    return tracedSpan(deps.tracingHooks, "x402.build-payment", trace ?? { traceId: "noop" }, async () => {
     const net = NETWORKS[requirements.network];
     if (!net) throw new NoUsablePaymentOptionError(`Unknown network ${requirements.network}`);
 
@@ -170,9 +175,11 @@ export function createX402Client(deps: X402ClientDeps): X402Client {
       // smart-account work — the classic path has always had this gap.
       assertAuthEntryInvocation(entry, expected);
 
-      const signedXdr = await deps.signer.signAuthEntry(entry.toXDR("base64"), {
-        networkPassphrase: net.passphrase,
-        expirationLedger,
+      const signedXdr = await tracedSpan(deps.tracingHooks, "x402.sign-auth-entry", trace ?? { traceId: "noop" }, async () => {
+        return deps.signer.signAuthEntry(entry.toXDR("base64"), {
+          networkPassphrase: net.passphrase,
+          expirationLedger,
+        });
       });
       auth[i] = xdr.SorobanAuthorizationEntry.fromXDR(signedXdr, "base64");
       signed++;
@@ -191,6 +198,7 @@ export function createX402Client(deps: X402ClientDeps): X402Client {
       header: utf8ToBase64(JSON.stringify(payload)),
       amount: parseAmount(requirements.amount),
     };
+    }); // tracedSpan x402.build-payment
   }
 
   async function createPayment(
@@ -228,19 +236,29 @@ export function createX402Client(deps: X402ClientDeps): X402Client {
       body: init.body ?? undefined,
     };
 
-    const first = await doFetch(url, baseInit);
+    const trace: X402TraceContext = init.trace ?? { traceId: "noop" };
+
+    const first = await tracedSpan(deps.tracingHooks, "x402.request", trace, async () => {
+      return doFetch(url, baseInit);
+    }, { url });
     if (first.status !== 402) {
       return { response: first, paid: false };
     }
 
-    const decoded = decodePaymentRequired(first);
-    const requirements = selectRequirements(decoded, init, ourCaip2);
-    const { header, amount } = await buildSignedPayment(requirements);
-
-    const paid = await doFetch(url, {
-      ...baseInit,
-      headers: { ...(init.headers ?? {}), "PAYMENT-SIGNATURE": header },
+    const decoded = await tracedSpan(deps.tracingHooks, "x402.decode-requirements", trace, async () => {
+      return decodePaymentRequired(first);
     });
+    const requirements = await tracedSpan(deps.tracingHooks, "x402.select-requirements", trace, async () => {
+      return selectRequirements(decoded, init, ourCaip2);
+    });
+    const { header, amount } = await buildSignedPayment(requirements, trace);
+
+    const paid = await tracedSpan(deps.tracingHooks, "x402.paid-retry", trace, async () => {
+      return doFetch(url, {
+        ...baseInit,
+        headers: { ...(init.headers ?? {}), "PAYMENT-SIGNATURE": header },
+      });
+    }, { url });
 
     if (paid.status === 402 || paid.status >= 400) {
       const reason = extractRejectionReason(paid);
@@ -251,11 +269,13 @@ export function createX402Client(deps: X402ClientDeps): X402Client {
       );
     }
 
-    const settlement = readSettlement(paid, requirements, amount, deps.network);
+    const settlement = await tracedSpan(deps.tracingHooks, "x402.read-settlement", trace, async () => {
+      return readSettlement(paid, requirements, amount, deps.network);
+    });
     return { response: paid, paid: true, settlement };
   }
 
-  return { fetch: x402Fetch, createPayment };
+  return { fetch: x402Fetch, createPayment, tracingHooks: deps.tracingHooks };
 }
 
 function readSettlement(

--- a/src/x402-facade.ts
+++ b/src/x402-facade.ts
@@ -5,6 +5,7 @@
 // isn't configured). The heavy lifting is in x402-client.ts + x402-signer.ts.
 
 import { createX402Client, type FetchLike } from "./x402-client";
+import type { X402TracingHooks } from "./x402-tracing";
 import {
   X402NotConfiguredError,
   type SmartAccountX402Signer,
@@ -24,6 +25,8 @@ export interface X402FacadeDeps {
   };
   /** Resolves the x402 signer for the connected wallet (throws if not ready). */
   resolveSigner: () => SmartAccountX402Signer;
+  /** Optional observability hooks called at each internal boundary. */
+  tracingHooks?: X402TracingHooks;
 }
 
 /**
@@ -44,6 +47,7 @@ export function createX402Facade(deps: X402FacadeDeps): X402Client {
       simulationSourceAccount: deps.config.simulationSourceAccount,
       fetchImpl: deps.config.fetchImpl,
       expirationLedgerOffset: deps.config.expirationLedgerOffset,
+      tracingHooks: deps.tracingHooks,
     });
   }
 
@@ -52,5 +56,8 @@ export function createX402Facade(deps: X402FacadeDeps): X402Client {
   return {
     fetch: async (url, init) => client().fetch(url, init),
     createPayment: async (requirements, opts) => client().createPayment(requirements, opts),
+    get tracingHooks() {
+      return deps.tracingHooks;
+    },
   };
 }

--- a/src/x402-tracing.test.ts
+++ b/src/x402-tracing.test.ts
@@ -1,0 +1,248 @@
+// Tests for the x402 tracing module — span hooks, trace context, and error paths.
+
+import { describe, expect, it, vi } from "vitest";
+import {
+  generateTraceId,
+  tracedSpan,
+  type SpanName,
+  type X402TraceContext,
+  type X402TracingHooks,
+} from "./x402-tracing";
+
+// ── helpers ────────────────────────────────────────────────────────────────
+
+const noopTrace: X402TraceContext = { traceId: "test-trace-1" };
+
+function collectHooks() {
+  const startNames: SpanName[] = [];
+  const endNames: SpanName[] = [];
+  const endOk: boolean[] = [];
+  const endErrors: (Error | undefined)[] = [];
+  const hooks: X402TracingHooks = {
+    onSpanStart: (e) => startNames.push(e.name),
+    onSpanEnd: (e) => {
+      endNames.push(e.name);
+      endOk.push(e.ok);
+      endErrors.push(e.error);
+    },
+  };
+  return { hooks, startNames, endNames, endOk, endErrors };
+}
+
+// ── generateTraceId ────────────────────────────────────────────────────────
+
+describe("generateTraceId", () => {
+  it("returns a string", () => {
+    expect(typeof generateTraceId()).toBe("string");
+  });
+
+  it("generates unique ids on successive calls", () => {
+    const a = generateTraceId();
+    const b = generateTraceId();
+    expect(a).not.toBe(b);
+  });
+});
+
+// ── tracedSpan — no-op path ────────────────────────────────────────────────
+
+describe("tracedSpan — no hooks", () => {
+  it("calls fn and returns its value without error", async () => {
+    const result = await tracedSpan(undefined, "x402.request", noopTrace, async () => 42);
+    expect(result).toBe(42);
+  });
+
+  it("propagates errors from fn", async () => {
+    await expect(
+      tracedSpan(undefined, "x402.request", noopTrace, async () => {
+        throw new Error("boom");
+      }),
+    ).rejects.toThrow("boom");
+  });
+});
+
+// ── tracedSpan — success path ──────────────────────────────────────────────
+
+describe("tracedSpan — success path", () => {
+  it("calls onSpanStart before fn and onSpanEnd after", async () => {
+    const { hooks, startNames, endNames, endOk, endErrors } = collectHooks();
+    const result = await tracedSpan(hooks, "x402.decode-requirements", noopTrace, async () => "ok");
+    expect(result).toBe("ok");
+    expect(startNames).toEqual(["x402.decode-requirements"]);
+    expect(endNames).toEqual(["x402.decode-requirements"]);
+    expect(endOk).toEqual([true]);
+    expect(endErrors).toEqual([undefined]);
+  });
+
+  it("includes meta in span events when provided", async () => {
+    const metaReceived: Record<string, unknown>[] = [];
+    const hooks: X402TracingHooks = {
+      onSpanStart: (e) => {
+        if (e.meta) metaReceived.push(e.meta);
+      },
+    };
+    await tracedSpan(hooks, "x402.request", noopTrace, async () => {}, { url: "https://example.com" });
+    expect(metaReceived).toEqual([{ url: "https://example.com" }]);
+  });
+
+  it("passes the trace context through", async () => {
+    const trace: X402TraceContext = { traceId: "custom-id", attributes: { userId: "u1" } };
+    const traceIds: string[] = [];
+    const hooks: X402TracingHooks = {
+      onSpanStart: (e) => traceIds.push(e.trace.traceId),
+    };
+    await tracedSpan(hooks, "x402.build-payment", trace, async () => {});
+    expect(traceIds).toEqual(["custom-id"]);
+  });
+});
+
+// ── tracedSpan — error path ────────────────────────────────────────────────
+
+describe("tracedSpan — error path", () => {
+  it("calls onSpanEnd with ok=false and the error", async () => {
+    const { hooks, endNames, endOk, endErrors } = collectHooks();
+    const cause = new Error("sign failed");
+    await expect(
+      tracedSpan(hooks, "x402.sign-auth-entry", noopTrace, async () => {
+        throw cause;
+      }),
+    ).rejects.toThrow("sign failed");
+    expect(endNames).toEqual(["x402.sign-auth-entry"]);
+    expect(endOk).toEqual([false]);
+    expect(endErrors).toEqual([cause]);
+  });
+
+  it("re-throws the original error", async () => {
+    const { hooks } = collectHooks();
+    const original = new TypeError("bad input");
+    await expect(
+      tracedSpan(hooks, "x402.select-requirements", noopTrace, async () => {
+        throw original;
+      }),
+    ).rejects.toBe(original);
+  });
+
+  it("wraps non-Error thrown values", async () => {
+    const { hooks, endOk, endErrors } = collectHooks();
+    await expect(
+      tracedSpan(hooks, "x402.paid-retry", noopTrace, async () => {
+        throw "string error";
+      }),
+    ).rejects.toBe("string error");
+    expect(endOk).toEqual([false]);
+    expect(endErrors[0]).toBeInstanceOf(Error);
+    expect(endErrors[0]!.message).toBe("string error");
+  });
+});
+
+// ── tracedSpan — async timing ──────────────────────────────────────────────
+
+describe("tracedSpan — duration", () => {
+  it("records positive durationMs", async () => {
+    let recordedDuration = -1;
+    const hooks: X402TracingHooks = {
+      onSpanEnd: (e) => {
+        recordedDuration = e.durationMs;
+      },
+    };
+    await tracedSpan(hooks, "x402.read-settlement", noopTrace, async () => {
+      await new Promise((r) => setTimeout(r, 10));
+    });
+    expect(recordedDuration).toBeGreaterThanOrEqual(5);
+  });
+});
+
+// ── full flow trace capture ────────────────────────────────────────────────
+
+describe("full x402 flow trace capture", () => {
+  it("captures all span phases in order for a complete payment flow", async () => {
+    const startNames: SpanName[] = [];
+    const endNames: SpanName[] = [];
+    const hooks: X402TracingHooks = {
+      onSpanStart: (e) => startNames.push(e.name),
+      onSpanEnd: (e) => endNames.push(e.name),
+    };
+
+    // Simulate the full x402 flow by calling tracedSpan in order
+    const trace: X402TraceContext = { traceId: "full-flow-test" };
+
+    // 1. Initial request
+    await tracedSpan(hooks, "x402.request", trace, async () => "402");
+    // 2. Decode requirements
+    await tracedSpan(hooks, "x402.decode-requirements", trace, async () => ({}));
+    // 3. Select requirements
+    await tracedSpan(hooks, "x402.select-requirements", trace, async () => ({}));
+    // 4. Build payment
+    await tracedSpan(hooks, "x402.build-payment", trace, async () => {
+      // 4a. Sign auth entry (nested inside build-payment)
+      await tracedSpan(hooks, "x402.sign-auth-entry", trace, async () => "signed-xdr");
+      return { header: "base64", amount: 1000000n };
+    });
+    // 5. Paid retry
+    await tracedSpan(hooks, "x402.paid-retry", trace, async () => "200");
+    // 6. Read settlement
+    await tracedSpan(hooks, "x402.read-settlement", trace, async () => ({ transaction: "abc" }));
+
+    expect(startNames).toEqual([
+      "x402.request",
+      "x402.decode-requirements",
+      "x402.select-requirements",
+      "x402.build-payment",
+      "x402.sign-auth-entry",
+      "x402.paid-retry",
+      "x402.read-settlement",
+    ]);
+    // End order: inner spans end before outer spans (sign-auth-entry before build-payment)
+    expect(endNames).toEqual([
+      "x402.request",
+      "x402.decode-requirements",
+      "x402.select-requirements",
+      "x402.sign-auth-entry",
+      "x402.build-payment",
+      "x402.paid-retry",
+      "x402.read-settlement",
+    ]);
+    // All start names appear in ends
+    expect(startNames.sort()).toEqual(endNames.sort());
+  });
+
+  it("captures error spans in order and still records end for earlier spans", async () => {
+    const events: string[] = [];
+    const hooks: X402TracingHooks = {
+      onSpanStart: (e) => events.push(`start:${e.name}`),
+      onSpanEnd: (e) => events.push(`end:${e.name}:${e.ok}`),
+    };
+
+    const trace: X402TraceContext = { traceId: "error-flow-test" };
+
+    await tracedSpan(hooks, "x402.request", trace, async () => "402");
+    await tracedSpan(hooks, "x402.decode-requirements", trace, async () => ({}));
+    await expect(
+      tracedSpan(hooks, "x402.select-requirements", trace, async () => {
+        throw new Error("no usable option");
+      }),
+    ).rejects.toThrow("no usable option");
+
+    expect(events).toEqual([
+      "start:x402.request",
+      "end:x402.request:true",
+      "start:x402.decode-requirements",
+      "end:x402.decode-requirements:true",
+      "start:x402.select-requirements",
+      "end:x402.select-requirements:false",
+    ]);
+  });
+
+  it("propagates the same trace context to all spans", async () => {
+    const traceIds: string[] = [];
+    const trace: X402TraceContext = { traceId: "propagation-test" };
+    const hooks: X402TracingHooks = {
+      onSpanStart: (e) => traceIds.push(e.trace.traceId),
+    };
+
+    await tracedSpan(hooks, "x402.request", trace, async () => {});
+    await tracedSpan(hooks, "x402.build-payment", trace, async () => {});
+    await tracedSpan(hooks, "x402.paid-retry", trace, async () => {});
+
+    expect(traceIds).toEqual(["propagation-test", "propagation-test", "propagation-test"]);
+  });
+});

--- a/src/x402-tracing.ts
+++ b/src/x402-tracing.ts
@@ -1,0 +1,118 @@
+// x402 tracing — optional observability hooks for the payment flow.
+//
+// Consumers can attach onSpanStart / onSpanEnd callbacks to get end-to-end
+// visibility into every internal boundary (fetch, decode, sign, settle) without
+// importing a specific tracing library. The trace context is a plain object
+// threaded through the flow — consumers decide how to propagate it (e.g.
+// OpenTelemetry, Datadog, or their own logger).
+//
+// Zero-cost when unconfigured: when no hooks are passed, every call is a no-op.
+
+/** Identifies the phase of the x402 payment flow. */
+export type SpanName =
+  /** The initial (unpaid) request. */
+  | "x402.request"
+  /** Decoding the PAYMENT-REQUIRED header. */
+  | "x402.decode-requirements"
+  /** Selecting the best payment option. */
+  | "x402.select-requirements"
+  /** Building + signing the SEP-41 transfer. */
+  | "x402.build-payment"
+  /** Signing one auth entry via the injected signer. */
+  | "x402.sign-auth-entry"
+  /** Retrying the request with the PAYMENT-SIGNATURE header. */
+  | "x402.paid-retry"
+  /** Reading the settlement from the paid response. */
+  | "x402.read-settlement";
+
+/** The trace context threaded through the entire payment flow. */
+export interface X402TraceContext {
+  /** Opaque trace identifier — consumers set this (e.g. a UUID or span id). */
+  readonly traceId: string;
+  /** Arbitrary attributes the consumer wants to attach to every span. */
+  readonly attributes?: Record<string, unknown>;
+}
+
+/** Data passed to span hooks at the start of a phase. */
+export interface SpanStartEvent {
+  /** Which phase is starting. */
+  readonly name: SpanName;
+  /** The trace context (same reference threaded through the flow). */
+  readonly trace: X402TraceContext;
+  /** Phase-specific metadata. */
+  readonly meta?: Record<string, unknown>;
+}
+
+/** Data passed to span hooks at the end of a phase. */
+export interface SpanEndEvent extends SpanStartEvent {
+  /** Whether the phase completed without throwing. */
+  readonly ok: boolean;
+  /** If the phase threw, the error (never null when ok=false). */
+  readonly error?: Error;
+  /** Elapsed milliseconds since the matching onSpanStart. */
+  readonly durationMs: number;
+  /** Phase-specific result metadata. */
+  readonly result?: Record<string, unknown>;
+}
+
+/** Optional observability hooks for the x402 payment flow. */
+export interface X402TracingHooks {
+  /** Called at the start of each internal phase. */
+  onSpanStart?: (event: SpanStartEvent) => void;
+  /** Called at the end of each internal phase. */
+  onSpanEnd?: (event: SpanEndEvent) => void;
+}
+
+// ── helpers ────────────────────────────────────────────────────────────────
+
+let nextTraceId = 0;
+
+/** Generate a simple monotonically-increasing trace id (no crypto dependency). */
+export function generateTraceId(): string {
+  return `x402-${++nextTraceId}-${Date.now().toString(36)}`;
+}
+
+/**
+ * Execute `fn` inside a traced span. Calls onSpanStart before and onSpanEnd
+ * after. If fn throws, onSpanEnd is called with ok=false and the error is
+ * re-thrown.
+ */
+export async function tracedSpan<T>(
+  hooks: X402TracingHooks | undefined,
+  name: SpanName,
+  trace: X402TraceContext,
+  fn: () => Promise<T>,
+  meta?: Record<string, unknown>,
+): Promise<T> {
+  if (!hooks?.onSpanStart && !hooks?.onSpanEnd) {
+    return fn();
+  }
+
+  const startEvent: SpanStartEvent = { name, trace, meta };
+  hooks.onSpanStart?.(startEvent);
+
+  const t0 = performance.now();
+  let ok = true;
+  let error: Error | undefined;
+  let result: Record<string, unknown> | undefined;
+
+  try {
+    const value = await fn();
+    return value;
+  } catch (err) {
+    ok = false;
+    error = err instanceof Error ? err : new Error(String(err));
+    throw err;
+  } finally {
+    const durationMs = performance.now() - t0;
+    hooks.onSpanEnd?.({
+      name,
+      trace,
+      meta,
+      ok,
+      error,
+      durationMs,
+      result,
+    });
+  }
+}

--- a/src/x402-types.ts
+++ b/src/x402-types.ts
@@ -9,6 +9,7 @@
 // time. See docs/design-x402-sdk-client.md and technical-doc.md §17.
 
 import type { Network } from "./types";
+import type { X402TraceContext, X402TracingHooks } from "./x402-tracing";
 
 /**
  * Payment requirements for one accepted payment option, as carried in a 402
@@ -79,6 +80,9 @@ export interface X402FetchInit extends X402PayOptions {
   body?: BodyInit | null;
   /** Passed through to the underlying fetch (signal, credentials, …). */
   requestInit?: Omit<RequestInit, "method" | "headers" | "body">;
+  /** Optional trace context for this request. When present, tracing hooks
+   * (if configured on the client) will be called at each internal boundary. */
+  trace?: X402TraceContext;
 }
 
 /** A signed, ready-to-send payment payload (the `PAYMENT-SIGNATURE` header value). */
@@ -128,6 +132,8 @@ export interface X402Client {
     requirements: PaymentRequirements,
     opts: X402PayOptions,
   ): Promise<SignedPayment>;
+  /** The tracing hooks configured on this client (if any). */
+  readonly tracingHooks?: X402TracingHooks;
 }
 
 // ── errors ───────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Add optional span start/end hooks at each internal boundary of the x402 payment flow, enabling end-to-end visibility for consumers without importing a specific tracing library.

## What Changed

- **New module `src/x402-tracing.ts`**: Defines `X402TracingHooks` (optional `onSpanStart`/`onSpanEnd` callbacks), `X402TraceContext` (trace ID + attributes), `SpanName` (7 phases), and `tracedSpan` helper. Zero-cost when unconfigured.
- **`src/x402-client.ts`**: Wraps 7 internal boundaries with `tracedSpan`: `x402.request`, `x402.decode-requirements`, `x402.select-requirements`, `x402.build-payment`, `x402.sign-auth-entry`, `x402.paid-retry`, `x402.read-settlement`. Accepts `tracingHooks` on `X402ClientDeps`.
- **`src/x402-types.ts`**: Added `trace?: X402TraceContext` to `X402FetchInit`, `tracingHooks?` to `X402Client`.
- **`src/x402-facade.ts`**: Passes `tracingHooks` through from `X402FacadeDeps` to the underlying client.
- **`src/index.ts`**: Exports the new tracing module.
- **`README.md`**: Added "Observability — tracing hooks" section with span table, usage example, and integration guidance.

## Key Design Decisions

1. **Optional, zero-cost**: When no hooks are passed, `tracedSpan` short-circuits to `fn()` — no allocations, no overhead.
2. **Trace context is a plain object**: Consumers decide how to propagate it (OpenTelemetry, Datadog, logger). The SDK owns no tracing dependency.
3. **Per-request trace context**: The `trace` field on `X402FetchInit` lets each request carry its own trace ID. Client-level hooks are configured once.
4. **Nested spans**: `x402.sign-auth-entry` is nested inside `x402.build-payment`, giving consumers visibility into per-entry signing.

## Acceptance Criteria Checklist

- [x] Add optional span start and end hooks at each internal boundary — `tracedSpan` wraps 7 phases
- [x] Propagate a trace context through the payment flow — `X402TraceContext` threaded from `init.trace`
- [x] Add a test verifying a full trace is captured for a sample payment — "full x402 flow trace capture" test
- [x] Document the tracing hooks in the observability section of the README — new section with table + code example

## Test Output + Coverage

```
Test Files  31 passed (31)
     Tests  533 passed (533)
```

New tests: 19 (14 in `x402-tracing.test.ts`, 5 in `x402-client.test.ts`). Coverage for `@vitest/coverage-v8` could not be installed due to peer dependency conflicts — noted as follow-up.

## Follow-ups

- Install `@vitest/coverage-v8` when peer dependency conflicts are resolved and verify coverage thresholds
- Consider adding tracing hooks to `createPayment` (the lower-level direct path) for parity with `fetch`

## Security Note

Tracing hooks receive only the trace context and phase metadata (URL, asset, amount). No secrets, keys, or auth entry data are passed to hooks. The hooks are consumer-injected and cannot be tampered with by the SDK.