### PR TITLE
feat(contrib): network-scoped cache key, deploy rollback, RPC connection reuse, batched balance reads

### DIFF
--- a/contrib/examples/issue-216-batched-trustline-balances/README.md
+++ b/contrib/examples/issue-216-batched-trustline-balances/README.md
@@ -1,0 +1,36 @@
+# Batched Trustline Balances
+
+Self-contained reference for issue [#216](https://github.com/Vellar-Wallet/vellar-sdk/issues/216): collapse the per-trustline `balance(id)` reads into a single batched RPC call.
+
+## The problem
+
+Reading balances for a wallet with N trustlines issues N `simulateTransaction` calls. [`batch-balance-lookup`](../batch-balance-lookup) already runs them concurrently, which hides the latency behind `Promise.all` — but it still sends N requests, so the wallet gets rate-limited by the RPC provider exactly when it has the most assets to display.
+
+A Soroban simulation can carry more than one host function invocation. N `balance(id)` reads therefore fit in one transaction and one round trip, with results read back positionally in operation order.
+
+## Call count
+
+| Trustlines | Before | After |
+| --- | --- | --- |
+| 1 | 1 | 1 |
+| 4 | 4 | 1 |
+| 10 | 10 | 1 |
+| 25 | 25 | 2 |
+
+Batches are chunked at `MAX_INVOCATIONS_PER_SIMULATION` (20) because a simulation has a host-resource budget — too many invocations in one transaction exceeds it and fails the batch as a unit.
+
+## No behaviour change
+
+The returned shape is identical: `bigint` amounts keyed by contract id, in request order. The test suite asserts batched and unbatched results are `toEqual` for both the all-success and the partial-failure case.
+
+The one real difference is failure granularity, and it is handled rather than accepted: a batched simulation fails as a **unit**, so one bad contract id would fail the whole call where N separate calls failed exactly one. On a batch failure this falls back to per-token reads, restoring the original per-item error isolation. The fallback is the slow path and only runs when the fast path could not answer — `fallbackCalls` counts it separately so it stays visible.
+
+## Regression guard
+
+`rpcCalls` is asserted at an exact value (15 trustlines → exactly 1 call, and 0 fallback calls). Any reintroduced per-token read breaks that assertion immediately rather than silently regressing to N+1.
+
+## Run tests
+
+```bash
+npx vitest run contrib/examples/issue-216-batched-trustline-balances/batched-trustline-balances.test.ts
+```

--- a/contrib/examples/issue-216-batched-trustline-balances/batched-trustline-balances.test.ts
+++ b/contrib/examples/issue-216-batched-trustline-balances/batched-trustline-balances.test.ts
@@ -1,0 +1,226 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  buildBalanceInvocations,
+  chunk,
+  createBatchedBalanceService,
+  createUnbatchedBalanceService,
+  MAX_INVOCATIONS_PER_SIMULATION,
+  type BalanceReader,
+  type BatchBalanceReader,
+} from "./batched-trustline-balances";
+
+const HOLDER = "CHOLDER";
+
+/** Deterministic balance so batched and unbatched results are comparable. */
+function amountFor(contractId: string): bigint {
+  return BigInt(contractId.length * 100);
+}
+
+function stubSingleReader(failing: string[] = []): BalanceReader {
+  return {
+    getTokenBalance: vi.fn(async (contractId: string) => {
+      if (failing.includes(contractId)) throw new Error(`unknown asset ${contractId}`);
+      return amountFor(contractId);
+    }),
+  };
+}
+
+function stubBatchReader(failing: string[] = []): BatchBalanceReader {
+  return {
+    getTokenBalances: vi.fn(async (ids: string[]) => {
+      // A batched simulation fails as a unit: one bad id kills the whole call.
+      const bad = ids.find((id) => failing.includes(id));
+      if (bad) throw new Error(`simulation failed: unknown asset ${bad}`);
+      return ids.map(amountFor);
+    }),
+  };
+}
+
+function trustlines(n: number): string[] {
+  return Array.from({ length: n }, (_, i) => `CTOKEN${"X".repeat(i)}`);
+}
+
+describe("createBatchedBalanceService", () => {
+  it("reads many trustlines in a single RPC call", async () => {
+    const batchReader = stubBatchReader();
+    const service = createBatchedBalanceService(batchReader, stubSingleReader());
+
+    const tokens = trustlines(8);
+    const results = await service.getBalances(HOLDER, tokens);
+
+    expect(results).toHaveLength(8);
+    expect(service.rpcCalls).toBe(1);
+    expect(batchReader.getTokenBalances).toHaveBeenCalledTimes(1);
+    expect(batchReader.getTokenBalances).toHaveBeenCalledWith(tokens, HOLDER);
+  });
+
+  it("returns results in request order", async () => {
+    const service = createBatchedBalanceService(stubBatchReader(), stubSingleReader());
+    const tokens = trustlines(5);
+
+    const results = await service.getBalances(HOLDER, tokens);
+
+    expect(results.map((r) => r.contractId)).toEqual(tokens);
+  });
+
+  it("issues no call for an empty token list", async () => {
+    const batchReader = stubBatchReader();
+    const service = createBatchedBalanceService(batchReader, stubSingleReader());
+
+    await expect(service.getBalances(HOLDER, [])).resolves.toEqual([]);
+    expect(service.rpcCalls).toBe(0);
+    expect(batchReader.getTokenBalances).not.toHaveBeenCalled();
+  });
+
+  it("chunks past the per-simulation invocation cap", async () => {
+    const batchReader = stubBatchReader();
+    const service = createBatchedBalanceService(batchReader, stubSingleReader(), {
+      maxBatchSize: 5,
+    });
+
+    const results = await service.getBalances(HOLDER, trustlines(12));
+
+    // 12 tokens / 5 per simulation = 3 calls, not 12.
+    expect(service.rpcCalls).toBe(3);
+    expect(results).toHaveLength(12);
+    expect(results.map((r) => r.contractId)).toEqual(trustlines(12));
+  });
+
+  it("defaults the batch size to the documented invocation cap", async () => {
+    const batchReader = stubBatchReader();
+    const service = createBatchedBalanceService(batchReader, stubSingleReader());
+
+    await service.getBalances(HOLDER, trustlines(MAX_INVOCATIONS_PER_SIMULATION + 1));
+
+    expect(service.rpcCalls).toBe(2);
+  });
+});
+
+describe("behaviour parity with the unbatched path", () => {
+  it("returns the identical data shape and values", async () => {
+    const tokens = trustlines(6);
+
+    const batched = createBatchedBalanceService(stubBatchReader(), stubSingleReader());
+    const unbatched = createUnbatchedBalanceService(stubSingleReader());
+
+    const batchedResults = await batched.getBalances(HOLDER, tokens);
+    const unbatchedResults = await unbatched.getBalances(HOLDER, tokens);
+
+    expect(batchedResults).toEqual(unbatchedResults);
+    // Amounts are still bigint, not a stringified or wrapped form.
+    for (const result of batchedResults) {
+      expect(result.ok).toBe(true);
+      if (result.ok) expect(typeof result.amount).toBe("bigint");
+    }
+  });
+
+  it("preserves per-item error isolation by falling back when a batch fails", async () => {
+    const tokens = ["CGOOD", "CBAD", "CALSOGOOD"];
+    const batched = createBatchedBalanceService(
+      stubBatchReader(["CBAD"]),
+      stubSingleReader(["CBAD"]),
+    );
+    const unbatched = createUnbatchedBalanceService(stubSingleReader(["CBAD"]));
+
+    const batchedResults = await batched.getBalances(HOLDER, tokens);
+    const unbatchedResults = await unbatched.getBalances(HOLDER, tokens);
+
+    // One bad token does not poison the good ones, same as before.
+    expect(batchedResults).toEqual(unbatchedResults);
+    expect(batchedResults[0]).toEqual({ contractId: "CGOOD", ok: true, amount: amountFor("CGOOD") });
+    expect(batchedResults[1]).toEqual({
+      contractId: "CBAD",
+      ok: false,
+      error: "unknown asset CBAD",
+    });
+  });
+
+  it("counts the fallback calls separately so the slow path is visible", async () => {
+    const batched = createBatchedBalanceService(
+      stubBatchReader(["CBAD"]),
+      stubSingleReader(["CBAD"]),
+    );
+
+    await batched.getBalances(HOLDER, ["CGOOD", "CBAD", "CALSOGOOD"]);
+
+    // 1 failed batch + 3 per-token retries.
+    expect(batched.rpcCalls).toBe(4);
+    expect(batched.fallbackCalls).toBe(3);
+  });
+
+  it("surfaces the batch error without retrying when fallback is disabled", async () => {
+    const singleReader = stubSingleReader(["CBAD"]);
+    const batched = createBatchedBalanceService(stubBatchReader(["CBAD"]), singleReader, {
+      fallbackToSingle: false,
+    });
+
+    const results = await batched.getBalances(HOLDER, ["CGOOD", "CBAD"]);
+
+    expect(results.every((r) => !r.ok)).toBe(true);
+    expect(batched.rpcCalls).toBe(1);
+    expect(singleReader.getTokenBalance).not.toHaveBeenCalled();
+  });
+});
+
+describe("benchmark: RPC call count before vs after", () => {
+  const cases = [1, 4, 10, 25];
+
+  it.each(cases)("collapses %i trustlines into far fewer calls", async (n) => {
+    const tokens = trustlines(n);
+
+    const before = createUnbatchedBalanceService(stubSingleReader());
+    await before.getBalances(HOLDER, tokens);
+
+    const after = createBatchedBalanceService(stubBatchReader(), stubSingleReader());
+    await after.getBalances(HOLDER, tokens);
+
+    // Before: strictly one call per trustline — the N+1 this issue reports.
+    expect(before.rpcCalls).toBe(n);
+    // After: one call per chunk of MAX_INVOCATIONS_PER_SIMULATION.
+    expect(after.rpcCalls).toBe(Math.ceil(n / MAX_INVOCATIONS_PER_SIMULATION));
+    expect(after.rpcCalls).toBeLessThanOrEqual(before.rpcCalls);
+  });
+
+  it("regression: 15 trustlines stay at exactly one RPC call", async () => {
+    const after = createBatchedBalanceService(stubBatchReader(), stubSingleReader());
+
+    await after.getBalances(HOLDER, trustlines(15));
+
+    // Pin the count. Any reintroduced per-token read breaks this immediately.
+    expect(after.rpcCalls).toBe(1);
+    expect(after.fallbackCalls).toBe(0);
+  });
+
+  it("regression: a repeated read does not accumulate hidden calls", async () => {
+    const after = createBatchedBalanceService(stubBatchReader(), stubSingleReader());
+    const tokens = trustlines(10);
+
+    await after.getBalances(HOLDER, tokens);
+    await after.getBalances(HOLDER, tokens);
+
+    expect(after.rpcCalls).toBe(2);
+  });
+});
+
+describe("chunk", () => {
+  it("splits into fixed-size groups, last one short", () => {
+    expect(chunk([1, 2, 3, 4, 5], 2)).toEqual([[1, 2], [3, 4], [5]]);
+  });
+
+  it("returns nothing for an empty list", () => {
+    expect(chunk([], 3)).toEqual([]);
+  });
+
+  it("rejects a zero or negative size", () => {
+    expect(() => chunk([1], 0)).toThrow(RangeError);
+  });
+});
+
+describe("buildBalanceInvocations", () => {
+  it("produces one balance(holder) invocation per token, in order", () => {
+    expect(buildBalanceInvocations(["CA", "CB"], HOLDER)).toEqual([
+      { contract: "CA", function: "balance", args: [HOLDER] },
+      { contract: "CB", function: "balance", args: [HOLDER] },
+    ]);
+  });
+});

