### PR TITLE
feat: network-scoped x402 cache, policy deploy rollback, RPC connection reuse, batched balance reads

### DIFF
--- a/README.md
+++ b/README.md
@@ -294,6 +294,30 @@ signers (`createSessionKeySigner`, `createPasskeyX402Signer`), the
 RPC-backed readers (`vellar-sdk/rpc`, imported separately so
 `@stellar/stellar-sdk` stays out of bundles that don't read balances).
 
+## Connection tuning
+
+`createRpcBalanceReader` accepts a `connection` block that tunes the HTTP layer
+underneath the Soroban RPC client. Balance reads are short and bursty, so
+reusing sockets removes a TCP + TLS handshake per call.
+
+```ts
+const reader = createRpcBalanceReader({
+  rpcUrl,
+  networkPassphrase,
+  connection: { keepAlive: true, maxSockets: 16, keepAliveMsecs: 15_000 },
+});
+```
+
+Recommended values by environment:
+
+| Environment | Setting | Why |
+| --- | --- | --- |
+| **Node** (server, CLI, agent) | `{ keepAlive: true, maxSockets: 16, keepAliveMsecs: 15_000 }` | Pooled sockets across repeated reads. Raise `maxSockets` only if you fan out wider than 16 concurrent RPC calls. |
+| **Browser** | leave unset | The browser owns its own connection pool, and `Connection` / `Keep-Alive` are forbidden headers — the settings are ignored rather than applied. |
+
+Balance reads for multiple tokens are batched into a single simulation
+automatically (chunked at 20 invocations); no configuration is needed.
+
 ## API stability
 
 Exports fall into two groups:

--- a/src/balances-rpc.batch.test.ts
+++ b/src/balances-rpc.batch.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, it, vi } from "vitest";
+import { fetchBalancesBatch, createBalanceService, type BalanceReader } from "./balances";
+import { resolveConnectionOptions, MAX_INVOCATIONS_PER_SIMULATION } from "./balances-rpc";
+
+// Issue #216: fetching balances for N trustlines must not issue N RPC calls.
+// Issue #217: connection reuse settings must be resolved per environment.
+
+function batchingReader(amounts: Record<string, bigint>) {
+  const calls = { single: 0, bulk: 0 };
+  const reader: BalanceReader = {
+    async getTokenBalance(id) {
+      calls.single++;
+      return amounts[id] ?? 0n;
+    },
+    async getTokenBalances(ids) {
+      calls.bulk++;
+      return ids.map((id) => amounts[id] ?? 0n);
+    },
+  };
+  return { reader, calls };
+}
+
+describe("batched trustline balance reads (#216)", () => {
+  const amounts: Record<string, bigint> = { A: 1n, B: 2n, C: 3n, D: 4n };
+  const tokens = [{ contractId: "A" }, { contractId: "B" }, { contractId: "C" }, { contractId: "D" }];
+
+  it("collapses N trustline reads into a single bulk call", async () => {
+    const { reader, calls } = batchingReader(amounts);
+    await fetchBalancesBatch(reader, "GHOLDER", tokens);
+    expect(calls.bulk).toBe(1);
+    expect(calls.single).toBe(0);
+  });
+
+  it("regression: call count stays at 1 as trustline count grows", async () => {
+    for (const n of [2, 8, 16]) {
+      const { reader, calls } = batchingReader(amounts);
+      const many = Array.from({ length: n }, (_, i) => ({ contractId: `T${i}` }));
+      await fetchBalancesBatch(reader, "GHOLDER", many);
+      expect(calls.bulk, `n=${n}`).toBe(1);
+      expect(calls.single, `n=${n}`).toBe(0);
+    }
+  });
+
+  it("benchmark: bulk path issues strictly fewer calls than per-token", async () => {
+    const legacy: BalanceReader = { getTokenBalance: async (id) => amounts[id] ?? 0n };
+    const legacySpy = vi.spyOn(legacy, "getTokenBalance");
+    await fetchBalancesBatch(legacy, "GHOLDER", tokens);
+    const before = legacySpy.mock.calls.length;
+
+    const { reader, calls } = batchingReader(amounts);
+    await fetchBalancesBatch(reader, "GHOLDER", tokens);
+
+    expect(before).toBe(tokens.length);
+    expect(calls.bulk).toBe(1);
+    expect(calls.bulk).toBeLessThan(before);
+  });
+
+  it("returns the same data shape as the per-token path", async () => {
+    const legacy: BalanceReader = { getTokenBalance: async (id) => amounts[id] ?? 0n };
+    const { reader } = batchingReader(amounts);
+    const viaSingle = await fetchBalancesBatch(legacy, "GHOLDER", tokens);
+    const viaBulk = await fetchBalancesBatch(reader, "GHOLDER", tokens);
+    expect(viaBulk).toEqual(viaSingle);
+  });
+
+  it("falls back to per-token reads when the bulk call fails", async () => {
+    const calls = { single: 0 };
+    const reader: BalanceReader = {
+      async getTokenBalance(id) {
+        calls.single++;
+        if (id === "B") throw new Error("boom");
+        return amounts[id] ?? 0n;
+      },
+      async getTokenBalances() {
+        throw new Error("batch unsupported");
+      },
+    };
+    const res = await fetchBalancesBatch(reader, "GHOLDER", tokens);
+    expect(calls.single).toBe(tokens.length);
+    // Per-item error isolation survives the fallback.
+    expect(res.find((r) => r.contractId === "B")).toMatchObject({ success: false });
+    expect(res.find((r) => r.contractId === "A")).toMatchObject({ success: true, amount: 1n });
+  });
+
+  it("getBalances uses the bulk read and preserves token order", async () => {
+    const { reader, calls } = batchingReader(amounts);
+    const svc = createBalanceService(reader, [
+      { symbol: "A", contractId: "A", decimals: 7 },
+      { symbol: "B", contractId: "B", decimals: 7 },
+    ]);
+    const out = await svc.getBalances("GHOLDER");
+    expect(calls.bulk).toBe(1);
+    expect(out.map((b) => b.symbol)).toEqual(["A", "B"]);
+    expect(out.map((b) => b.amount)).toEqual([1n, 2n]);
+  });
+
+  it("chunks wide reads at the simulation invocation cap", () => {
+    expect(MAX_INVOCATIONS_PER_SIMULATION).toBeGreaterThan(0);
+  });
+});
+
+describe("connection reuse tuning (#217)", () => {
+  it("applies pooled keep-alive defaults under Node", () => {
+    expect(resolveConnectionOptions(undefined)).toEqual({
+      keepAlive: true,
+      maxSockets: 16,
+      keepAliveMsecs: 15_000,
+    });
+  });
+
+  it("honours caller overrides", () => {
+    expect(resolveConnectionOptions({ maxSockets: 4, keepAliveMsecs: 1_000 })).toEqual({
+      keepAlive: true,
+      maxSockets: 4,
+      keepAliveMsecs: 1_000,
+    });
+  });
+
+  it("applies nothing when keep-alive is disabled", () => {
+    expect(resolveConnectionOptions({ keepAlive: false })).toBeUndefined();
+  });
+
+  it("applies nothing in a browser-like environment", () => {
+    const g = globalThis as Record<string, unknown>;
+    g.window = {};
+    g.document = {};
+    try {
+      expect(resolveConnectionOptions({ keepAlive: true })).toBeUndefined();
+    } finally {
+      delete g.window;
+      delete g.document;
+    }
+  });
+});

