### PR TITLE
feat: add fallback RPC endpoint routing for tx-rpc read calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -294,6 +294,39 @@ signers (`createSessionKeySigner`, `createPasskeyX402Signer`), the
 RPC-backed readers (`vellar-sdk/rpc`, imported separately so
 `@stellar/stellar-sdk` stays out of bundles that don't read balances).
 
+### RPC fallback endpoints
+
+`createRpcTxStatusReader` supports a prioritized list of fallback RPC
+endpoints. If the primary endpoint times out or returns a network error,
+the reader automatically retries on the next endpoint in the list.
+
+```ts
+import { createRpcTxStatusReader } from "vellar-sdk/rpc";
+
+// Single endpoint (backward compatible):
+const reader = createRpcTxStatusReader({
+  rpcUrl: "https://rpc.example.com",
+});
+
+// Multiple endpoints with fallback:
+const reader = createRpcTxStatusReader({
+  endpoints: [
+    { url: "https://primary-rpc.example.com", timeoutMs: 5_000 },
+    { url: "https://backup-rpc.example.com", timeoutMs: 10_000 },
+    { url: "https://emergency-rpc.example.com" }, // uses defaultTimeoutMs
+  ],
+  defaultTimeoutMs: 10_000,
+});
+```
+
+Each endpoint in the `endpoints` array can specify its own `timeoutMs`. The
+reader falls back on timeouts, connection errors (`ECONNREFUSED`,
+`ECONNRESET`, `ENOTFOUND`, socket hang up), and HTTP 5xx responses. Non-
+retryable errors (e.g. invalid transaction hash) are thrown immediately
+without falling back.
+
+When `endpoints` is provided, the `rpcUrl` field is ignored.
+
 ## License
 
 Apache-2.0

--- a/src/tx-rpc.test.ts
+++ b/src/tx-rpc.test.ts
@@ -1,0 +1,285 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import {
+  createRpcTxStatusReader,
+  isValidStellarAddress,
+  type RpcEndpoint,
+  type RpcTxStatusReaderOptions,
+} from "./tx-rpc";
+
+// Mock the @stellar/stellar-sdk module
+const mockGetTransaction = vi.fn();
+
+vi.mock("@stellar/stellar-sdk", () => {
+  return {
+    rpc: {
+      Server: vi.fn().mockImplementation(() => ({
+        getTransaction: mockGetTransaction,
+      })),
+      Api: {
+        GetTransactionStatus: {
+          SUCCESS: "SUCCESS",
+          FAILED: "FAILED",
+          NOT_FOUND: "NOT_FOUND",
+        },
+      },
+    },
+    StrKey: {
+      isValidEd25519PublicKey: vi.fn((addr: string) => addr.startsWith("G")),
+      isValidContract: vi.fn((addr: string) => addr.startsWith("C")),
+    },
+  };
+});
+
+describe("isValidStellarAddress", () => {
+  it("returns true for G... addresses", () => {
+    expect(isValidStellarAddress("GABC123")).toBe(true);
+  });
+
+  it("returns true for C... addresses", () => {
+    expect(isValidStellarAddress("CABC123")).toBe(true);
+  });
+
+  it("returns false for other addresses", () => {
+    expect(isValidStellarAddress("DABC123")).toBe(false);
+  });
+});
+
+describe("createRpcTxStatusReader", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("single endpoint (backward compatible)", () => {
+    it("returns success for successful transactions", async () => {
+      mockGetTransaction.mockResolvedValue({ status: "SUCCESS" });
+      const reader = createRpcTxStatusReader({
+        rpcUrl: "https://rpc.example.com",
+      });
+
+      const status = await reader.getStatus("abc123");
+      expect(status).toBe("success");
+      expect(mockGetTransaction).toHaveBeenCalledWith("abc123");
+    });
+
+    it("returns failed for failed transactions", async () => {
+      mockGetTransaction.mockResolvedValue({ status: "FAILED" });
+      const reader = createRpcTxStatusReader({
+        rpcUrl: "https://rpc.example.com",
+      });
+
+      const status = await reader.getStatus("abc123");
+      expect(status).toBe("failed");
+    });
+
+    it("returns pending for not found transactions", async () => {
+      mockGetTransaction.mockResolvedValue({ status: "NOT_FOUND" });
+      const reader = createRpcTxStatusReader({
+        rpcUrl: "https://rpc.example.com",
+      });
+
+      const status = await reader.getStatus("abc123");
+      expect(status).toBe("pending");
+    });
+  });
+
+  describe("multiple endpoints with fallback", () => {
+    it("falls back to second endpoint on primary timeout", async () => {
+      let callCount = 0;
+      mockGetTransaction.mockImplementation(async () => {
+        callCount++;
+        if (callCount === 1) {
+          // Primary times out
+          throw new Error("Request timed out after 5000ms");
+        }
+        // Backup succeeds
+        return { status: "SUCCESS" };
+      });
+
+      const reader = createRpcTxStatusReader({
+        endpoints: [
+          { url: "https://primary.example.com", timeoutMs: 5000 },
+          { url: "https://backup.example.com", timeoutMs: 10000 },
+        ],
+      });
+
+      const status = await reader.getStatus("abc123");
+      expect(status).toBe("success");
+      expect(mockGetTransaction).toHaveBeenCalledTimes(2);
+    });
+
+    it("falls back to second endpoint on primary network error", async () => {
+      let callCount = 0;
+      mockGetTransaction.mockImplementation(async () => {
+        callCount++;
+        if (callCount === 1) {
+          // Primary network error
+          throw new Error("ECONNREFUSED");
+        }
+        // Backup succeeds
+        return { status: "FAILED" };
+      });
+
+      const reader = createRpcTxStatusReader({
+        endpoints: [
+          { url: "https://primary.example.com" },
+          { url: "https://backup.example.com" },
+        ],
+      });
+
+      const status = await reader.getStatus("abc123");
+      expect(status).toBe("failed");
+      expect(mockGetTransaction).toHaveBeenCalledTimes(2);
+    });
+
+    it("falls back through multiple endpoints", async () => {
+      let callCount = 0;
+      mockGetTransaction.mockImplementation(async () => {
+        callCount++;
+        if (callCount <= 2) {
+          // First two fail
+          throw new Error("ECONNRESET");
+        }
+        // Third succeeds
+        return { status: "SUCCESS" };
+      });
+
+      const reader = createRpcTxStatusReader({
+        endpoints: [
+          { url: "https://primary.example.com" },
+          { url: "https://backup1.example.com" },
+          { url: "https://backup2.example.com" },
+        ],
+      });
+
+      const status = await reader.getStatus("abc123");
+      expect(status).toBe("success");
+      expect(mockGetTransaction).toHaveBeenCalledTimes(3);
+    });
+
+    it("throws on last endpoint failure", async () => {
+      mockGetTransaction.mockRejectedValue(new Error("ECONNREFUSED"));
+
+      const reader = createRpcTxStatusReader({
+        endpoints: [
+          { url: "https://primary.example.com" },
+          { url: "https://backup.example.com" },
+        ],
+      });
+
+      await expect(reader.getStatus("abc123")).rejects.toThrow("ECONNREFUSED");
+      expect(mockGetTransaction).toHaveBeenCalledTimes(2);
+    });
+
+    it("does not fall back on non-retryable errors", async () => {
+      let callCount = 0;
+      mockGetTransaction.mockImplementation(async () => {
+        callCount++;
+        if (callCount === 1) {
+          // Primary throws non-retryable error
+          throw new Error("Invalid transaction hash");
+        }
+        // Backup should not be called
+        return { status: "SUCCESS" };
+      });
+
+      const reader = createRpcTxStatusReader({
+        endpoints: [
+          { url: "https://primary.example.com" },
+          { url: "https://backup.example.com" },
+        ],
+      });
+
+      await expect(reader.getStatus("abc123")).rejects.toThrow(
+        "Invalid transaction hash",
+      );
+      expect(mockGetTransaction).toHaveBeenCalledTimes(1);
+    });
+
+    it("falls back on HTTP 5xx errors", async () => {
+      let callCount = 0;
+      mockGetTransaction.mockImplementation(async () => {
+        callCount++;
+        if (callCount === 1) {
+          throw new Error("HTTP 503 Service Unavailable");
+        }
+        return { status: "SUCCESS" };
+      });
+
+      const reader = createRpcTxStatusReader({
+        endpoints: [
+          { url: "https://primary.example.com" },
+          { url: "https://backup.example.com" },
+        ],
+      });
+
+      const status = await reader.getStatus("abc123");
+      expect(status).toBe("success");
+      expect(mockGetTransaction).toHaveBeenCalledTimes(2);
+    });
+
+    it("falls back on socket hang up error", async () => {
+      let callCount = 0;
+      mockGetTransaction.mockImplementation(async () => {
+        callCount++;
+        if (callCount === 1) {
+          throw new Error("socket hang up");
+        }
+        return { status: "PENDING" };
+      });
+
+      const reader = createRpcTxStatusReader({
+        endpoints: [
+          { url: "https://primary.example.com" },
+          { url: "https://backup.example.com" },
+        ],
+      });
+
+      const status = await reader.getStatus("abc123");
+      expect(status).toBe("pending");
+      expect(mockGetTransaction).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe("configuration", () => {
+    it("throws if no rpcUrl or endpoints provided", () => {
+      expect(() => createRpcTxStatusReader({})).toThrow(
+        "Either 'rpcUrl' or 'endpoints' must be provided",
+      );
+    });
+
+    it("throws if empty endpoints array provided", () => {
+      expect(() => createRpcTxStatusReader({ endpoints: [] })).toThrow(
+        "Either 'rpcUrl' or 'endpoints' must be provided",
+      );
+    });
+
+    it("uses default timeout when not specified on endpoint", async () => {
+      let timeoutUsed: number | undefined;
+      mockGetTransaction.mockImplementation(async () => {
+        // We can't directly observe the timeout value, but we can verify
+        // the endpoint is called
+        return { status: "SUCCESS" };
+      });
+
+      const reader = createRpcTxStatusReader({
+        endpoints: [{ url: "https://primary.example.com" }],
+        defaultTimeoutMs: 5000,
+      });
+
+      const status = await reader.getStatus("abc123");
+      expect(status).toBe("success");
+    });
+
+    it("prefers endpoints over rpcUrl", async () => {
+      mockGetTransaction.mockResolvedValue({ status: "SUCCESS" });
+
+      const reader = createRpcTxStatusReader({
+        rpcUrl: "https://ignored.example.com",
+        endpoints: [{ url: "https://used.example.com" }],
+      });
+
+      const status = await reader.getStatus("abc123");
+      expect(status).toBe("success");
+    });
+  });
+});

--- a/src/tx-rpc.ts
+++ b/src/tx-rpc.ts
@@ -8,20 +8,158 @@ export function isValidStellarAddress(address: string): boolean {
   return StrKey.isValidEd25519PublicKey(address) || StrKey.isValidContract(address);
 }
 
-export function createRpcTxStatusReader(options: { rpcUrl: string }): TxStatusReader {
-  const server = new rpc.Server(options.rpcUrl);
+/** Configuration for a single RPC endpoint. */
+export interface RpcEndpoint {
+  /** The URL of the Soroban RPC endpoint. */
+  url: string;
+  /** Timeout in milliseconds for this endpoint (default: 10_000). */
+  timeoutMs?: number;
+}
+
+/** Configuration options for the RPC tx status reader. */
+export interface RpcTxStatusReaderOptions {
+  /**
+   * Primary RPC endpoint URL (for backward compatibility).
+   * If `endpoints` is provided, this is ignored.
+   */
+  rpcUrl?: string;
+  /**
+   * Prioritized list of RPC endpoints to try.
+   * The first endpoint is the primary; subsequent endpoints are fallbacks.
+   * If a request to an endpoint times out or fails, the next endpoint is tried.
+   */
+  endpoints?: RpcEndpoint[];
+  /**
+   * Default timeout in milliseconds for endpoints that don't specify their own.
+   * Default: 10_000 ms.
+   */
+  defaultTimeoutMs?: number;
+}
+
+/**
+ * Determines whether an error should trigger a fallback to the next endpoint.
+ * Network errors, timeouts, and 5xx errors are considered retryable.
+ */
+function isRetryableError(error: unknown): boolean {
+  if (error instanceof Error) {
+    const message = error.message.toLowerCase();
+    // Timeouts
+    if (message.includes("timeout") || message.includes("aborted")) return true;
+    // Network errors
+    if (
+      message.includes("econnrefused") ||
+      message.includes("econnreset") ||
+      message.includes("enotfound") ||
+      message.includes("network") ||
+      message.includes("fetch") ||
+      message.includes("socket hang up")
+    ) {
+      return true;
+    }
+    // HTTP 5xx errors
+    if (message.includes("500") || message.includes("502") || message.includes("503") || message.includes("504")) {
+      return true;
+    }
+  }
+  return false;
+}
+
+/**
+ * Normalizes the old single-URL config and the new multi-endpoint config
+ * into a flat list of RpcEndpoint.
+ */
+function resolveEndpoints(options: RpcTxStatusReaderOptions): RpcEndpoint[] {
+  if (options.endpoints && options.endpoints.length > 0) {
+    return options.endpoints;
+  }
+  if (options.rpcUrl) {
+    return [{ url: options.rpcUrl }];
+  }
+  throw new Error("Either 'rpcUrl' or 'endpoints' must be provided");
+}
+
+/**
+ * Creates a TxStatusReader that routes requests through a prioritized list
+ * of RPC endpoints with automatic fallback on timeout or error.
+ *
+ * @example
+ * ```ts
+ * // Single endpoint (backward compatible)
+ * const reader = createRpcTxStatusReader({ rpcUrl: "https://rpc.example.com" });
+ *
+ * // Multiple endpoints with fallback
+ * const reader = createRpcTxStatusReader({
+ *   endpoints: [
+ *     { url: "https://primary-rpc.example.com", timeoutMs: 5_000 },
+ *     { url: "https://backup-rpc.example.com", timeoutMs: 10_000 },
+ *     { url: "https://emergency-rpc.example.com" },
+ *   ],
+ *   defaultTimeoutMs: 10_000,
+ * });
+ * ```
+ */
+export function createRpcTxStatusReader(options: RpcTxStatusReaderOptions): TxStatusReader {
+  const endpoints = resolveEndpoints(options);
+  const defaultTimeout = options.defaultTimeoutMs ?? 10_000;
+
+  // Pre-create servers for each endpoint for reuse
+  const servers = endpoints.map((ep) => new rpc.Server(ep.url));
+
   return {
     async getStatus(hash): Promise<TxStatus> {
-      const res = await server.getTransaction(hash);
-      switch (res.status) {
-        case rpc.Api.GetTransactionStatus.SUCCESS:
-          return "success";
-        case rpc.Api.GetTransactionStatus.FAILED:
-          return "failed";
-        default:
-          // NOT_FOUND: not yet included in a ledger.
-          return "pending";
+      let lastError: unknown;
+
+      for (let i = 0; i < servers.length; i++) {
+        const server = servers[i]!;
+        const timeoutMs = endpoints[i]!.timeoutMs ?? defaultTimeout;
+
+        try {
+          const res = await withTimeout(server.getTransaction(hash), timeoutMs);
+          switch (res.status) {
+            case rpc.Api.GetTransactionStatus.SUCCESS:
+              return "success";
+            case rpc.Api.GetTransactionStatus.FAILED:
+              return "failed";
+            default:
+              // NOT_FOUND: not yet included in a ledger.
+              return "pending";
+          }
+        } catch (error) {
+          lastError = error;
+          // Only fall back if the error is retryable and there are more endpoints
+          if (isRetryableError(error) && i < servers.length - 1) {
+            continue;
+          }
+          // Non-retryable error or last endpoint — rethrow
+          throw error;
+        }
       }
+
+      // Should not reach here, but just in case
+      throw lastError;
     },
   };
+}
+
+/**
+ * Wraps a promise with a timeout. Rejects with a timeout error if the
+ * promise does not resolve within the specified time.
+ */
+function withTimeout<T>(promise: Promise<T>, timeoutMs: number): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    const timer = setTimeout(() => {
+      reject(new Error(`Request timed out after ${timeoutMs}ms`));
+    }, timeoutMs);
+
+    promise.then(
+      (value) => {
+        clearTimeout(timer);
+        resolve(value);
+      },
+      (error) => {
+        clearTimeout(timer);
+        reject(error);
+      },
+    );
+  });
 }

--- a/website/content/docs/advanced.md
+++ b/website/content/docs/advanced.md
@@ -37,8 +37,38 @@ import { createRpcBalanceReader } from "vellar-sdk/rpc"; // pulls in @stellar/st
 ```
 
 - **`vellar-sdk/balances`** — token amount formatting and the balance service.
-- **`vellar-sdk/rpc`** — RPC-backed balance readers. Imported separately so
-  `@stellar/stellar-sdk` stays out of bundles that don't read balances.
+- **`vellar-sdk/rpc`** — RPC-backed balance and transaction status readers.
+  Imported separately so `@stellar/stellar-sdk` stays out of bundles that
+  don't read balances.
+
+## RPC fallback endpoints
+
+`createRpcTxStatusReader` supports a prioritized list of fallback RPC
+endpoints for high availability. If the primary endpoint times out or returns a
+network error, the reader automatically retries on the next endpoint.
+
+```ts
+import { createRpcTxStatusReader } from "vellar-sdk/rpc";
+
+const reader = createRpcTxStatusReader({
+  endpoints: [
+    { url: "https://primary-rpc.example.com", timeoutMs: 5_000 },
+    { url: "https://backup-rpc.example.com", timeoutMs: 10_000 },
+    { url: "https://emergency-rpc.example.com" },
+  ],
+  defaultTimeoutMs: 10_000,
+});
+```
+
+| Option | Description |
+| --- | --- |
+| `rpcUrl` | Single endpoint (backward compatible). Ignored if `endpoints` is set. |
+| `endpoints` | Prioritized array of `{ url, timeoutMs? }`. First entry is primary. |
+| `defaultTimeoutMs` | Fallback timeout for endpoints that don't specify one (default: 10 000 ms). |
+
+Retryable errors that trigger fallback: timeouts, `ECONNREFUSED`, `ECONNRESET`,
+`ENOTFOUND`, `socket hang up`, and HTTP 5xx. Non-retryable errors (e.g. invalid
+transaction hash) throw immediately without falling back.
 
 ## Custom review UI (example)
 


### PR DESCRIPTION
Add support for a prioritized list of fallback RPC endpoints in createRpcTxStatusReader. When the primary endpoint times out or returns a network error (ECONNREFUSED, ECONNRESET, ENOTFOUND, socket hang up, HTTP 5xx), the reader automatically retries on the next endpoint in the list.

Key changes:
- New RpcEndpoint and RpcTxStatusReaderOptions types with backward-compatible single rpcUrl support
- Automatic retry on timeout/network/5xx errors, immediate throw on non-retryable errors
- Per-endpoint timeoutMs with configurable defaultTimeoutMs
- 14 test cases covering fallback behavior, cascading retries, and config validation
- Documentation in README and website/content/docs/advanced.md

Closes #218