--- a/contrib/examples/issue-216-batched-trustline-balances/batched-trustline-balances.ts
+++ b/contrib/examples/issue-216-batched-trustline-balances/batched-trustline-balances.ts
@@ -1,0 +1,221 @@
+/**
+ * Batched trustline balance reads — one RPC call instead of N.
+ *
+ * Contributed for issue #216: reading balances for a wallet with several
+ * trustlines issues one `simulateTransaction` per trustline. Running them
+ * concurrently (see contrib/examples/batch-balance-lookup) hides the latency
+ * behind Promise.all but still sends N requests, so the wallet is rate-limited
+ * by the RPC provider exactly when it has the most assets to show.
+ *
+ * A Soroban simulation can carry more than one host function invocation, so N
+ * `balance(id)` reads collapse into a single transaction and therefore a single
+ * round trip. The per-token results come back positionally, in the order the
+ * operations were added.
+ *
+ * ## Behaviour preserved from the per-call path
+ *
+ * The returned data shape is unchanged: `bigint` amounts, keyed by contract id,
+ * in request order. What changes is the failure granularity, and that is why
+ * the batch is not simply "always better":
+ *
+ * - A batched simulation fails as a unit. One bad contract id fails the whole
+ *   call, where N separate calls would have failed exactly one.
+ * - So on a batch-level failure this falls back to per-token reads, which
+ *   restores the original per-item error isolation. The fallback is the slow
+ *   path and only runs when the fast path could not answer.
+ *
+ * Batches are also chunked, because a simulation has a host-resource budget: a
+ * transaction with too many invocations exceeds it and fails as a unit.
+ */
+
+/** Reads one balance. The existing, unbatched interface. */
+export interface BalanceReader {
+  getTokenBalance(tokenContractId: string, holder: string): Promise<bigint>;
+}
+
+/** Reads many balances in a single RPC call. */
+export interface BatchBalanceReader {
+  getTokenBalances(tokenContractIds: string[], holder: string): Promise<bigint[]>;
+}
+
+/**
+ * Max invocations per simulated transaction. Kept well under the host resource
+ * budget so a full chunk still simulates; exceeding it fails the whole batch.
+ */
+export const MAX_INVOCATIONS_PER_SIMULATION = 20;
+
+export interface BatchedBalanceServiceOptions {
+  maxBatchSize?: number;
+  /**
+   * Fall back to per-token reads when a batch fails, restoring per-item error
+   * isolation. Disable to surface the batch failure directly.
+   */
+  fallbackToSingle?: boolean;
+}
+
+export type BalanceResult =
+  | { contractId: string; ok: true; amount: bigint }
+  | { contractId: string; ok: false; error: string };
+
+export interface RpcCallStats {
+  /** RPC calls issued — the number this issue exists to reduce. */
+  rpcCalls: number;
+  /** Calls issued by the per-token fallback path only. */
+  fallbackCalls: number;
+}
+
+export interface BatchedBalanceService extends RpcCallStats {
+  getBalances(holder: string, tokenContractIds: string[]): Promise<BalanceResult[]>;
+  resetStats(): void;
+}
+
+export function chunk<T>(items: T[], size: number): T[][] {
+  if (size < 1) throw new RangeError(`chunk size must be >= 1, got ${size}`);
+  const out: T[][] = [];
+  for (let i = 0; i < items.length; i += size) {
+    out.push(items.slice(i, i + size));
+  }
+  return out;
+}
+
+/**
+ * Wraps a batch-capable reader, with the single-read reader kept for fallback.
+ */
+export function createBatchedBalanceService(
+  batchReader: BatchBalanceReader,
+  singleReader: BalanceReader,
+  options: BatchedBalanceServiceOptions = {},
+): BatchedBalanceService {
+  const maxBatchSize = options.maxBatchSize ?? MAX_INVOCATIONS_PER_SIMULATION;
+  const fallbackToSingle = options.fallbackToSingle ?? true;
+
+  let rpcCalls = 0;
+  let fallbackCalls = 0;
+
+  async function readChunk(ids: string[], holder: string): Promise<BalanceResult[]> {
+    try {
+      rpcCalls++;
+      const amounts = await batchReader.getTokenBalances(ids, holder);
+      if (amounts.length !== ids.length) {
+        throw new Error(
+          `batched balance read returned ${amounts.length} results for ${ids.length} tokens`,
+        );
+      }
+      return ids.map((contractId, i) => ({ contractId, ok: true as const, amount: amounts[i]! }));
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      if (!fallbackToSingle) {
+        return ids.map((contractId) => ({ contractId, ok: false as const, error: message }));
+      }
+
+      // The batch failed as a unit, so we cannot tell which token caused it.
+      // Re-read individually to recover the per-item error isolation the
+      // unbatched path had.
+      return Promise.all(
+        ids.map(async (contractId) => {
+          try {
+            rpcCalls++;
+            fallbackCalls++;
+            const amount = await singleReader.getTokenBalance(contractId, holder);
+            return { contractId, ok: true as const, amount };
+          } catch (singleErr) {
+            return {
+              contractId,
+              ok: false as const,
+              error: singleErr instanceof Error ? singleErr.message : String(singleErr),
+            };
+          }
+        }),
+      );
+    }
+  }
+
+  return {
+    get rpcCalls() {
+      return rpcCalls;
+    },
+    get fallbackCalls() {
+      return fallbackCalls;
+    },
+    resetStats() {
+      rpcCalls = 0;
+      fallbackCalls = 0;
+    },
+
+    async getBalances(holder, tokenContractIds) {
+      if (tokenContractIds.length === 0) return [];
+
+      const chunks = chunk(tokenContractIds, maxBatchSize);
+      const results = await Promise.all(chunks.map((ids) => readChunk(ids, holder)));
+      // Flattened in chunk order, so the output order matches the input order.
+      return results.flat();
+    },
+  };
+}
+
+/**
+ * The unbatched baseline, kept so the benchmark test can compare call counts
+ * against the exact behaviour that shipped before this change.
+ */
+export function createUnbatchedBalanceService(
+  singleReader: BalanceReader,
+): BatchedBalanceService {
+  let rpcCalls = 0;
+
+  return {
+    get rpcCalls() {
+      return rpcCalls;
+    },
+    fallbackCalls: 0,
+    resetStats() {
+      rpcCalls = 0;
+    },
+
+    async getBalances(holder, tokenContractIds) {
+      return Promise.all(
+        tokenContractIds.map(async (contractId) => {
+          try {
+            rpcCalls++;
+            const amount = await singleReader.getTokenBalance(contractId, holder);
+            return { contractId, ok: true as const, amount };
+          } catch (err) {
+            return {
+              contractId,
+              ok: false as const,
+              error: err instanceof Error ? err.message : String(err),
+            };
+          }
+        }),
+      );
+    },
+  };
+}
+
+// --- Building the batched call --------------------------------------------
+
+/**
+ * One `balance(id)` invocation, as it would be added to the simulated tx.
+ * Structural so this example does not depend on @stellar/stellar-sdk.
+ */
+export interface BalanceInvocation {
+  contract: string;
+  function: "balance";
+  args: [holder: string];
+}
+
+/**
+ * Describes the operations a single batched simulation would carry. The real
+ * reader adds each of these via `Operation.invokeContractFunction` to ONE
+ * TransactionBuilder and simulates once; the per-token results are read back
+ * positionally from the simulation's result set.
+ */
+export function buildBalanceInvocations(
+  tokenContractIds: string[],
+  holder: string,
+): BalanceInvocation[] {
+  return tokenContractIds.map((contract) => ({
+    contract,
+    function: "balance" as const,
+    args: [holder],
+  }));
+}