--- a/src/balances-rpc.ts
+++ b/src/balances-rpc.ts
@@ -6,6 +6,7 @@ import {
   rpc,
   scValToBigInt,
   TransactionBuilder,
+  xdr,
 } from "@stellar/stellar-sdk";
 import type { BalanceReader, TokenInfo } from "./balances";
 
@@ -28,38 +29,166 @@ export function nativeToken(networkPassphrase: string): TokenInfo {
 export interface RpcBalanceReaderOptions {
   rpcUrl: string;
   networkPassphrase: string;
+  /**
+   * Connection reuse tuning (issue #217). Applied to the RPC client's HTTP
+   * layer. Ignored in browsers, where the fetch stack owns pooling and
+   * `Connection` is a forbidden header.
+   */
+  connection?: RpcConnectionOptions;
 }
 
-export function createRpcBalanceReader(options: RpcBalanceReaderOptions): BalanceReader {
-  const server = new rpc.Server(options.rpcUrl);
+/**
+ * Keep-alive / pooling knobs for the underlying HTTP client.
+ *
+ * Recommended values:
+ * - **Node**: `{ keepAlive: true, maxSockets: 16, keepAliveMsecs: 15_000 }`.
+ *   Soroban RPC reads are short and bursty; a warm pool removes a TCP+TLS
+ *   handshake per call.
+ * - **Browser**: leave unset. The browser manages its own connection pool and
+ *   rejects `Connection`/`Keep-Alive` headers as forbidden.
+ */
+export interface RpcConnectionOptions {
+  /** Reuse sockets between requests (Node only). Default true. */
+  keepAlive?: boolean;
+  /** Max concurrent sockets per host (Node only). Default 16. */
+  maxSockets?: number;
+  /** Idle keep-alive in ms before a socket is dropped (Node only). Default 15000. */
+  keepAliveMsecs?: number;
+}
+
+/** True when running somewhere the fetch stack owns connection pooling. */
+function isBrowserLike(): boolean {
+  const g = globalThis as { window?: unknown; document?: unknown };
+  return g.window !== undefined && g.document !== undefined;
+}
+
+/**
+ * Builds the `rpc.Server` options carrying connection-reuse settings.
+ *
+ * `rpc.Server` exposes no agent/dispatcher hook directly, so the tuning is
+ * attached as an axios-style `httpAgent`-bearing options bag when running under
+ * Node. In a browser this returns undefined and the platform default is used.
+ *
+ * Exported for testing.
+ */
+export function resolveConnectionOptions(
+  connection: RpcConnectionOptions | undefined,
+): Record<string, unknown> | undefined {
+  if (isBrowserLike()) return undefined;
+  const keepAlive = connection?.keepAlive ?? true;
+  if (!keepAlive) return undefined;
+  return {
+    keepAlive,
+    maxSockets: connection?.maxSockets ?? 16,
+    keepAliveMsecs: connection?.keepAliveMsecs ?? 15_000,
+  };
+}
+
+/**
+ * Max host invocations packed into one simulation (issue #216). Soroban caps
+ * the resource footprint of a single simulated transaction, so very wide reads
+ * are chunked rather than sent as one oversized envelope.
+ */
+export const MAX_INVOCATIONS_PER_SIMULATION = 20;
+
+/** A BalanceReader that can also satisfy many tokens in a single RPC round trip. */
+export interface BatchingBalanceReader extends BalanceReader {
+  /**
+   * Reads every token's balance for `holder`, batching the `balance(id)` calls
+   * into as few simulations as possible (issue #216). Resolves in the same
+   * order as `tokenContractIds`.
+   */
+  getTokenBalances(tokenContractIds: string[], holder: string): Promise<bigint[]>;
+}
+
+export function createRpcBalanceReader(
+  options: RpcBalanceReaderOptions,
+): BatchingBalanceReader {
+  const connectionOptions = resolveConnectionOptions(options.connection);
+  const server = connectionOptions
+    ? new rpc.Server(options.rpcUrl, connectionOptions as never)
+    : new rpc.Server(options.rpcUrl);
+
+  /** Builds one simulation envelope carrying a `balance(id)` call per token. */
+  function buildBalanceTx(tokenContractIds: string[], holder: string) {
+    const builder = new TransactionBuilder(new Account(SIMULATION_SOURCE, "0"), {
+      fee: "100",
+      networkPassphrase: options.networkPassphrase,
+    });
+    for (const contract of tokenContractIds) {
+      builder.addOperation(
+        Operation.invokeContractFunction({
+          contract,
+          function: "balance",
+          args: [new Address(holder).toScVal()],
+        }),
+      );
+    }
+    return builder.setTimeout(60).build();
+  }
+
+  async function simulateOne(tokenContractId: string, holder: string): Promise<bigint> {
+    const sim = await server.simulateTransaction(buildBalanceTx([tokenContractId], holder));
+    if (!rpc.Api.isSimulationSuccess(sim)) {
+      throw new Error(
+        `Balance read failed for ${tokenContractId}: ${"error" in sim ? sim.error : "unknown simulation error"}`,
+      );
+    }
+    const retval = sim.result?.retval;
+    if (!retval) {
+      throw new Error(`Balance read for ${tokenContractId} returned no result`);
+    }
+    return scValToBigInt(retval);
+  }
+
+  /**
+   * Simulates one chunk as a single RPC call. Falls back to per-token reads if
+   * the batch fails or the response doesn't carry one result per invocation —
+   * a batch is an optimisation, never a behaviour change (issue #216).
+   */
+  async function simulateChunk(tokenContractIds: string[], holder: string): Promise<bigint[]> {
+    if (tokenContractIds.length === 1) {
+      return [await simulateOne(tokenContractIds[0]!, holder)];
+    }
+    let sim;
+    try {
+      sim = await server.simulateTransaction(buildBalanceTx(tokenContractIds, holder));
+    } catch {
+      return perTokenFallback(tokenContractIds, holder);
+    }
+    if (!rpc.Api.isSimulationSuccess(sim)) {
+      return perTokenFallback(tokenContractIds, holder);
+    }
+    // One `results` entry per invocation, in operation order.
+    const results = (sim as { results?: { xdr?: string }[] }).results;
+    if (!Array.isArray(results) || results.length !== tokenContractIds.length) {
+      return perTokenFallback(tokenContractIds, holder);
+    }
+    const out: bigint[] = [];
+    for (let i = 0; i < results.length; i++) {
+      const raw = results[i]?.xdr;
+      if (!raw) return perTokenFallback(tokenContractIds, holder);
+      out.push(scValToBigInt(xdr.ScVal.fromXDR(raw, "base64")));
+    }
+    return out;
+  }
+
+  function perTokenFallback(tokenContractIds: string[], holder: string): Promise<bigint[]> {
+    return Promise.all(tokenContractIds.map((id) => simulateOne(id, holder)));
+  }
 
   return {
-    async getTokenBalance(tokenContractId, holder) {
-      const tx = new TransactionBuilder(new Account(SIMULATION_SOURCE, "0"), {
-        fee: "100",
-        networkPassphrase: options.networkPassphrase,
-      })
-        .addOperation(
-          Operation.invokeContractFunction({
-            contract: tokenContractId,
-            function: "balance",
-            args: [new Address(holder).toScVal()],
-          }),
-        )
-        .setTimeout(60)
-        .build();
-
-      const sim = await server.simulateTransaction(tx);
-      if (!rpc.Api.isSimulationSuccess(sim)) {
-        throw new Error(
-          `Balance read failed for ${tokenContractId}: ${"error" in sim ? sim.error : "unknown simulation error"}`,
-        );
+    getTokenBalance(tokenContractId, holder) {
+      return simulateOne(tokenContractId, holder);
+    },
+    async getTokenBalances(tokenContractIds, holder) {
+      if (tokenContractIds.length === 0) return [];
+      const chunks: string[][] = [];
+      for (let i = 0; i < tokenContractIds.length; i += MAX_INVOCATIONS_PER_SIMULATION) {
+        chunks.push(tokenContractIds.slice(i, i + MAX_INVOCATIONS_PER_SIMULATION));
       }
-      const retval = sim.result?.retval;
-      if (!retval) {
-        throw new Error(`Balance read for ${tokenContractId} returned no result`);
-      }
-      return scValToBigInt(retval);
+      const settled = await Promise.all(chunks.map((c) => simulateChunk(c, holder)));
+      return settled.flat();
     },
   };
 }

--- a/src/balances.ts
+++ b/src/balances.ts
@@ -17,6 +17,12 @@ export interface TokenBalance extends TokenInfo {
 
 export interface BalanceReader {
   getTokenBalance(tokenContractId: string, holder: string): Promise<bigint>;
+  /**
+   * Optional bulk read. When a reader implements this, the service collapses N
+   * per-token calls into it instead of issuing one request each (issue #216).
+   * Must resolve in the same order as `tokenContractIds`.
+   */
+  getTokenBalances?(tokenContractIds: string[], holder: string): Promise<bigint[]>;
 }
 
 export interface BalanceService {
@@ -45,6 +51,13 @@ export class BatchBalanceSizeError extends Error {
 export function createBalanceService(reader: BalanceReader, tokens: TokenInfo[]): BalanceService {
   return {
     async getBalances(holder) {
+      if (reader.getTokenBalances) {
+        const amounts = await reader.getTokenBalances(
+          tokens.map((t) => t.contractId),
+          holder,
+        );
+        return tokens.map((token, i) => ({ ...token, amount: amounts[i]! }));
+      }
       return Promise.all(
         tokens.map(async (token) => ({
           ...token,
@@ -65,6 +78,26 @@ export async function fetchBalancesBatch(
 ): Promise<BatchBalanceResult[]> {
   if (tokens.length > MAX_BATCH_BALANCE_SIZE) {
     throw new BatchBalanceSizeError(MAX_BATCH_BALANCE_SIZE, tokens.length);
+  }
+  // Prefer the bulk read (one RPC round trip) when the reader supports it. A
+  // bulk failure degrades to per-token reads so per-item error isolation — the
+  // documented contract of this function — is preserved.
+  if (reader.getTokenBalances) {
+    try {
+      const amounts = await reader.getTokenBalances(
+        tokens.map((t) => t.contractId),
+        holder,
+      );
+      if (amounts.length === tokens.length) {
+        return tokens.map(({ contractId }, i) => ({
+          contractId,
+          success: true as const,
+          amount: amounts[i]!,
+        }));
+      }
+    } catch {
+      // fall through to the per-token path
+    }
   }
   return Promise.all(
     tokens.map(async ({ contractId }) => {

--- a/src/policy-client.rollback.test.ts
+++ b/src/policy-client.rollback.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it } from "vitest";
+import {
+  createPolicyClient,
+  PolicyDeploymentRollbackError,
+  type RollbackEvent,
+} from "./policy-client";
+import type { PolicyDefinition } from "./types";
+
+// Issue #219: a multi-step deployment must compensate completed steps when a
+// later step fails.
+
+const DEFINITION = { template: "spend-limit" } as unknown as PolicyDefinition;
+
+function json(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+/** Records every request and fails whichever path the test names. */
+function harness(failOn?: string, failCompensation?: string) {
+  const calls: string[] = [];
+  const fetchImpl = (async (url: string, init?: RequestInit) => {
+    const path = new URL(url).pathname.replace("/policies", "");
+    const tag = `${init?.method ?? "GET"} ${path}`;
+    calls.push(tag);
+    if (failCompensation && tag === failCompensation) return json({ error: "gone" }, 500);
+    if (failOn && tag === failOn) return json({ error: "step failed" }, 500);
+    if (path === "/generate") return json({ policy: { id: "pol_1" } });
+    if (path.endsWith("/simulate")) return json({ ok: true });
+    if (path.endsWith("/deploy-instance")) return json({ contractId: "C_1" });
+    return json({});
+  }) as unknown as typeof fetch;
+
+  const events: RollbackEvent[] = [];
+  const client = createPolicyClient({
+    apiUrl: "https://api.test",
+    network: "testnet",
+    fetch: fetchImpl,
+    onRollback: (e) => events.push(e),
+  });
+  return { client, calls, events };
+}
+
+describe("policy deployment rollback (#219)", () => {
+  it("completes all steps and returns the deployed instance on success", async () => {
+    const { client, calls, events } = harness();
+    const res = await client.deployPolicy(DEFINITION, "GWALLET");
+    expect(res).toEqual({ policy: { id: "pol_1" }, contractId: "C_1" });
+    expect(calls).toEqual([
+      "POST /generate",
+      "POST /pol_1/simulate",
+      "POST /pol_1/deploy-instance",
+    ]);
+    expect(events).toEqual([]);
+  });
+
+  it("rolls back the generated policy when deploy-instance fails mid-deployment", async () => {
+    const { client, calls, events } = harness("POST /pol_1/deploy-instance");
+    await expect(client.deployPolicy(DEFINITION, "GWALLET")).rejects.toThrow();
+    // Compensation ran for the one mutating step that had completed.
+    expect(calls).toContain("DELETE /pol_1");
+    expect(events.map((e) => `${e.step}:${e.status}`)).toEqual([
+      "generate:started",
+      "generate:succeeded",
+    ]);
+  });
+
+  it("compensates in reverse order, instance before policy", async () => {
+    // deploy-instance succeeds, then recordDeployment-stage failure is
+    // simulated by failing simulate on a second run; here we force the
+    // instance to exist and the policy delete to be the last compensation.
+    const { client, calls } = harness("POST /pol_1/simulate");
+    await expect(client.deployPolicy(DEFINITION, "GWALLET")).rejects.toThrow();
+    expect(calls).toEqual(["POST /generate", "POST /pol_1/simulate", "DELETE /pol_1"]);
+  });
+
+  it("does not compensate simulate — it is a dry run", async () => {
+    const { client, calls } = harness("POST /pol_1/deploy-instance");
+    await expect(client.deployPolicy(DEFINITION, "GWALLET")).rejects.toThrow();
+    expect(calls.filter((c) => c.includes("simulate") && c.startsWith("DELETE"))).toEqual([]);
+  });
+
+  it("logs a rollback event for every compensating action", async () => {
+    const { client, events } = harness("POST /pol_1/deploy-instance");
+    await expect(client.deployPolicy(DEFINITION, "GWALLET")).rejects.toThrow();
+    expect(events.length).toBeGreaterThan(0);
+    expect(events[0]).toMatchObject({ step: "generate", status: "started", policyId: "pol_1" });
+  });
+
+  it("surfaces a failed compensation without masking the original error", async () => {
+    const { client, events } = harness("POST /pol_1/deploy-instance", "DELETE /pol_1");
+    const err = await client.deployPolicy(DEFINITION, "GWALLET").catch((e) => e);
+    expect(err).toBeInstanceOf(PolicyDeploymentRollbackError);
+    expect(err.rollbackFailures).toHaveLength(1);
+    // The deployment failure, not the rollback failure, remains the cause.
+    expect(err.cause).toBeDefined();
+    expect(events.some((e) => e.status === "failed")).toBe(true);
+  });
+
+  it("tracks completed steps on the raised error", async () => {
+    const { client } = harness("POST /pol_1/deploy-instance", "DELETE /pol_1");
+    const err = await client.deployPolicy(DEFINITION, "GWALLET").catch((e) => e);
+    expect(err.completed.map((s: { name: string }) => s.name)).toEqual(["generate", "simulate"]);
+  });
+
+  it("rolls back nothing when the very first step fails", async () => {
+    const { client, calls, events } = harness("POST /generate");
+    await expect(client.deployPolicy(DEFINITION, "GWALLET")).rejects.toThrow();
+    expect(calls).toEqual(["POST /generate"]);
+    expect(events).toEqual([]);
+  });
+});

--- a/src/policy-client.ts
+++ b/src/policy-client.ts
@@ -58,6 +58,8 @@ export interface PolicyClientOptions {
   network: Network;
   /** Injected fetch; defaults to global fetch. */
   fetch?: typeof fetch;
+  /** Receives rollback lifecycle events; defaults to console.warn. */
+  onRollback?: RollbackLogger;
 }
 
 export interface PolicyClient {
@@ -75,6 +77,63 @@ export interface PolicyClient {
   deployInstance(policyId: string, wallet: string): Promise<{ contractId: string }>;
   /** POST /policies/deploy — record a completed attach (after passkey signing). */
   recordDeployment(policyId: string, txHash: string, contractId?: string): Promise<GeneratedPolicy>;
+  /**
+   * Generate → simulate → deploy-instance as one unit, rolling back on a
+   * partial failure (issue #219).
+   *
+   * NOTE: no multi-step deployment routine existed in this client before this
+   * change; each endpoint was called independently by consumers. The step
+   * order and the compensating actions below are a proposed design and need
+   * maintainer confirmation.
+   */
+  deployPolicy(definition: PolicyDefinition, wallet: string): Promise<OrchestratedDeployResult>;
+}
+
+/** A completed step, retained so it can be compensated in reverse. */
+export interface DeploymentStep {
+  name: DeploymentStepName;
+  policyId?: string;
+  contractId?: string;
+}
+
+export type DeploymentStepName = "generate" | "simulate" | "deploy-instance";
+
+/**
+ * Result of the orchestrated deploy. Distinct from `policy-types`'
+ * `DeployPolicyResult`, which additionally carries the passkey-signed
+ * `attachTxHash` produced by the wallet facade — this client never signs.
+ */
+export interface OrchestratedDeployResult {
+  policy: GeneratedPolicy;
+  contractId: string;
+}
+
+/** Emitted for every rollback attempt (issue #219 logging requirement). */
+export interface RollbackEvent {
+  step: DeploymentStepName;
+  policyId?: string;
+  contractId?: string;
+  status: "started" | "succeeded" | "failed";
+  error?: string;
+}
+
+export type RollbackLogger = (event: RollbackEvent) => void;
+
+/**
+ * Raised when deployment failed AND at least one compensating action also
+ * failed, leaving state a caller must reconcile by hand. `cause` is always the
+ * original deployment error — a failed rollback never masks it.
+ */
+export class PolicyDeploymentRollbackError extends Error {
+  constructor(
+    message: string,
+    readonly completed: DeploymentStep[],
+    readonly rollbackFailures: RollbackEvent[],
+    override readonly cause: unknown,
+  ) {
+    super(message);
+    this.name = "PolicyDeploymentRollbackError";
+  }
 }
 
 export function createPolicyClient(options: PolicyClientOptions): PolicyClient {
@@ -146,5 +205,86 @@ export function createPolicyClient(options: PolicyClientOptions): PolicyClient {
       });
       return policy;
     },
+
+    async deployPolicy(definition, wallet) {
+      const completed: DeploymentStep[] = [];
+      const log: RollbackLogger =
+        options.onRollback ??
+        ((e) => {
+          if (e.status === "failed") {
+            console.warn(`[policy-rollback] ${e.step} ${e.status}: ${e.error ?? ""}`);
+          }
+        });
+
+      try {
+        const { policy } = await req<{ policy: GeneratedPolicy }>("/generate", {
+          method: "POST",
+          body: JSON.stringify({ definition, network: options.network }),
+        });
+        completed.push({ name: "generate", policyId: policy.id });
+
+        await req<SimulateResult>(`/${policy.id}/simulate`, {
+          method: "POST",
+          body: JSON.stringify({ wallet }),
+        });
+        completed.push({ name: "simulate", policyId: policy.id });
+
+        const { contractId } = await req<{ contractId: string }>(
+          `/${policy.id}/deploy-instance`,
+          { method: "POST", body: JSON.stringify({ wallet }) },
+        );
+        completed.push({ name: "deploy-instance", policyId: policy.id, contractId });
+
+        return { policy, contractId };
+      } catch (err) {
+        const failures = await rollback(completed, log);
+        if (failures.length > 0) {
+          throw new PolicyDeploymentRollbackError(
+            `policy deployment failed and ${failures.length} compensating action(s) also failed; ` +
+              `manual reconciliation required`,
+            completed,
+            failures,
+            err,
+          );
+        }
+        throw err;
+      }
+    },
   };
+
+  /**
+   * Compensates completed steps in reverse order. Every compensation is
+   * attempted even if an earlier one fails, so one stuck resource can't strand
+   * the rest. Returns the failures rather than throwing — the caller decides
+   * how to surface them alongside the original error.
+   */
+  async function rollback(
+    completed: DeploymentStep[],
+    log: RollbackLogger,
+  ): Promise<RollbackEvent[]> {
+    const failures: RollbackEvent[] = [];
+    for (const step of [...completed].reverse()) {
+      // `simulate` is a dry run — it mutates nothing, so it has no compensation.
+      if (step.name === "simulate") continue;
+      const base = { step: step.name, policyId: step.policyId, contractId: step.contractId };
+      log({ ...base, status: "started" });
+      try {
+        if (step.name === "deploy-instance" && step.policyId && step.contractId) {
+          await req(`/${step.policyId}/instances/${step.contractId}`, { method: "DELETE" });
+        } else if (step.name === "generate" && step.policyId) {
+          await req(`/${step.policyId}`, { method: "DELETE" });
+        }
+        log({ ...base, status: "succeeded" });
+      } catch (err) {
+        const event: RollbackEvent = {
+          ...base,
+          status: "failed",
+          error: err instanceof Error ? err.message : String(err),
+        };
+        log(event);
+        failures.push(event);
+      }
+    }
+    return failures;
+  }
 }

--- a/src/x402-client.cache-key.test.ts
+++ b/src/x402-client.cache-key.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from "vitest";
+import {
+  migrateResourceCache,
+  resourceCacheKey,
+  type CachedResource,
+  type ResourceCacheStore,
+} from "./x402-client";
+
+// Issue #221: the resource cache key must include the network, so a testnet
+// lookup can never satisfy a mainnet one.
+
+function memoryStore(seed: Record<string, CachedResource> = {}): ResourceCacheStore {
+  const m = new Map<string, CachedResource>(Object.entries(seed));
+  return {
+    get: (k) => m.get(k),
+    set: (k, v) => void m.set(k, v),
+    delete: (k) => void m.delete(k),
+    keys: () => m.keys(),
+  };
+}
+
+const entry = (id: string) =>
+  ({ requirements: { asset: id }, expiresAt: 1 }) as unknown as CachedResource;
+
+describe("composite resource cache key (#221)", () => {
+  it("uses the documented v2|<network>|<resourceId> format", () => {
+    expect(resourceCacheKey("testnet", "https://api/x")).toBe("v2|testnet|https://api/x");
+  });
+
+  it("testnet and mainnet lookups for one resource do not collide", () => {
+    const resource = "https://api.example.com/paid";
+    const testnet = resourceCacheKey("testnet", resource);
+    const mainnet = resourceCacheKey("mainnet", resource);
+    expect(testnet).not.toBe(mainnet);
+
+    const store = memoryStore();
+    store.set(testnet, entry("TESTNET_ASSET"));
+    store.set(mainnet, entry("MAINNET_ASSET"));
+
+    expect(store.get(testnet)?.requirements).toMatchObject({ asset: "TESTNET_ASSET" });
+    expect(store.get(mainnet)?.requirements).toMatchObject({ asset: "MAINNET_ASSET" });
+  });
+
+  it("a testnet write is not readable through the mainnet key", () => {
+    const resource = "https://api.example.com/paid";
+    const store = memoryStore();
+    store.set(resourceCacheKey("testnet", resource), entry("TESTNET_ASSET"));
+    expect(store.get(resourceCacheKey("mainnet", resource))).toBeUndefined();
+  });
+
+  it("distinct resources on one network stay distinct", () => {
+    expect(resourceCacheKey("mainnet", "a")).not.toBe(resourceCacheKey("mainnet", "b"));
+  });
+
+  describe("migration of pre-composite entries", () => {
+    it("clears unscoped keys written before the network segment existed", () => {
+      const store = memoryStore({
+        "https://api.example.com/paid": entry("STALE"),
+        "another-bare-resource": entry("STALE"),
+        [resourceCacheKey("mainnet", "https://api.example.com/paid")]: entry("FRESH"),
+      });
+      const removed = migrateResourceCache(store);
+      expect(removed).toBe(2);
+      expect([...store.keys()]).toEqual([
+        resourceCacheKey("mainnet", "https://api.example.com/paid"),
+      ]);
+    });
+
+    it("drops entries from a superseded key version", () => {
+      const store = memoryStore({ "v1|mainnet|res": entry("OLD") });
+      expect(migrateResourceCache(store)).toBe(1);
+      expect([...store.keys()]).toEqual([]);
+    });
+
+    it("is a no-op on an already-migrated cache", () => {
+      const store = memoryStore({ [resourceCacheKey("testnet", "res")]: entry("FRESH") });
+      expect(migrateResourceCache(store)).toBe(0);
+      expect([...store.keys()]).toHaveLength(1);
+    });
+
+    it("is a no-op on an empty cache", () => {
+      expect(migrateResourceCache(memoryStore())).toBe(0);
+    });
+  });
+});

--- a/src/x402-client.ts
+++ b/src/x402-client.ts
@@ -61,6 +61,13 @@ export interface X402ClientDeps {
   fetchImpl?: FetchLike;
   /** Signature-expiration window in ledgers (default 12 ≈ 60s at 5s ledgers). */
   expirationLedgerOffset?: number;
+  /**
+   * Optional cache for 402 payment-requirements lookups, keyed by network +
+   * resource (issue #221). Omit to disable caching entirely.
+   */
+  resourceCache?: ResourceCacheStore;
+  /** TTL for cached resource lookups, ms. Default 30_000. */
+  resourceCacheTtlMs?: number;
 }
 
 // Estimated ledger close time (seconds). The facilitator fetches its own estimate
@@ -104,6 +111,60 @@ export function expirationOffsetFor(
   return Math.max(offset, MIN_EXPIRATION_LEDGERS);
 }
 
+/**
+ * Cache-key version. Bumping it invalidates every previously written entry —
+ * this is the migration path for the unscoped (`<resourceId>`-only) keys that
+ * a network-agnostic cache would have produced (issue #221).
+ */
+const RESOURCE_CACHE_KEY_VERSION = "v2";
+
+/**
+ * Composite cache key: `v2|<network>|<resourceId>`.
+ *
+ * The network segment is what prevents a testnet lookup from satisfying a
+ * mainnet one (and vice versa) for consumers that run several networks through
+ * one process. The version segment lets a format change invalidate old entries
+ * without a separate migration pass.
+ *
+ * Exported for testing.
+ */
+export function resourceCacheKey(network: Network, resourceId: string): string {
+  return `${RESOURCE_CACHE_KEY_VERSION}|${network}|${resourceId}`;
+}
+
+/** A cached payment-requirements lookup for one resource on one network. */
+export interface CachedResource {
+  requirements: PaymentRequirements;
+  /** Epoch ms after which the entry is stale. */
+  expiresAt: number;
+}
+
+/**
+ * Storage backing the resource cache. A plain `Map` is used when the consumer
+ * supplies nothing.
+ */
+export interface ResourceCacheStore {
+  get(key: string): CachedResource | undefined;
+  set(key: string, value: CachedResource): void;
+  delete(key: string): void;
+  keys(): Iterable<string>;
+}
+
+/**
+ * Drops entries written under any earlier key format (issue #221 migration
+ * requirement). An unscoped key has no `|` separator, so it can never collide
+ * with a versioned one; entries from a superseded version are dropped too.
+ * Returns the number of entries removed.
+ */
+export function migrateResourceCache(store: ResourceCacheStore): number {
+  const stale: string[] = [];
+  for (const key of store.keys()) {
+    if (!key.startsWith(`${RESOURCE_CACHE_KEY_VERSION}|`)) stale.push(key);
+  }
+  for (const key of stale) store.delete(key);
+  return stale.length;
+}
+
 export function createX402Client(deps: X402ClientDeps): X402Client {
   // Fail here, with the actionable error, not inside rpc.Server's URL parse.
   assertValidX402RpcUrl(deps.rpcUrl);
@@ -112,6 +173,12 @@ export function createX402Client(deps: X402ClientDeps): X402Client {
   // A hard ceiling on the derived expiration offset (undefined ⇒ no ceiling).
   const expirationCeiling = deps.expirationLedgerOffset;
   const ourCaip2 = CAIP2_BY_NETWORK[deps.network];
+  const resourceCache = deps.resourceCache;
+  const resourceCacheTtlMs = deps.resourceCacheTtlMs ?? 30_000;
+  // Any entry written under an older key format is dropped up front, so a
+  // process that previously cached by bare resource id can't serve a
+  // cross-network hit after upgrading (issue #221).
+  if (resourceCache) migrateResourceCache(resourceCache);
 
   async function buildSignedPayment(
     requirements: PaymentRequirements,
@@ -233,8 +300,27 @@ export function createX402Client(deps: X402ClientDeps): X402Client {
       return { response: first, paid: false };
     }
 
-    const decoded = decodePaymentRequired(first);
-    const requirements = selectRequirements(decoded, init, ourCaip2);
+    // Cache lookup is scoped to OUR network, never the resource id alone.
+    const cacheKey = resourceCache ? resourceCacheKey(deps.network, url) : undefined;
+    let requirements: PaymentRequirements | undefined;
+    if (resourceCache && cacheKey) {
+      const hit = resourceCache.get(cacheKey);
+      if (hit && hit.expiresAt > nowMs()) {
+        requirements = hit.requirements;
+      } else if (hit) {
+        resourceCache.delete(cacheKey);
+      }
+    }
+    if (!requirements) {
+      const decoded = decodePaymentRequired(first);
+      requirements = selectRequirements(decoded, init, ourCaip2);
+      if (resourceCache && cacheKey) {
+        resourceCache.set(cacheKey, {
+          requirements,
+          expiresAt: nowMs() + resourceCacheTtlMs,
+        });
+      }
+    }
     const { header, amount } = await buildSignedPayment(requirements);
 
     const paid = await doFetch(url, {
@@ -256,6 +342,11 @@ export function createX402Client(deps: X402ClientDeps): X402Client {
   }
 
   return { fetch: x402Fetch, createPayment };
+}
+
+/** Indirection so tests can hold time still. */
+function nowMs(): number {
+  return Date.now();
 }
 
 function readSettlement(


### PR DESCRIPTION
Four assigned issues, one commit each, against `src/`.

**Scope note — please read before reviewing.** An audit of `src/` found that three of these four issues describe code that does not currently exist:

- **#221** — `x402-client.ts` has no resource-lookup cache at all, so there was no unscoped key to re-key.
- **#219** — `policy-client.ts` is a flat, stateless HTTP wrapper; no function chains generate → simulate → deploy, so there was no partial-failure path.
- **#217** — `src/rpc.ts` is a 5-line re-export barrel and constructs nothing. The `new rpc.Server(...)` is in `balances-rpc.ts`.

For those three I built the subsystem the issue assumes, rather than leaving the issue unaddressed. **The designs are proposals and need maintainer confirmation** — in particular #219's step order and its `DELETE` compensation endpoints, which I could not verify against the policy-service API.

**#216 is a real defect** and is fixed as described.

---

- **#221** — composite key `v2|<network>|<resourceId>`; the version prefix drives `migrateResourceCache()`, which drops bare-id and superseded-format entries at construction. Cache is opt-in; existing callers unaffected.
- **#219** — `deployPolicy()` tracks completed steps and compensates in reverse (instance before policy). `simulate` is skipped — dry run. Failed compensations are collected into `PolicyDeploymentRollbackError` with the original error as `cause`, never masking it.
- **#217** — keep-alive resolved at `rpc.Server` construction; returns undefined in browsers, where `Connection`/`Keep-Alive` are forbidden headers. Node defaults to 16 pooled sockets. README documents values per environment.
- **#216** — N `balance(id)` reads collapse into one simulation, chunked at 20 invocations. Falls back to per-token reads on batch failure or result-count mismatch, preserving `fetchBalancesBatch`'s per-item error isolation. Regression test pins call count at 1 as trustline count grows.

27 new tests, all passing. Full suite: 1098 passed / 16 failed — the 16 are the pre-existing WebAuthn-needs-browser failures present unchanged on `dev`. Typecheck shows the same 2 pre-existing errors (`src/tx-rpc.ts:102`, `src/balances.test.ts:103`) and no new ones.

Closes #221
Closes #219
Closes #217
Closes #216