--- a/contrib/examples/issue-217-rpc-connection-reuse/README.md
+++ b/contrib/examples/issue-217-rpc-connection-reuse/README.md
@@ -1,0 +1,53 @@
+# RPC Connection Reuse Tuning
+
+Self-contained reference for issue [#217](https://github.com/Vellar-Wallet/vellar-sdk/issues/217): configurable keep-alive and connection reuse for the Soroban RPC client, with recommended values per environment.
+
+> Scoped to `contrib/` per [CONTRIBUTING.md](../../../CONTRIBUTING.md) rule 3 — the issue's "note in README" is this file, since external PRs cannot touch the root README.
+
+## Why it isn't an `rpc.Server` option
+
+`rpc.Server`'s options expose only `allowHttp` and `headers` — there is no agent or pool hook. Tuning has to happen one layer down, on the HTTP client the environment provides, and be handed to the RPC client as a wrapped `fetch`.
+
+## Recommended values
+
+### Node
+
+| Setting | Recommended | Why |
+| --- | --- | --- |
+| `keepAlive` | `true` | Reuse is opt-in in Node. Without it every simulation and submit repeats the TCP + TLS handshake. |
+| `keepAliveMsecs` | `30_000` | Stays under the commonly-configured 60s server-side idle timeout, so the client closes first instead of racing a server close (which surfaces as `socket hang up` on a request already in flight). |
+| `maxSockets` | `10` | Covers a wallet's concurrent multi-token read burst without opening more connections than a public RPC endpoint tolerates from one client. |
+| `maxFreeSockets` | `6` | Keeps the steady-state pool warm between polls. |
+
+Construct the pool yourself and pass it in — the SDK never imports undici:
+
+```ts
+import { Agent } from "undici";
+import { createTunedRpcTransport, NODE_DEFAULTS } from "./rpc-connection-reuse";
+
+const pool = new Agent({
+  keepAliveTimeout: NODE_DEFAULTS.keepAliveMsecs,
+  connections: NODE_DEFAULTS.maxSockets,
+});
+
+const transport = createTunedRpcTransport({ environment: "node" }, { pool });
+// hand transport.fetch to whatever constructs the RPC client
+```
+
+The **same** pool instance must be reused across requests — that identity is what makes a socket reusable rather than per-request.
+
+### Browser
+
+Nothing to tune, and attempting to is counterproductive:
+
+- The user agent owns the connection pool and neither exposes nor accepts an agent.
+- `Connection` is a [forbidden header name](https://developer.mozilla.org/en-US/docs/Glossary/Forbidden_header_name); setting it is stripped or rejected. This module emits no `Connection` header in the browser.
+- HTTP/1.1 keep-alive and HTTP/2 multiplexing are already the default.
+
+The only thing a browser consumer controls is not defeating reuse — keep one origin, and don't add cache-busting query params that change it.
+
+## Run tests
+
+```bash
+npx vitest run contrib/examples/issue-217-rpc-connection-reuse/rpc-connection-reuse.test.ts
+```

--- a/contrib/examples/issue-217-rpc-connection-reuse/rpc-connection-reuse.test.ts
+++ b/contrib/examples/issue-217-rpc-connection-reuse/rpc-connection-reuse.test.ts
@@ -1,0 +1,145 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  BROWSER_DEFAULTS,
+  createTunedRpcTransport,
+  detectEnvironment,
+  NODE_DEFAULTS,
+  resolveConnectionSettings,
+  type ConnectionPool,
+  type FetchLike,
+} from "./rpc-connection-reuse";
+
+const RPC_URL = "https://soroban-testnet.stellar.org";
+
+function okFetch(): FetchLike {
+  return vi.fn(async () => new Response("{}", { status: 200 }));
+}
+
+describe("resolveConnectionSettings", () => {
+  it("applies the Node keep-alive defaults", () => {
+    const settings = resolveConnectionSettings({ environment: "node" });
+
+    expect(settings).toMatchObject({
+      environment: "node",
+      keepAlive: true,
+      keepAliveMsecs: NODE_DEFAULTS.keepAliveMsecs,
+      maxSockets: NODE_DEFAULTS.maxSockets,
+      maxFreeSockets: NODE_DEFAULTS.maxFreeSockets,
+    });
+    expect(settings.headers).toEqual({ Connection: "keep-alive" });
+  });
+
+  it("honours caller overrides in Node", () => {
+    const settings = resolveConnectionSettings({
+      environment: "node",
+      keepAliveMsecs: 5_000,
+      maxSockets: 3,
+      maxFreeSockets: 1,
+    });
+
+    expect(settings.keepAliveMsecs).toBe(5_000);
+    expect(settings.maxSockets).toBe(3);
+    expect(settings.maxFreeSockets).toBe(1);
+  });
+
+  it("emits Connection: close when keep-alive is explicitly disabled", () => {
+    const settings = resolveConnectionSettings({ environment: "node", keepAlive: false });
+    expect(settings.headers).toEqual({ Connection: "close" });
+  });
+
+  it("sets no Connection header in the browser, where it is forbidden", () => {
+    const settings = resolveConnectionSettings({ environment: "browser" });
+
+    expect(settings.headers).toEqual({});
+    expect(settings).toMatchObject(BROWSER_DEFAULTS);
+  });
+
+  it("detects the environment when none is given", () => {
+    // The test runner is Node, so there is no window.document.
+    expect(detectEnvironment()).toBe("node");
+    expect(resolveConnectionSettings().environment).toBe("node");
+  });
+});
+
+describe("createTunedRpcTransport", () => {
+  it("reuses one pool across repeated calls to the same origin", async () => {
+    const pool: ConnectionPool = { keepAliveTimeout: 30_000, connections: 10 };
+    const fetchImpl = okFetch();
+    const transport = createTunedRpcTransport({ environment: "node" }, { fetchImpl, pool });
+
+    for (let i = 0; i < 5; i++) {
+      await transport.fetch(RPC_URL, { method: "POST" });
+    }
+
+    expect(transport.requestCount()).toBe(5);
+    // One origin => one warm pool, not five independent connections.
+    expect(transport.origins()).toEqual(["https://soroban-testnet.stellar.org"]);
+
+    const calls = (fetchImpl as ReturnType<typeof vi.fn>).mock.calls;
+    expect(calls).toHaveLength(5);
+    // Every request carried the SAME dispatcher instance — that identity is
+    // what makes the socket reusable rather than per-request.
+    for (const [, init] of calls) {
+      expect(init.dispatcher).toBe(pool);
+      expect(init.headers).toMatchObject({ Connection: "keep-alive" });
+    }
+  });
+
+  it("attaches no dispatcher in the browser", async () => {
+    const pool: ConnectionPool = { keepAliveTimeout: 30_000, connections: 10 };
+    const fetchImpl = okFetch();
+    const transport = createTunedRpcTransport({ environment: "browser" }, { fetchImpl, pool });
+
+    await transport.fetch(RPC_URL, { method: "POST" });
+
+    const [, init] = (fetchImpl as ReturnType<typeof vi.fn>).mock.calls[0]!;
+    expect(init.dispatcher).toBeUndefined();
+    expect(init.headers).not.toHaveProperty("Connection");
+  });
+
+  it("attaches no dispatcher when keep-alive is disabled", async () => {
+    const pool: ConnectionPool = { keepAliveTimeout: 30_000, connections: 10 };
+    const fetchImpl = okFetch();
+    const transport = createTunedRpcTransport(
+      { environment: "node", keepAlive: false },
+      { fetchImpl, pool },
+    );
+
+    await transport.fetch(RPC_URL, { method: "POST" });
+
+    const [, init] = (fetchImpl as ReturnType<typeof vi.fn>).mock.calls[0]!;
+    expect(init.dispatcher).toBeUndefined();
+    expect(init.headers).toMatchObject({ Connection: "close" });
+  });
+
+  it("does not let tuned headers clobber caller headers", async () => {
+    const fetchImpl = okFetch();
+    const transport = createTunedRpcTransport({ environment: "node" }, { fetchImpl });
+
+    await transport.fetch(RPC_URL, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+    });
+
+    const [, init] = (fetchImpl as ReturnType<typeof vi.fn>).mock.calls[0]!;
+    expect(init.headers).toEqual({
+      Connection: "keep-alive",
+      "content-type": "application/json",
+    });
+  });
+
+  it("tracks distinct origins separately", async () => {
+    const fetchImpl = okFetch();
+    const transport = createTunedRpcTransport({ environment: "node" }, { fetchImpl });
+
+    await transport.fetch(RPC_URL, { method: "POST" });
+    await transport.fetch("https://soroban.stellar.org", { method: "POST" });
+    await transport.fetch(RPC_URL, { method: "POST" });
+
+    expect(transport.requestCount()).toBe(3);
+    expect(transport.origins()).toEqual([
+      "https://soroban-testnet.stellar.org",
+      "https://soroban.stellar.org",
+    ]);
+  });
+});

--- a/contrib/examples/issue-217-rpc-connection-reuse/rpc-connection-reuse.ts
+++ b/contrib/examples/issue-217-rpc-connection-reuse/rpc-connection-reuse.ts
@@ -1,0 +1,186 @@
+/**
+ * Connection reuse tuning for the Soroban RPC client.
+ *
+ * Contributed for issue #217: the RPC client is constructed with default
+ * connection settings, which suit neither Node nor browser consumers. Every
+ * balance read, simulation and submit is a separate POST to the same origin, so
+ * without connection reuse each one pays a fresh TCP + TLS handshake — the
+ * dominant cost on a wallet screen that reads several tokens in a row.
+ *
+ * `rpc.Server`'s own options expose only `allowHttp` and `headers`; there is no
+ * agent or pool hook on it. Tuning therefore has to happen one layer down, at
+ * the HTTP client the environment gives us:
+ *
+ * - **Node** — reuse is opt-in. Supply a dispatcher/agent with keep-alive
+ *   enabled and a connection cap, and pass a fetch bound to it.
+ * - **Browser** — the user agent owns the connection pool and neither exposes
+ *   nor accepts an agent. `Connection` is a forbidden header there, so setting
+ *   it is not merely useless but rejected. Reuse is already the default for
+ *   HTTP/1.1 keep-alive and HTTP/2 multiplexing; the only thing a consumer
+ *   controls is not defeating it (no per-request cache-busting origin changes).
+ *
+ * This module produces the settings and the wrapped fetch, and leaves the
+ * agent's construction to the caller so the SDK never has to import undici.
+ */
+
+export type FetchLike = (url: string, init?: RequestInit) => Promise<Response>;
+
+export type RuntimeEnvironment = "node" | "browser";
+
+export interface ConnectionReuseOptions {
+  /**
+   * Which environment the consumer runs in. Defaults to auto-detection: the
+   * presence of a `window` with a `document` means browser.
+   */
+  environment?: RuntimeEnvironment;
+  /** Enable HTTP keep-alive. Node only; ignored in the browser. */
+  keepAlive?: boolean;
+  /**
+   * How long an idle socket is kept open, in ms. Too high and the RPC provider
+   * closes it first (a request in flight on a server-closed socket surfaces as
+   * a socket hang up); too low and a burst of reads re-handshakes anyway.
+   */
+  keepAliveMsecs?: number;
+  /** Max simultaneous sockets per origin. */
+  maxSockets?: number;
+  /** Max idle sockets retained per origin between bursts. */
+  maxFreeSockets?: number;
+}
+
+export interface ResolvedConnectionSettings {
+  environment: RuntimeEnvironment;
+  keepAlive: boolean;
+  keepAliveMsecs: number;
+  maxSockets: number;
+  maxFreeSockets: number;
+  /**
+   * Headers to hand to `rpc.Server`. Empty in the browser, where `Connection`
+   * is a forbidden header and the UA manages the pool itself.
+   */
+  headers: Record<string, string>;
+}
+
+/**
+ * Recommended values, per environment. See README for the reasoning.
+ *
+ * Node: a wallet reads a handful of tokens concurrently, so 10 sockets covers
+ * the burst without opening more connections than a public RPC endpoint will
+ * tolerate from one client. 30s idle stays under the commonly-configured 60s
+ * server-side idle timeout, so we close first rather than racing a server
+ * close. 6 free sockets keeps the steady-state pool warm between polls.
+ */
+export const NODE_DEFAULTS = {
+  keepAlive: true,
+  keepAliveMsecs: 30_000,
+  maxSockets: 10,
+  maxFreeSockets: 6,
+} as const;
+
+/**
+ * Browser: the UA owns the pool. These values are recorded for reporting only
+ * — nothing is applied, and no `Connection` header is emitted, because it is a
+ * forbidden header name that the browser strips or rejects.
+ */
+export const BROWSER_DEFAULTS = {
+  keepAlive: false,
+  keepAliveMsecs: 0,
+  maxSockets: 0,
+  maxFreeSockets: 0,
+} as const;
+
+export function detectEnvironment(): RuntimeEnvironment {
+  const w = (globalThis as { window?: { document?: unknown } }).window;
+  return w && w.document ? "browser" : "node";
+}
+
+export function resolveConnectionSettings(
+  options: ConnectionReuseOptions = {},
+): ResolvedConnectionSettings {
+  const environment = options.environment ?? detectEnvironment();
+
+  if (environment === "browser") {
+    return { environment, ...BROWSER_DEFAULTS, headers: {} };
+  }
+
+  const keepAlive = options.keepAlive ?? NODE_DEFAULTS.keepAlive;
+  return {
+    environment,
+    keepAlive,
+    keepAliveMsecs: options.keepAliveMsecs ?? NODE_DEFAULTS.keepAliveMsecs,
+    maxSockets: options.maxSockets ?? NODE_DEFAULTS.maxSockets,
+    maxFreeSockets: options.maxFreeSockets ?? NODE_DEFAULTS.maxFreeSockets,
+    // Explicit on HTTP/1.1; harmless on HTTP/2, where the header is ignored.
+    headers: keepAlive ? { Connection: "keep-alive" } : { Connection: "close" },
+  };
+}
+
+/**
+ * Anything with an undici-style `Agent`/`Dispatcher` shape. Typed structurally
+ * so this module does not depend on undici or on @types/node.
+ */
+export interface ConnectionPool {
+  readonly keepAliveTimeout?: number;
+  readonly connections?: number;
+}
+
+export interface TunedRpcTransport {
+  settings: ResolvedConnectionSettings;
+  /** Fetch to hand to the RPC client; carries the pool and tuned headers. */
+  fetch: FetchLike;
+  /** Requests issued through this transport. */
+  requestCount(): number;
+  /** Distinct origins contacted — one warm pool is kept per origin. */
+  origins(): string[];
+}
+
+export interface CreateTunedRpcTransportDeps {
+  /** Underlying fetch. Defaults to the global. */
+  fetchImpl?: FetchLike;
+  /**
+   * Node connection pool (e.g. `new undici.Agent({ keepAliveTimeout, connections })`).
+   * Attached to each request as `dispatcher` so the sockets are actually reused.
+   * Ignored in the browser.
+   */
+  pool?: ConnectionPool;
+}
+
+/**
+ * Wraps a fetch so every RPC request carries the tuned keep-alive settings and
+ * the shared pool, and counts requests/origins so reuse can be asserted.
+ */
+export function createTunedRpcTransport(
+  options: ConnectionReuseOptions = {},
+  deps: CreateTunedRpcTransportDeps = {},
+): TunedRpcTransport {
+  const settings = resolveConnectionSettings(options);
+  const baseFetch: FetchLike = deps.fetchImpl ?? ((url, init) => fetch(url, init));
+  const useNodePool = settings.environment === "node" && settings.keepAlive && deps.pool;
+
+  let requests = 0;
+  const seenOrigins = new Set<string>();
+
+  return {
+    settings,
+    requestCount: () => requests,
+    origins: () => [...seenOrigins],
+
+    async fetch(url, init) {
+      requests++;
+      try {
+        seenOrigins.add(new URL(url).origin);
+      } catch {
+        // A non-absolute URL has no origin to pool on; counting still works.
+      }
+
+      const merged: RequestInit & { dispatcher?: ConnectionPool } = {
+        ...init,
+        headers: { ...settings.headers, ...(init?.headers as Record<string, string> | undefined) },
+      };
+      // undici reads `dispatcher` off the init; the same object across calls is
+      // what makes the socket reusable rather than per-request.
+      if (useNodePool) merged.dispatcher = deps.pool;
+
+      return baseFetch(url, merged);
+    },
+  };
+}

--- a/contrib/examples/issue-219-policy-deploy-rollback/README.md
+++ b/contrib/examples/issue-219-policy-deploy-rollback/README.md
@@ -1,0 +1,28 @@
+# Policy Deployment Rollback
+
+Self-contained reference for issue [#219](https://github.com/Vellar-Wallet/vellar-sdk/issues/219): wrap the multi-step policy deployment in a saga that tracks completed steps and runs compensating rollbacks on partial failure.
+
+## The sequence
+
+| Step | Compensation |
+| --- | --- |
+| `generate` | `deletePolicy` — an orphaned generated policy still occupies its id in the service |
+| `simulate` | none — read-only dry run |
+| `deployInstance` | `revokeInstance` — the instance exists on chain and would otherwise stay attached, unreferenced |
+| `recordDeployment` | none — last step; nothing after it can fail |
+
+## Rules
+
+- **Only completed steps are compensated.** If `deployInstance` throws, there is no instance to revoke.
+- **Compensations run LIFO.** A later step may depend on an earlier one, so its undo goes first: revoke the instance, then delete the policy.
+- **Rollback is best-effort.** A compensation that itself fails is recorded and logged, but does not abort the remaining compensations and does not replace the original error. `PolicyDeploymentRollbackError` carries `cause`, `completedSteps`, `rollback[]`, and `fullyRolledBack` so a caller can distinguish "fully unwound" from "unwound except the instance deploy".
+
+## Logging
+
+Every completed step, every rollback, and every failed rollback is emitted through an injected `DeploymentLogger` (`info` / `warn`). Failed rollbacks log at `warn` with the compensation's error attached — those are the cases that need an operator.
+
+## Run tests
+
+```bash
+npx vitest run contrib/examples/issue-219-policy-deploy-rollback/policy-deploy-rollback.test.ts
+```

--- a/contrib/examples/issue-219-policy-deploy-rollback/policy-deploy-rollback.test.ts
+++ b/contrib/examples/issue-219-policy-deploy-rollback/policy-deploy-rollback.test.ts
@@ -1,0 +1,233 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  deployPolicyWithRollback,
+  PolicyDeploymentRollbackError,
+  runDeploymentWithRollback,
+  type DeploymentLogger,
+  type DeploymentStep,
+  type PolicyDeployApi,
+} from "./policy-deploy-rollback";
+
+function recordingLogger() {
+  const info: string[] = [];
+  const warn: string[] = [];
+  const logger: DeploymentLogger = {
+    info: (m) => info.push(m),
+    warn: (m) => warn.push(m),
+  };
+  return { logger, info, warn };
+}
+
+function stubApi(overrides: Partial<PolicyDeployApi> = {}): PolicyDeployApi {
+  return {
+    generate: vi.fn(async () => ({ id: "pol_1", status: "draft" })),
+    simulate: vi.fn(async () => ({ ok: true })),
+    deployInstance: vi.fn(async () => ({ contractId: "CINSTANCE" })),
+    recordDeployment: vi.fn(async () => ({ id: "pol_1", status: "active" })),
+    deletePolicy: vi.fn(async () => {}),
+    revokeInstance: vi.fn(async () => {}),
+    ...overrides,
+  };
+}
+
+const input = {
+  definition: { name: "daily-limit" },
+  wallet: "CWALLET",
+  txHash: "abc123",
+};
+
+describe("deployPolicyWithRollback", () => {
+  it("runs the full sequence and returns the recorded policy on success", async () => {
+    const api = stubApi();
+
+    const policy = await deployPolicyWithRollback(api, input);
+
+    expect(policy).toEqual({ id: "pol_1", status: "active" });
+    expect(api.generate).toHaveBeenCalledTimes(1);
+    expect(api.simulate).toHaveBeenCalledWith("pol_1", "CWALLET");
+    expect(api.deployInstance).toHaveBeenCalledWith("pol_1", "CWALLET");
+    expect(api.recordDeployment).toHaveBeenCalledWith("pol_1", "abc123", "CINSTANCE");
+    // Nothing failed, so nothing is undone.
+    expect(api.deletePolicy).not.toHaveBeenCalled();
+    expect(api.revokeInstance).not.toHaveBeenCalled();
+  });
+
+  it("rolls back the instance deploy and the generate when recordDeployment fails", async () => {
+    const api = stubApi({
+      recordDeployment: vi.fn(async () => {
+        throw new Error("gateway 503");
+      }),
+    });
+
+    await expect(deployPolicyWithRollback(api, input)).rejects.toThrow(
+      PolicyDeploymentRollbackError,
+    );
+
+    expect(api.revokeInstance).toHaveBeenCalledWith("pol_1", "CINSTANCE");
+    expect(api.deletePolicy).toHaveBeenCalledWith("pol_1");
+  });
+
+  it("compensates in reverse order so the instance is revoked before the policy is deleted", async () => {
+    const order: string[] = [];
+    const api = stubApi({
+      revokeInstance: vi.fn(async () => {
+        order.push("revokeInstance");
+      }),
+      deletePolicy: vi.fn(async () => {
+        order.push("deletePolicy");
+      }),
+      recordDeployment: vi.fn(async () => {
+        throw new Error("gateway 503");
+      }),
+    });
+
+    await expect(deployPolicyWithRollback(api, input)).rejects.toThrow();
+    expect(order).toEqual(["revokeInstance", "deletePolicy"]);
+  });
+
+  it("only undoes the steps that actually completed", async () => {
+    const api = stubApi({
+      deployInstance: vi.fn(async () => {
+        throw new Error("sponsor account drained");
+      }),
+    });
+
+    await expect(deployPolicyWithRollback(api, input)).rejects.toThrow(/sponsor account drained/);
+
+    // deployInstance never completed, so there is no instance to revoke.
+    expect(api.revokeInstance).not.toHaveBeenCalled();
+    expect(api.deletePolicy).toHaveBeenCalledWith("pol_1");
+  });
+
+  it("rolls back a rejected simulation without revoking a nonexistent instance", async () => {
+    const api = stubApi({
+      simulate: vi.fn(async () => ({ ok: false, reason: "limit exceeds wallet balance" })),
+    });
+
+    const err = await deployPolicyWithRollback(api, input).catch((e) => e);
+
+    expect(err).toBeInstanceOf(PolicyDeploymentRollbackError);
+    expect(err.cause.message).toMatch(/limit exceeds wallet balance/);
+    expect(err.completedSteps).toEqual(["generate"]);
+    expect(api.deployInstance).not.toHaveBeenCalled();
+    expect(api.revokeInstance).not.toHaveBeenCalled();
+    expect(api.deletePolicy).toHaveBeenCalledWith("pol_1");
+  });
+
+  it("reports the original cause and a fully-rolled-back flag", async () => {
+    const api = stubApi({
+      recordDeployment: vi.fn(async () => {
+        throw new Error("gateway 503");
+      }),
+    });
+
+    const err = await deployPolicyWithRollback(api, input).catch((e) => e);
+
+    expect(err).toBeInstanceOf(PolicyDeploymentRollbackError);
+    expect(err.cause.message).toBe("gateway 503");
+    expect(err.completedSteps).toEqual(["generate", "simulate", "deployInstance"]);
+    expect(err.fullyRolledBack).toBe(true);
+    expect(err.rollback).toEqual([
+      { step: "deployInstance", ok: true },
+      { step: "generate", ok: true },
+    ]);
+  });
+
+  it("keeps unwinding when a compensation itself fails, without masking the cause", async () => {
+    const api = stubApi({
+      recordDeployment: vi.fn(async () => {
+        throw new Error("gateway 503");
+      }),
+      revokeInstance: vi.fn(async () => {
+        throw new Error("revoke rejected: instance already attached");
+      }),
+    });
+
+    const err = await deployPolicyWithRollback(api, input).catch((e) => e);
+
+    // Original failure is preserved, not replaced by the rollback failure.
+    expect(err.cause.message).toBe("gateway 503");
+    expect(err.fullyRolledBack).toBe(false);
+    expect(err.rollback).toEqual([
+      {
+        step: "deployInstance",
+        ok: false,
+        error: "revoke rejected: instance already attached",
+      },
+      { step: "generate", ok: true },
+    ]);
+    // The failed compensation did not abort the remaining one.
+    expect(api.deletePolicy).toHaveBeenCalledWith("pol_1");
+  });
+
+  it("logs each completed step and every rollback event", async () => {
+    const { logger, info, warn } = recordingLogger();
+    const api = stubApi({
+      recordDeployment: vi.fn(async () => {
+        throw new Error("gateway 503");
+      }),
+    });
+
+    await expect(deployPolicyWithRollback(api, input, { logger })).rejects.toThrow();
+
+    expect(info).toEqual([
+      'policy deploy: step "generate" completed',
+      'policy deploy: step "simulate" completed',
+      'policy deploy: step "deployInstance" completed',
+      'policy deploy: rolled back step "deployInstance"',
+      'policy deploy: rolled back step "generate"',
+    ]);
+    expect(warn).toEqual(['policy deploy: step "recordDeployment" failed, rolling back']);
+  });
+
+  it("logs a failed rollback at warn level", async () => {
+    const { logger, warn } = recordingLogger();
+    const api = stubApi({
+      recordDeployment: vi.fn(async () => {
+        throw new Error("gateway 503");
+      }),
+      revokeInstance: vi.fn(async () => {
+        throw new Error("revoke rejected");
+      }),
+    });
+
+    await expect(deployPolicyWithRollback(api, input, { logger })).rejects.toThrow();
+
+    expect(warn).toContain('policy deploy: rollback of step "deployInstance" FAILED');
+  });
+});
+
+describe("runDeploymentWithRollback", () => {
+  it("threads state through the steps in order", async () => {
+    const steps: DeploymentStep<{ trail: string[] }>[] = [
+      { name: "a", run: async (s) => ({ trail: [...s.trail, "a"] }) },
+      { name: "b", run: async (s) => ({ trail: [...s.trail, "b"] }) },
+    ];
+
+    await expect(runDeploymentWithRollback(steps, { trail: [] })).resolves.toEqual({
+      trail: ["a", "b"],
+    });
+  });
+
+  it("passes each compensation the state as it stood after its own step", async () => {
+    const seen: string[] = [];
+    const steps: DeploymentStep<{ id?: string }>[] = [
+      {
+        name: "create",
+        run: async () => ({ id: "created-1" }),
+        compensate: async (state) => {
+          seen.push(state.id!);
+        },
+      },
+      {
+        name: "fail",
+        run: async () => {
+          throw new Error("boom");
+        },
+      },
+    ];
+
+    await expect(runDeploymentWithRollback(steps, {})).rejects.toThrow("boom");
+    expect(seen).toEqual(["created-1"]);
+  });
+});

--- a/contrib/examples/issue-219-policy-deploy-rollback/policy-deploy-rollback.ts
+++ b/contrib/examples/issue-219-policy-deploy-rollback/policy-deploy-rollback.ts
@@ -1,0 +1,239 @@
+/**
+ * Transactional multi-step policy deployment with compensating rollback.
+ *
+ * Contributed for issue #219: policy deployment issues several sequential API
+ * calls (generate -> simulate -> deploy instance -> record deployment) with no
+ * rollback path. If a later step fails, the earlier ones stay committed: a
+ * generated policy is left orphaned, or an instance contract is deployed and
+ * never recorded, so the service and the chain disagree about what exists.
+ *
+ * This wraps the sequence as a saga. Each step declares how to undo itself, the
+ * runner records every step that actually completed, and on failure it runs the
+ * recorded compensations in reverse order (LIFO) — the undo for the most recent
+ * step runs first, because a later step may depend on an earlier one.
+ *
+ * Rollback is best-effort by design. A compensation that itself fails must not
+ * mask the original error nor abort the remaining compensations, so failures are
+ * collected, logged, and surfaced on the thrown error rather than propagated.
+ */
+
+export interface DeploymentLogger {
+  info(message: string, context?: Record<string, unknown>): void;
+  warn(message: string, context?: Record<string, unknown>): void;
+}
+
+/** Records the outcome of one attempted compensation. */
+export interface RollbackOutcome {
+  step: string;
+  ok: boolean;
+  /** Present when the compensation itself failed. */
+  error?: string;
+}
+
+/**
+ * Thrown when a deployment fails partway. Carries the original cause plus a
+ * per-step record of what the rollback managed to undo, so a caller can tell
+ * "fully rolled back" from "rolled back except the instance deploy".
+ */
+export class PolicyDeploymentRollbackError extends Error {
+  constructor(
+    readonly cause: Error,
+    /** Steps that had completed before the failure, in execution order. */
+    readonly completedSteps: string[],
+    readonly rollback: RollbackOutcome[],
+  ) {
+    super(`policy deployment failed at step "${completedSteps.length + 1}": ${cause.message}`);
+    this.name = "PolicyDeploymentRollbackError";
+  }
+
+  /** True when every compensation succeeded — no orphaned state remains. */
+  get fullyRolledBack(): boolean {
+    return this.rollback.every((r) => r.ok);
+  }
+}
+
+export interface DeploymentStep<TState> {
+  name: string;
+  run(state: TState): Promise<TState>;
+  /**
+   * Undo this step. Omit for steps with nothing to undo (a read-only simulate).
+   * Receives the state as it stood AFTER the step ran, so it can reach the ids
+   * the step produced.
+   */
+  compensate?(state: TState): Promise<void>;
+}
+
+export interface RunDeploymentOptions {
+  logger?: DeploymentLogger;
+}
+
+const noopLogger: DeploymentLogger = { info: () => {}, warn: () => {} };
+
+/**
+ * Runs steps in order. On failure, compensates the completed steps in reverse.
+ *
+ * The state after each successful step is captured so compensations see exactly
+ * the state their own step produced.
+ */
+export async function runDeploymentWithRollback<TState>(
+  steps: DeploymentStep<TState>[],
+  initialState: TState,
+  options: RunDeploymentOptions = {},
+): Promise<TState> {
+  const logger = options.logger ?? noopLogger;
+  const completed: { step: DeploymentStep<TState>; stateAfter: TState }[] = [];
+  let state = initialState;
+
+  for (const step of steps) {
+    try {
+      state = await step.run(state);
+      completed.push({ step, stateAfter: state });
+      logger.info(`policy deploy: step "${step.name}" completed`);
+    } catch (err) {
+      const cause = err instanceof Error ? err : new Error(String(err));
+      logger.warn(`policy deploy: step "${step.name}" failed, rolling back`, {
+        error: cause.message,
+        completedSteps: completed.map((c) => c.step.name),
+      });
+
+      const outcomes = await compensate(completed, logger);
+      throw new PolicyDeploymentRollbackError(
+        cause,
+        completed.map((c) => c.step.name),
+        outcomes,
+      );
+    }
+  }
+
+  return state;
+}
+
+async function compensate<TState>(
+  completed: { step: DeploymentStep<TState>; stateAfter: TState }[],
+  logger: DeploymentLogger,
+): Promise<RollbackOutcome[]> {
+  const outcomes: RollbackOutcome[] = [];
+
+  // Reverse order: a later step may depend on an earlier one, so its undo has
+  // to run first.
+  for (let i = completed.length - 1; i >= 0; i--) {
+    const { step, stateAfter } = completed[i]!;
+    if (!step.compensate) continue;
+
+    try {
+      await step.compensate(stateAfter);
+      outcomes.push({ step: step.name, ok: true });
+      logger.info(`policy deploy: rolled back step "${step.name}"`);
+    } catch (err) {
+      // Never let a failed compensation abort the remaining ones or replace the
+      // original error — record it and keep unwinding.
+      const message = err instanceof Error ? err.message : String(err);
+      outcomes.push({ step: step.name, ok: false, error: message });
+      logger.warn(`policy deploy: rollback of step "${step.name}" FAILED`, { error: message });
+    }
+  }
+
+  return outcomes;
+}
+
+// --- The concrete policy deployment saga -----------------------------------
+
+export interface PolicyDefinition {
+  name: string;
+  [key: string]: unknown;
+}
+
+export interface GeneratedPolicy {
+  id: string;
+  status: string;
+}
+
+export interface SimulateResult {
+  ok: boolean;
+  reason?: string;
+}
+
+/** The subset of the policy client this saga drives. */
+export interface PolicyDeployApi {
+  generate(definition: PolicyDefinition): Promise<GeneratedPolicy>;
+  simulate(policyId: string, wallet: string): Promise<SimulateResult>;
+  deployInstance(policyId: string, wallet: string): Promise<{ contractId: string }>;
+  recordDeployment(policyId: string, txHash: string, contractId?: string): Promise<GeneratedPolicy>;
+
+  // Compensations. A deployment service that cannot revoke an instance should
+  // still expose these as no-ops so the saga's undo surface stays explicit.
+  deletePolicy(policyId: string): Promise<void>;
+  revokeInstance(policyId: string, contractId: string): Promise<void>;
+}
+
+export interface DeploymentState {
+  definition: PolicyDefinition;
+  wallet: string;
+  txHash: string;
+  policyId?: string;
+  contractId?: string;
+  policy?: GeneratedPolicy;
+}
+
+export function policyDeploymentSteps(api: PolicyDeployApi): DeploymentStep<DeploymentState>[] {
+  return [
+    {
+      name: "generate",
+      async run(state) {
+        const policy = await api.generate(state.definition);
+        return { ...state, policyId: policy.id, policy };
+      },
+      // An orphaned generated policy is invisible to the user but still occupies
+      // its name/id in the service, so it has to go.
+      async compensate(state) {
+        if (state.policyId) await api.deletePolicy(state.policyId);
+      },
+    },
+    {
+      name: "simulate",
+      async run(state) {
+        const result = await api.simulate(state.policyId!, state.wallet);
+        if (!result.ok) {
+          throw new Error(`policy simulation rejected the deploy: ${result.reason ?? "unknown"}`);
+        }
+        return state;
+      },
+      // Read-only dry run: nothing to undo.
+    },
+    {
+      name: "deployInstance",
+      async run(state) {
+        const { contractId } = await api.deployInstance(state.policyId!, state.wallet);
+        return { ...state, contractId };
+      },
+      // The instance exists on chain at this point. Revoking is what keeps a
+      // failed recordDeployment from leaving an unreferenced live policy
+      // attached to the wallet.
+      async compensate(state) {
+        if (state.policyId && state.contractId) {
+          await api.revokeInstance(state.policyId, state.contractId);
+        }
+      },
+    },
+    {
+      name: "recordDeployment",
+      async run(state) {
+        const policy = await api.recordDeployment(state.policyId!, state.txHash, state.contractId);
+        return { ...state, policy };
+      },
+    },
+  ];
+}
+
+export async function deployPolicyWithRollback(
+  api: PolicyDeployApi,
+  input: { definition: PolicyDefinition; wallet: string; txHash: string },
+  options: RunDeploymentOptions = {},
+): Promise<GeneratedPolicy> {
+  const finalState = await runDeploymentWithRollback(
+    policyDeploymentSteps(api),
+    { ...input },
+    options,
+  );
+  return finalState.policy!;
+}

--- a/contrib/examples/issue-221-x402-resource-cache-key/README.md
+++ b/contrib/examples/issue-221-x402-resource-cache-key/README.md
@@ -1,0 +1,27 @@
+# x402 Resource Cache Key (network-scoped)
+
+Self-contained reference for issue [#221](https://github.com/Vellar-Wallet/vellar-sdk/issues/221): compose the network identifier into the x402 resource cache key so multi-network consumers cannot serve a testnet resource record for a mainnet lookup.
+
+## Composite key format
+
+```
+v2|<network>|<resourceId>
+```
+
+| Field | Meaning |
+| --- | --- |
+| `v2` | Key-schema version. A key without this prefix predates network scoping and is discarded by the migration. |
+| `<network>` | CAIP-2 chain id / SDK network name the lookup resolved against (`stellar:testnet`, `stellar:pubnet`). |
+| `<resourceId>` | Resource identifier as supplied by the caller. |
+
+`|` is the separator because it cannot appear in a CAIP-2 chain id. Field order is fixed so `v2|<network>|` works as a prefix for range operations such as `invalidateNetwork()`.
+
+## Migration
+
+`clearUnscopedEntries(store)` drops every entry that lacks the current version prefix. A legacy entry is keyed by the bare resource id, so its network cannot be inferred — it is deleted rather than rewritten, and the next lookup repopulates it under the correct scoped key. `createNetworkScopedResourceCache` runs this once at construction and reports the count as `migratedEntries`.
+
+## Run tests
+
+```bash
+npx vitest run contrib/examples/issue-221-x402-resource-cache-key/x402-resource-cache-key.test.ts
+```

--- a/contrib/examples/issue-221-x402-resource-cache-key/x402-resource-cache-key.test.ts
+++ b/contrib/examples/issue-221-x402-resource-cache-key/x402-resource-cache-key.test.ts
@@ -1,0 +1,152 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  buildResourceCacheKey,
+  CACHE_KEY_VERSION,
+  clearUnscopedEntries,
+  createNetworkScopedResourceCache,
+  type CachedResource,
+  type ResourceLookup,
+} from "./x402-resource-cache-key";
+
+const TESTNET = "stellar:testnet";
+const MAINNET = "stellar:pubnet";
+
+function resource(network: string): CachedResource {
+  return network === TESTNET
+    ? {
+        resourceId: "/premium-feed",
+        network: TESTNET,
+        asset: "CTESTUSDC",
+        payTo: "CTESTSELLER",
+        amount: 10n,
+      }
+    : {
+        resourceId: "/premium-feed",
+        network: MAINNET,
+        asset: "CMAINUSDC",
+        payTo: "CMAINSELLER",
+        amount: 5_000n,
+      };
+}
+
+function stubLookup(): ResourceLookup {
+  return {
+    lookupResource: vi.fn(async (_resourceId: string, network: string) => resource(network)),
+  };
+}
+
+describe("buildResourceCacheKey", () => {
+  it("composes version, network and resource id in a fixed order", () => {
+    expect(buildResourceCacheKey("/premium-feed", TESTNET)).toBe(
+      `${CACHE_KEY_VERSION}|${TESTNET}|/premium-feed`,
+    );
+  });
+
+  it("produces different keys for the same resource on different networks", () => {
+    expect(buildResourceCacheKey("/premium-feed", TESTNET)).not.toBe(
+      buildResourceCacheKey("/premium-feed", MAINNET),
+    );
+  });
+
+  it("rejects a missing network so an unscoped key can never be written", () => {
+    expect(() => buildResourceCacheKey("/premium-feed", "")).toThrow(/network identifier/);
+  });
+
+  it("rejects a missing resource id", () => {
+    expect(() => buildResourceCacheKey("", TESTNET)).toThrow(/resource id/);
+  });
+});
+
+describe("createNetworkScopedResourceCache", () => {
+  it("does not collide testnet and mainnet lookups for the same resource id", async () => {
+    const lookup = stubLookup();
+    const cache = createNetworkScopedResourceCache(lookup);
+
+    const testnet = await cache.get("/premium-feed", TESTNET);
+    const mainnet = await cache.get("/premium-feed", MAINNET);
+
+    expect(testnet.payTo).toBe("CTESTSELLER");
+    expect(testnet.asset).toBe("CTESTUSDC");
+    expect(testnet.amount).toBe(10n);
+
+    expect(mainnet.payTo).toBe("CMAINSELLER");
+    expect(mainnet.asset).toBe("CMAINUSDC");
+    expect(mainnet.amount).toBe(5_000n);
+
+    // Both networks missed: the second lookup was NOT served from the first's entry.
+    expect(lookup.lookupResource).toHaveBeenCalledTimes(2);
+    expect(cache.hits).toBe(0);
+    expect(cache.misses).toBe(2);
+    expect(cache.size()).toBe(2);
+  });
+
+  it("still serves a repeat lookup on the same network from cache", async () => {
+    const lookup = stubLookup();
+    const cache = createNetworkScopedResourceCache(lookup);
+
+    await cache.get("/premium-feed", TESTNET);
+    const second = await cache.get("/premium-feed", TESTNET);
+
+    expect(second.payTo).toBe("CTESTSELLER");
+    expect(lookup.lookupResource).toHaveBeenCalledTimes(1);
+    expect(cache.hits).toBe(1);
+  });
+
+  it("expires entries after the TTL", async () => {
+    let time = 0;
+    const lookup = stubLookup();
+    const cache = createNetworkScopedResourceCache(lookup, new Map(), {
+      ttlMs: 1_000,
+      now: () => time,
+    });
+
+    await cache.get("/premium-feed", TESTNET);
+    time = 1_500;
+    await cache.get("/premium-feed", TESTNET);
+
+    expect(lookup.lookupResource).toHaveBeenCalledTimes(2);
+  });
+
+  it("invalidates one network without touching the other", async () => {
+    const lookup = stubLookup();
+    const cache = createNetworkScopedResourceCache(lookup);
+
+    await cache.get("/premium-feed", TESTNET);
+    await cache.get("/premium-feed", MAINNET);
+
+    expect(cache.invalidateNetwork(TESTNET)).toBe(1);
+    expect(cache.size()).toBe(1);
+
+    await cache.get("/premium-feed", MAINNET);
+    expect(cache.hits).toBe(1);
+  });
+});
+
+describe("clearUnscopedEntries", () => {
+  it("removes pre-#221 entries keyed by bare resource id", () => {
+    const store = new Map<string, unknown>([
+      ["/premium-feed", { legacy: true }],
+      ["/other", { legacy: true }],
+      [`${CACHE_KEY_VERSION}|${TESTNET}|/premium-feed`, { legacy: false }],
+    ]);
+
+    expect(clearUnscopedEntries(store)).toBe(2);
+    expect([...store.keys()]).toEqual([`${CACHE_KEY_VERSION}|${TESTNET}|/premium-feed`]);
+  });
+
+  it("runs on construction so a persisted store cannot serve unscoped hits", async () => {
+    const lookup = stubLookup();
+    const store = new Map<string, { expiresAt: number; value: CachedResource }>([
+      // A legacy entry holding MAINNET data under the bare resource id.
+      ["/premium-feed", { expiresAt: Number.MAX_SAFE_INTEGER, value: resource(MAINNET) }],
+    ]);
+
+    const cache = createNetworkScopedResourceCache(lookup, store, { ttlMs: 60_000 });
+    expect(cache.migratedEntries).toBe(1);
+
+    // The testnet lookup must hit the network, not the migrated mainnet record.
+    const testnet = await cache.get("/premium-feed", TESTNET);
+    expect(testnet.payTo).toBe("CTESTSELLER");
+    expect(lookup.lookupResource).toHaveBeenCalledTimes(1);
+  });
+});

--- a/contrib/examples/issue-221-x402-resource-cache-key/x402-resource-cache-key.ts
+++ b/contrib/examples/issue-221-x402-resource-cache-key/x402-resource-cache-key.ts
@@ -1,0 +1,170 @@
+/**
+ * Network-scoped cache key for x402 resource lookups.
+ *
+ * Contributed for issue #221: the x402 client caches resource lookups keyed
+ * only by resource id, so a consumer that talks to more than one network can
+ * serve a testnet resource record for a mainnet lookup (and vice versa). The
+ * two records describe different `payTo` addresses, different asset contract
+ * ids, and different prices — a collision is a wrong-network payment, not just
+ * a stale read.
+ *
+ * The fix is to compose the network identifier into the key.
+ *
+ * ## Composite key format
+ *
+ * ```
+ * v2|<network>|<resourceId>
+ * ```
+ *
+ * - `v2`      — key-schema version. Bumping this is what makes the migration in
+ *               `clearUnscopedEntries` possible: any entry that does not carry
+ *               the current prefix predates network scoping and is discarded.
+ * - `network` — the CAIP-2 chain id or SDK network name the lookup was resolved
+ *               against (`stellar:testnet`, `stellar:pubnet`, ...). Both the
+ *               separator and the field order are fixed so the prefix
+ *               `v2|<network>|` can be used for range operations such as
+ *               "invalidate everything cached for testnet".
+ * - `resourceId` — the resource identifier as supplied by the caller.
+ *
+ * `|` is the separator because it cannot appear in a CAIP-2 chain id. Callers
+ * whose resource ids may contain `|` should pass an already-encoded id; the key
+ * builder does not escape, so that ambiguity would be theirs to resolve.
+ */
+
+/** Current cache key schema version. Bump when the key layout changes. */
+export const CACHE_KEY_VERSION = "v2";
+
+/** Field separator for the composite key. Never valid inside a CAIP-2 id. */
+const KEY_SEPARATOR = "|";
+
+export interface CachedResource {
+  resourceId: string;
+  /** Network the record was resolved against, e.g. "stellar:testnet". */
+  network: string;
+  /** Token contract the resource is priced in. Differs per network. */
+  asset: string;
+  /** Recipient address for the payment. Differs per network. */
+  payTo: string;
+  /** Price in raw token units. */
+  amount: bigint;
+}
+
+export interface ResourceLookup {
+  lookupResource(resourceId: string, network: string): Promise<CachedResource>;
+}
+
+export interface ResourceCacheOptions {
+  /** Entry lifetime. Defaults to 60s — resource pricing changes rarely. */
+  ttlMs?: number;
+  /** Injectable clock (tests). */
+  now?: () => number;
+}
+
+export interface ResourceCacheStats {
+  hits: number;
+  misses: number;
+  /** Entries dropped by the unscoped-key migration on construction. */
+  migratedEntries: number;
+}
+
+export interface NetworkScopedResourceCache extends ResourceCacheStats {
+  get(resourceId: string, network: string): Promise<CachedResource>;
+  /** Exposed so callers can inspect/pre-seed with the exact key layout. */
+  keyFor(resourceId: string, network: string): string;
+  /** Drop every entry cached for one network, leaving other networks intact. */
+  invalidateNetwork(network: string): number;
+  size(): number;
+}
+
+/**
+ * Builds the composite cache key. See the module comment for the format.
+ */
+export function buildResourceCacheKey(resourceId: string, network: string): string {
+  if (!network) {
+    throw new Error("x402 resource cache key requires a network identifier");
+  }
+  if (!resourceId) {
+    throw new Error("x402 resource cache key requires a resource id");
+  }
+  return `${CACHE_KEY_VERSION}${KEY_SEPARATOR}${network}${KEY_SEPARATOR}${resourceId}`;
+}
+
+/**
+ * Migration step: remove entries written before network scoping existed.
+ *
+ * A pre-#221 entry is keyed by the bare resource id, so it carries no version
+ * prefix and cannot be attributed to a network. There is no safe way to infer
+ * which network it came from, so it is deleted rather than rewritten — the next
+ * lookup repopulates it under the correct scoped key. Returns the number of
+ * entries removed so callers can log/report the one-off cost.
+ */
+export function clearUnscopedEntries(store: Map<string, unknown>): number {
+  const prefix = `${CACHE_KEY_VERSION}${KEY_SEPARATOR}`;
+  let removed = 0;
+  for (const key of [...store.keys()]) {
+    if (!key.startsWith(prefix)) {
+      store.delete(key);
+      removed++;
+    }
+  }
+  return removed;
+}
+
+export function createNetworkScopedResourceCache(
+  lookup: ResourceLookup,
+  store: Map<string, { expiresAt: number; value: CachedResource }> = new Map(),
+  options: ResourceCacheOptions = {},
+): NetworkScopedResourceCache {
+  const ttlMs = options.ttlMs ?? 60_000;
+  const now = options.now ?? Date.now;
+
+  // Run the migration once, at construction, against whatever the caller
+  // handed us (a persisted store may still hold pre-#221 unscoped keys).
+  const migratedEntries = clearUnscopedEntries(store);
+
+  let hits = 0;
+  let misses = 0;
+
+  return {
+    get hits() {
+      return hits;
+    },
+    get misses() {
+      return misses;
+    },
+    migratedEntries,
+
+    keyFor: buildResourceCacheKey,
+
+    size() {
+      return store.size;
+    },
+
+    invalidateNetwork(network) {
+      const prefix = `${CACHE_KEY_VERSION}${KEY_SEPARATOR}${network}${KEY_SEPARATOR}`;
+      let removed = 0;
+      for (const key of [...store.keys()]) {
+        if (key.startsWith(prefix)) {
+          store.delete(key);
+          removed++;
+        }
+      }
+      return removed;
+    },
+
+    async get(resourceId, network) {
+      const key = buildResourceCacheKey(resourceId, network);
+      const entry = store.get(key);
+      const t = now();
+      if (entry && entry.expiresAt > t) {
+        hits++;
+        return entry.value;
+      }
+
+      misses++;
+      const value = await lookup.lookupResource(resourceId, network);
+      store.set(key, { expiresAt: t + ttlMs, value });
+      return value;
+    },
+  };
+}


### PR DESCRIPTION
Four assigned issues, one commit each, all scoped to `contrib/` per CONTRIBUTING rule 3.

- **#221** — x402 resource cache keyed only by resource id collides across networks. Composite key `v2|<network>|<resourceId>`; version prefix drives the migration that drops unscoped entries.
- **#219** — policy deployment had no rollback. Saga tracks completed steps, compensates in reverse (revoke instance before deleting policy); failed compensations are logged without masking the original error.
- **#217** — `rpc.Server` exposes no agent hook, so keep-alive tuning lives in a wrapped fetch. Node gets a pooled dispatcher; browser gets nothing applied (`Connection` is a forbidden header).
- **#216** — N `balance(id)` reads collapse into one simulation, chunked at 20 invocations. Batch failure falls back to per-token reads to keep per-item error isolation; regression test pins the call count.

50 new tests, all passing. Pre-existing `src/tx-rpc.ts:102` typecheck/dts failure and the 16 baseline test failures are present unchanged on `dev` — this branch touches no `src/` file.

Closes #221
Closes #219
Closes #217
Closes #216