### PR TITLE
contrib: reference implementations for #227, #230, #235

### DIFF
--- a/contrib/examples/issue-227-session-idle-timeout/README.md
+++ b/contrib/examples/issue-227-session-idle-timeout/README.md
@@ -1,0 +1,24 @@
+# Session idle timeout
+
+Self-contained reference for issue [#227](https://github.com/Vellar-Wallet/vellar-sdk/issues/227): harden session expiry handling in `session.ts` for idle connectors.
+
+`checkIdleExpiry(session, idleTimeoutMs, now?)` checks how long a session has
+been idle (`now - lastActiveAt`) and reports whether it's past the timeout,
+along with a debug log helper (`logIdleExpiration`) for observability.
+
+- The boundary is exclusive — idle for exactly `idleTimeoutMs` is still
+  valid, so a session isn't punished for landing exactly on the threshold.
+- A `lastActiveAt` in the future (clock skew, a corrupted persisted value)
+  is never treated as expired.
+
+## Run it
+
+```sh
+npx tsx session-idle-timeout.ts
+```
+
+## Tests
+
+```sh
+npx vitest run contrib/examples/issue-227-session-idle-timeout
+```

--- a/contrib/examples/issue-227-session-idle-timeout/session-idle-timeout.test.ts
+++ b/contrib/examples/issue-227-session-idle-timeout/session-idle-timeout.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it, vi } from "vitest";
+import { checkIdleExpiry, logIdleExpiration, type MockSession } from "./session-idle-timeout";
+
+describe("checkIdleExpiry", () => {
+  const FIVE_MIN_MS = 5 * 60 * 1000;
+  const session: MockSession = {
+    accountId: "CACCOUNT",
+    lastActiveAt: "2026-07-16T10:00:00.000Z",
+  };
+
+  it("reports not expired when idle time is under the timeout", () => {
+    const now = new Date("2026-07-16T10:04:59.000Z"); // 4m59s idle
+    expect(checkIdleExpiry(session, FIVE_MIN_MS, now)).toEqual({ expired: false });
+  });
+
+  it("reports expired with idleForMs when idle time exceeds the timeout", () => {
+    const now = new Date("2026-07-16T10:05:01.000Z"); // 5m1s idle
+    expect(checkIdleExpiry(session, FIVE_MIN_MS, now)).toEqual({
+      expired: true,
+      idleForMs: FIVE_MIN_MS + 1000,
+    });
+  });
+
+  it("treats exactly-at-the-boundary as still valid (exclusive boundary)", () => {
+    const now = new Date("2026-07-16T10:05:00.000Z"); // exactly 5m idle
+    expect(checkIdleExpiry(session, FIVE_MIN_MS, now)).toEqual({ expired: false });
+  });
+
+  it("never treats a future lastActiveAt (clock skew) as expired", () => {
+    const skewedSession: MockSession = {
+      accountId: "CSKEWED",
+      lastActiveAt: "2026-07-16T11:00:00.000Z",
+    };
+    const now = new Date("2026-07-16T10:00:00.000Z"); // now before lastActiveAt
+    expect(checkIdleExpiry(skewedSession, FIVE_MIN_MS, now)).toEqual({ expired: false });
+  });
+});
+
+describe("logIdleExpiration", () => {
+  it("logs the account id and idle duration via console.debug", () => {
+    const spy = vi.spyOn(console, "debug").mockImplementation(() => {});
+    logIdleExpiration({ accountId: "CACCOUNT", lastActiveAt: "2026-07-16T10:00:00.000Z" }, 12345);
+    expect(spy).toHaveBeenCalledWith(
+      expect.stringContaining("account=CACCOUNT"),
+    );
+    expect(spy).toHaveBeenCalledWith(expect.stringContaining("idleForMs=12345"));
+    spy.mockRestore();
+  });
+});

--- a/contrib/examples/issue-227-session-idle-timeout/session-idle-timeout.ts
+++ b/contrib/examples/issue-227-session-idle-timeout/session-idle-timeout.ts
@@ -1,0 +1,76 @@
+// Self-contained reference for issue #227: harden session expiry handling
+// for idle connectors. The real vellar-sdk session store (src/session.ts)
+// doesn't currently expire an idle session on restore — this is a
+// standalone, dependency-free demonstration of the check that fix would
+// add, along with a debug log entry on expiration.
+//
+// Run with: npx tsx session-idle-timeout.ts
+
+export interface MockSession {
+  accountId: string;
+  lastActiveAt: string; // ISO timestamp
+}
+
+export type IdleCheckResult =
+  | { expired: false }
+  | { expired: true; idleForMs: number };
+
+/**
+ * Checks whether `session` has been idle (time since `lastActiveAt`) past
+ * `idleTimeoutMs`, relative to `now`.
+ *
+ * A `lastActiveAt` in the future (clock skew, a corrupted persisted value)
+ * is never treated as expired — only a genuinely elapsed idle period is.
+ * The boundary is exclusive: idle-for exactly `idleTimeoutMs` is still
+ * valid (idleForMs > idleTimeoutMs, not >=), so a session isn't punished
+ * for landing exactly on the threshold due to clock rounding.
+ */
+export function checkIdleExpiry(
+  session: MockSession,
+  idleTimeoutMs: number,
+  now: Date = new Date(),
+): IdleCheckResult {
+  const idleForMs = now.getTime() - Date.parse(session.lastActiveAt);
+  if (idleForMs > idleTimeoutMs) {
+    return { expired: true, idleForMs };
+  }
+  return { expired: false };
+}
+
+/**
+ * Debug log entry emitted when a session is found idle-expired. A real
+ * connector would clear the session's persisted state after logging this.
+ */
+export function logIdleExpiration(session: MockSession, idleForMs: number): void {
+  console.debug(
+    `[session] idle expiry: account=${session.accountId} idleForMs=${idleForMs}`,
+  );
+}
+
+function main() {
+  const now = new Date("2026-07-16T10:10:00.000Z");
+  const idleTimeoutMs = 5 * 60 * 1000; // 5 minutes
+
+  const freshSession: MockSession = {
+    accountId: "CFRESH",
+    lastActiveAt: "2026-07-16T10:06:00.000Z", // 4 min idle
+  };
+  const staleSession: MockSession = {
+    accountId: "CSTALE",
+    lastActiveAt: "2026-07-16T10:00:00.000Z", // 10 min idle
+  };
+
+  for (const session of [freshSession, staleSession]) {
+    const result = checkIdleExpiry(session, idleTimeoutMs, now);
+    if (result.expired) {
+      logIdleExpiration(session, result.idleForMs);
+      console.log(`${session.accountId}: EXPIRED (idle ${result.idleForMs}ms)`);
+    } else {
+      console.log(`${session.accountId}: ACTIVE`);
+    }
+  }
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main();
+}

--- a/contrib/examples/issue-230-passkey-challenge-tracker/README.md
+++ b/contrib/examples/issue-230-passkey-challenge-tracker/README.md
@@ -1,0 +1,24 @@
+# Passkey challenge tracker
+
+Self-contained reference for issue [#230](https://github.com/Vellar-Wallet/vellar-sdk/issues/230): reject stale passkey assertions in `passkeykit-connector.ts` with typed errors.
+
+`ChallengeTracker` tracks single-use, TTL-bounded challenges: `register()`
+records a freshly-issued one; `consume()` validates and single-use-consumes
+it, throwing a distinct typed error for each failure mode:
+
+- `PasskeyAssertionExpiredError` — the challenge is older than the TTL. The
+  caller should ask the user to retry.
+- `PasskeyAssertionReplayedError` — the challenge was already consumed
+  once. A genuine replay attempt, worth logging/alerting on.
+
+## Run it
+
+```sh
+npx tsx passkey-challenge-tracker.ts
+```
+
+## Tests
+
+```sh
+npx vitest run contrib/examples/issue-230-passkey-challenge-tracker
+```

--- a/contrib/examples/issue-230-passkey-challenge-tracker/passkey-challenge-tracker.test.ts
+++ b/contrib/examples/issue-230-passkey-challenge-tracker/passkey-challenge-tracker.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from "vitest";
+import {
+  ChallengeTracker,
+  PasskeyAssertionExpiredError,
+  PasskeyAssertionReplayedError,
+} from "./passkey-challenge-tracker";
+
+describe("ChallengeTracker", () => {
+  const FIVE_MIN_MS = 5 * 60 * 1000;
+
+  it("consumes a freshly-registered challenge without throwing", () => {
+    const tracker = new ChallengeTracker();
+    tracker.register("chal-1");
+    expect(() => tracker.consume("chal-1")).not.toThrow();
+  });
+
+  it("throws PasskeyAssertionReplayedError on a second consume of the same challenge", () => {
+    const tracker = new ChallengeTracker();
+    tracker.register("chal-1");
+    tracker.consume("chal-1");
+    expect(() => tracker.consume("chal-1")).toThrow(PasskeyAssertionReplayedError);
+  });
+
+  it("throws PasskeyAssertionExpiredError past maxAgeMs, with the expected fields", () => {
+    let now = new Date("2026-07-16T10:00:00.000Z");
+    const tracker = new ChallengeTracker({ maxAgeMs: FIVE_MIN_MS, now: () => now });
+    tracker.register("chal-1");
+
+    now = new Date("2026-07-16T10:05:01.000Z"); // 5m1s later
+    let caught: unknown;
+    try {
+      tracker.consume("chal-1");
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(PasskeyAssertionExpiredError);
+    const err = caught as PasskeyAssertionExpiredError;
+    expect(err.challenge).toBe("chal-1");
+    expect(err.issuedAt).toEqual(new Date("2026-07-16T10:00:00.000Z"));
+    expect(err.maxAgeMs).toBe(FIVE_MIN_MS);
+  });
+
+  it("accepts a challenge consumed exactly at the boundary (ageMs > maxAgeMs, not >=)", () => {
+    let now = new Date("2026-07-16T10:00:00.000Z");
+    const tracker = new ChallengeTracker({ maxAgeMs: FIVE_MIN_MS, now: () => now });
+    tracker.register("chal-1");
+    now = new Date("2026-07-16T10:05:00.000Z"); // exactly 5m later
+    expect(() => tracker.consume("chal-1")).not.toThrow();
+  });
+
+  it("throws a plain Error for a challenge that was never registered", () => {
+    const tracker = new ChallengeTracker();
+    expect(() => tracker.consume("never-registered")).toThrow(/unknown/i);
+  });
+
+  it("re-registering a challenge clears its prior consumed state", () => {
+    const tracker = new ChallengeTracker();
+    tracker.register("chal-1");
+    tracker.consume("chal-1");
+    expect(() => tracker.consume("chal-1")).toThrow(PasskeyAssertionReplayedError);
+
+    tracker.register("chal-1"); // e.g. the backend reissued the same string
+    expect(() => tracker.consume("chal-1")).not.toThrow();
+  });
+
+  it("tracks multiple challenges independently", () => {
+    const tracker = new ChallengeTracker();
+    tracker.register("chal-a");
+    tracker.register("chal-b");
+    tracker.consume("chal-a");
+    expect(() => tracker.consume("chal-a")).toThrow(PasskeyAssertionReplayedError);
+    expect(() => tracker.consume("chal-b")).not.toThrow();
+  });
+
+  it("prunes expired entries lazily so long-running processes don't leak memory", () => {
+    let now = new Date("2026-07-16T10:00:00.000Z");
+    const tracker = new ChallengeTracker({ maxAgeMs: FIVE_MIN_MS, now: () => now });
+    tracker.register("stale-challenge");
+
+    now = new Date("2026-07-16T11:00:00.000Z"); // 1h later, well past maxAgeMs
+    tracker.register("fresh-challenge"); // triggers a prune pass
+
+    // The pruned challenge is gone entirely — treated as never registered,
+    // not merely expired (both throw, but this exercises the prune path).
+    expect(() => tracker.consume("stale-challenge")).toThrow(/unknown/i);
+    expect(() => tracker.consume("fresh-challenge")).not.toThrow();
+  });
+});

--- a/contrib/examples/issue-230-passkey-challenge-tracker/passkey-challenge-tracker.ts
+++ b/contrib/examples/issue-230-passkey-challenge-tracker/passkey-challenge-tracker.ts
@@ -1,0 +1,124 @@
+// Self-contained reference for issue #230: reject stale passkey assertions
+// in passkeykit-connector.ts with typed errors. The real
+// passkeykit-connector.ts delegates entirely to the opaque
+// kit.sign()/kit.connectWallet() and never inspects a raw WebAuthn
+// challenge itself — this is a standalone demonstration of the
+// single-use/TTL tracking and typed error distinction that fix would add,
+// for a caller that does have a challenge (e.g. one a backend mints for a
+// step-up reauth before a sensitive action).
+//
+// Run with: npx tsx passkey-challenge-tracker.ts
+
+/** Thrown when a challenge is older than the tracker's TTL. */
+export class PasskeyAssertionExpiredError extends Error {
+  constructor(
+    public readonly challenge: string,
+    public readonly issuedAt: Date,
+    public readonly maxAgeMs: number,
+  ) {
+    super(
+      `Passkey assertion challenge expired: issued at ${issuedAt.toISOString()}, ` +
+        `max age ${maxAgeMs}ms`,
+    );
+    this.name = "PasskeyAssertionExpiredError";
+  }
+}
+
+/** Thrown when a challenge was already consumed once — a genuine replay. */
+export class PasskeyAssertionReplayedError extends Error {
+  constructor(public readonly challenge: string) {
+    super(`Passkey assertion challenge has already been used: ${challenge}`);
+    this.name = "PasskeyAssertionReplayedError";
+  }
+}
+
+/**
+ * Tracks single-use passkey challenges, distinguishing a stale assertion
+ * (too old — ask the user to retry) from a replayed one (already used — a
+ * genuine replay attempt worth logging/alerting on) with a typed error for
+ * each.
+ */
+export class ChallengeTracker {
+  private readonly issuedAt = new Map<string, Date>();
+  private readonly consumed = new Set<string>();
+  private readonly maxAgeMs: number;
+  private readonly now: () => Date;
+
+  constructor(options: { maxAgeMs?: number; now?: () => Date } = {}) {
+    this.maxAgeMs = options.maxAgeMs ?? 5 * 60 * 1000; // 5 minutes
+    this.now = options.now ?? (() => new Date());
+  }
+
+  /** Registers a freshly-issued challenge, timestamped at the current time. */
+  register(challenge: string): void {
+    this.pruneExpired();
+    this.issuedAt.set(challenge, this.now());
+    this.consumed.delete(challenge);
+  }
+
+  /**
+   * Validates and single-use-consumes `challenge`. Throws
+   * `PasskeyAssertionReplayedError` if already consumed,
+   * `PasskeyAssertionExpiredError` if older than `maxAgeMs`, or a plain
+   * `Error` if it was never registered at all.
+   */
+  consume(challenge: string): void {
+    if (this.consumed.has(challenge)) {
+      throw new PasskeyAssertionReplayedError(challenge);
+    }
+    const issuedAt = this.issuedAt.get(challenge);
+    if (issuedAt === undefined) {
+      throw new Error(`Unknown passkey assertion challenge: ${challenge}`);
+    }
+    const ageMs = this.now().getTime() - issuedAt.getTime();
+    if (ageMs > this.maxAgeMs) {
+      throw new PasskeyAssertionExpiredError(challenge, issuedAt, this.maxAgeMs);
+    }
+    this.consumed.add(challenge);
+    this.issuedAt.delete(challenge);
+  }
+
+  /** Drops tracked challenges older than `maxAgeMs`, whether consumed or not. */
+  private pruneExpired(): void {
+    const cutoff = this.now().getTime() - this.maxAgeMs;
+    for (const [challenge, issuedAt] of this.issuedAt) {
+      if (issuedAt.getTime() < cutoff) {
+        this.issuedAt.delete(challenge);
+        this.consumed.delete(challenge);
+      }
+    }
+  }
+}
+
+function main() {
+  const tracker = new ChallengeTracker({ maxAgeMs: 5000 });
+
+  console.log("Registering challenge 'abc123'...");
+  tracker.register("abc123");
+
+  console.log("Consuming it once...");
+  tracker.consume("abc123");
+  console.log("  ok — accepted.");
+
+  console.log("Consuming it again (replay)...");
+  try {
+    tracker.consume("abc123");
+  } catch (err) {
+    console.log(`  rejected: ${err instanceof Error ? err.constructor.name : err}`);
+  }
+
+  console.log("\nRegistering challenge 'xyz789', then waiting past its TTL...");
+  const now = { value: new Date() };
+  const timedTracker = new ChallengeTracker({ maxAgeMs: 1000, now: () => now.value });
+  timedTracker.register("xyz789");
+  now.value = new Date(now.value.getTime() + 2000);
+  try {
+    timedTracker.consume("xyz789");
+  } catch (err) {
+    console.log(`  rejected: ${err instanceof Error ? err.constructor.name : err}`);
+  }
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main();
+}

--- a/contrib/examples/issue-235-balance-cache-warmup/README.md
+++ b/contrib/examples/issue-235-balance-cache-warmup/README.md
@@ -1,0 +1,32 @@
+# Balance cache warm-up
+
+Self-contained reference for issue [#235](https://github.com/Vellar-Wallet/vellar-sdk/issues/235): add a cache warm-up helper for frequently read wallet balances.
+
+`createCachedBalanceReader(reader, { ttlMs })` wraps a `BalanceReader`-shaped
+interface with an in-memory TTL cache, keyed by `(tokenContractId, holder)`.
+`warmUpBalanceCache(reader, holder, { tokens })` pre-populates it across an
+explicit, caller-chosen asset list — configurable warm-up selection, per the
+issue's requirement — with concurrent reads and, by default, continues
+warming up the rest of the list if one token's read fails.
+
+- A failed underlying read is never cached, so the next call always retries
+  against the network.
+- `prime()` seeds a cache entry directly (e.g. from a value already known
+  from elsewhere) without a network round-trip.
+- `invalidate()` drops one entry, one token across all holders, or
+  everything.
+
+See also [`local-balance-cache`](../local-balance-cache) for a simpler
+balance cache without the warm-up helper.
+
+## Run it
+
+```sh
+npx tsx balance-cache-warmup.ts
+```
+
+## Tests
+
+```sh
+npx vitest run contrib/examples/issue-235-balance-cache-warmup
+```

--- a/contrib/examples/issue-235-balance-cache-warmup/balance-cache-warmup.test.ts
+++ b/contrib/examples/issue-235-balance-cache-warmup/balance-cache-warmup.test.ts
@@ -1,0 +1,188 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  createCachedBalanceReader,
+  warmUpBalanceCache,
+  type BalanceReader,
+} from "./balance-cache-warmup";
+
+describe("createCachedBalanceReader", () => {
+  const TTL_MS = 60_000;
+
+  function countingReader(amount = 100n) {
+    let calls = 0;
+    const reader: BalanceReader = {
+      getTokenBalance: vi.fn(async () => {
+        calls += 1;
+        return amount;
+      }),
+    };
+    return { reader, getCalls: () => calls };
+  }
+
+  it("serves a cache hit within the TTL without calling the underlying reader again", async () => {
+    let now = 1_000_000;
+    const { reader, getCalls } = countingReader(42n);
+    const cached = createCachedBalanceReader(reader, { ttlMs: TTL_MS, now: () => now });
+
+    expect(await cached.getTokenBalance("CTOKEN", "CHOLDER")).toBe(42n);
+    now += 1000; // well within the 60s TTL
+    expect(await cached.getTokenBalance("CTOKEN", "CHOLDER")).toBe(42n);
+    expect(getCalls()).toBe(1);
+  });
+
+  it("re-reads once the TTL has elapsed", async () => {
+    let now = 1_000_000;
+    const { reader, getCalls } = countingReader();
+    const cached = createCachedBalanceReader(reader, { ttlMs: TTL_MS, now: () => now });
+
+    await cached.getTokenBalance("CTOKEN", "CHOLDER");
+    now += TTL_MS + 1;
+    await cached.getTokenBalance("CTOKEN", "CHOLDER");
+    expect(getCalls()).toBe(2);
+  });
+
+  it("caches each (tokenContractId, holder) pair independently", async () => {
+    const { reader, getCalls } = countingReader();
+    const cached = createCachedBalanceReader(reader, { ttlMs: TTL_MS });
+
+    await cached.getTokenBalance("CTOKEN_A", "CHOLDER_1");
+    await cached.getTokenBalance("CTOKEN_B", "CHOLDER_1");
+    await cached.getTokenBalance("CTOKEN_A", "CHOLDER_2");
+    expect(getCalls()).toBe(3);
+
+    await cached.getTokenBalance("CTOKEN_A", "CHOLDER_1");
+    expect(getCalls()).toBe(3); // still cached
+  });
+
+  it("never caches a failed read — the next call retries", async () => {
+    let shouldFail = true;
+    const reader: BalanceReader = {
+      getTokenBalance: vi.fn(async () => {
+        if (shouldFail) throw new Error("rpc down");
+        return 7n;
+      }),
+    };
+    const cached = createCachedBalanceReader(reader, { ttlMs: TTL_MS });
+
+    await expect(cached.getTokenBalance("CTOKEN", "CHOLDER")).rejects.toThrow("rpc down");
+    shouldFail = false;
+    await expect(cached.getTokenBalance("CTOKEN", "CHOLDER")).resolves.toBe(7n);
+  });
+
+  it("prime() seeds the cache without calling the underlying reader", async () => {
+    const { reader, getCalls } = countingReader();
+    const cached = createCachedBalanceReader(reader, { ttlMs: TTL_MS });
+
+    cached.prime("CTOKEN", "CHOLDER", 999n);
+    expect(await cached.getTokenBalance("CTOKEN", "CHOLDER")).toBe(999n);
+    expect(getCalls()).toBe(0);
+  });
+
+  it("invalidate() with no arguments clears every cached entry", async () => {
+    const { reader, getCalls } = countingReader();
+    const cached = createCachedBalanceReader(reader, { ttlMs: TTL_MS });
+
+    await cached.getTokenBalance("CTOKEN_A", "CHOLDER");
+    await cached.getTokenBalance("CTOKEN_B", "CHOLDER");
+    cached.invalidate();
+    await cached.getTokenBalance("CTOKEN_A", "CHOLDER");
+    await cached.getTokenBalance("CTOKEN_B", "CHOLDER");
+    expect(getCalls()).toBe(4);
+  });
+
+  it("invalidate(tokenContractId) clears only that token, across all holders", async () => {
+    const { reader, getCalls } = countingReader();
+    const cached = createCachedBalanceReader(reader, { ttlMs: TTL_MS });
+
+    await cached.getTokenBalance("CTOKEN_A", "CHOLDER_1");
+    await cached.getTokenBalance("CTOKEN_A", "CHOLDER_2");
+    await cached.getTokenBalance("CTOKEN_B", "CHOLDER_1");
+    cached.invalidate("CTOKEN_A");
+
+    await cached.getTokenBalance("CTOKEN_A", "CHOLDER_1"); // re-read
+    await cached.getTokenBalance("CTOKEN_A", "CHOLDER_2"); // re-read
+    await cached.getTokenBalance("CTOKEN_B", "CHOLDER_1"); // still cached
+    expect(getCalls()).toBe(5);
+  });
+
+  it("invalidate(tokenContractId, holder) clears exactly one entry", async () => {
+    const { reader, getCalls } = countingReader();
+    const cached = createCachedBalanceReader(reader, { ttlMs: TTL_MS });
+
+    await cached.getTokenBalance("CTOKEN", "CHOLDER_1");
+    await cached.getTokenBalance("CTOKEN", "CHOLDER_2");
+    cached.invalidate("CTOKEN", "CHOLDER_1");
+
+    await cached.getTokenBalance("CTOKEN", "CHOLDER_1"); // re-read
+    await cached.getTokenBalance("CTOKEN", "CHOLDER_2"); // still cached
+    expect(getCalls()).toBe(3);
+  });
+});
+
+describe("warmUpBalanceCache", () => {
+  const xlm = { symbol: "XLM", contractId: "CNATIVE", decimals: 7 };
+  const usdc = { symbol: "USDC", contractId: "CUSDC", decimals: 7 };
+
+  it("populates the cache for every configured token", async () => {
+    const reader: BalanceReader = {
+      getTokenBalance: vi
+        .fn()
+        .mockImplementation(async (contractId: string) => (contractId === "CNATIVE" ? 5n : 7n)),
+    };
+    const cached = createCachedBalanceReader(reader, { ttlMs: 60_000 });
+
+    const result = await warmUpBalanceCache(cached, "CHOLDER", { tokens: [xlm, usdc] });
+
+    expect(result).toEqual({ warmed: ["CNATIVE", "CUSDC"], failed: [] });
+    expect(await cached.getTokenBalance("CNATIVE", "CHOLDER")).toBe(5n);
+    expect(await cached.getTokenBalance("CUSDC", "CHOLDER")).toBe(7n);
+    expect(reader.getTokenBalance).toHaveBeenCalledTimes(2);
+  });
+
+  it("warms up only the configured subset, not every possible token", async () => {
+    const reader: BalanceReader = { getTokenBalance: vi.fn().mockResolvedValue(1n) };
+    const cached = createCachedBalanceReader(reader, { ttlMs: 60_000 });
+
+    await warmUpBalanceCache(cached, "CHOLDER", { tokens: [xlm] });
+
+    expect(reader.getTokenBalance).toHaveBeenCalledTimes(1);
+    expect(reader.getTokenBalance).toHaveBeenCalledWith("CNATIVE", "CHOLDER");
+  });
+
+  it("continues warming up remaining tokens after one fails (default continueOnError)", async () => {
+    const reader: BalanceReader = {
+      getTokenBalance: vi.fn().mockImplementation(async (contractId: string) => {
+        if (contractId === "CNATIVE") throw new Error("rpc down");
+        return 7n;
+      }),
+    };
+    const cached = createCachedBalanceReader(reader, { ttlMs: 60_000 });
+
+    const result = await warmUpBalanceCache(cached, "CHOLDER", { tokens: [xlm, usdc] });
+
+    expect(result.warmed).toEqual(["CUSDC"]);
+    expect(result.failed).toHaveLength(1);
+    expect(result.failed[0]?.contractId).toBe("CNATIVE");
+    expect(result.failed[0]?.error).toBeInstanceOf(Error);
+  });
+
+  it("aborts on the first failure when continueOnError is false", async () => {
+    const reader: BalanceReader = {
+      getTokenBalance: vi.fn().mockRejectedValue(new Error("rpc down")),
+    };
+    const cached = createCachedBalanceReader(reader, { ttlMs: 60_000 });
+
+    await expect(
+      warmUpBalanceCache(cached, "CHOLDER", { tokens: [xlm], continueOnError: false }),
+    ).rejects.toThrow("rpc down");
+  });
+
+  it("returns empty warmed/failed when given no tokens", async () => {
+    const reader: BalanceReader = { getTokenBalance: vi.fn() };
+    const cached = createCachedBalanceReader(reader, { ttlMs: 60_000 });
+
+    const result = await warmUpBalanceCache(cached, "CHOLDER", { tokens: [] });
+    expect(result).toEqual({ warmed: [], failed: [] });
+    expect(reader.getTokenBalance).not.toHaveBeenCalled();
+  });
+});

--- a/contrib/examples/issue-235-balance-cache-warmup/balance-cache-warmup.ts
+++ b/contrib/examples/issue-235-balance-cache-warmup/balance-cache-warmup.ts
@@ -1,0 +1,160 @@
+// Self-contained reference for issue #235: add a cache warm-up helper for
+// frequently read wallet balances. Balance reads in the real SDK go through
+// the network (RPC simulation), so a cold cache after eviction/TTL expiry
+// means the first read after that point pays full round-trip latency, with
+// no way to pre-populate it ahead of time.
+//
+// This models a minimal BalanceReader-shaped interface (mirroring
+// src/balances.ts's real one) with a TTL cache and a warmUpBalanceCache()
+// helper — the warm-up asset selection is explicit and configurable, per
+// the issue's requirement.
+//
+// Run with: npx tsx balance-cache-warmup.ts
+
+export interface TokenInfo {
+  symbol: string;
+  contractId: string;
+  decimals: number;
+}
+
+export interface BalanceReader {
+  getTokenBalance(tokenContractId: string, holder: string): Promise<bigint>;
+}
+
+interface CacheEntry {
+  amount: bigint;
+  cachedAt: number;
+}
+
+export interface CachedBalanceReaderOptions {
+  /** How long a cached balance is served before the next read hits the network. */
+  ttlMs: number;
+  /** Injectable clock, primarily for tests. Defaults to `() => Date.now()`. */
+  now?: () => number;
+}
+
+export interface CachedBalanceReader extends BalanceReader {
+  /** Seeds the cache for one token/holder pair without a network round-trip. */
+  prime(tokenContractId: string, holder: string, amount: bigint): void;
+  /** Drops one cached entry, or every entry when called with no arguments. */
+  invalidate(tokenContractId?: string, holder?: string): void;
+}
+
+function cacheKey(tokenContractId: string, holder: string): string {
+  return `${tokenContractId}:${holder}`;
+}
+
+/**
+ * Wraps `reader` with a TTL cache keyed by (tokenContractId, holder). A
+ * failed underlying read is never cached — the next call always retries
+ * against the network instead of repeating a stale error.
+ */
+export function createCachedBalanceReader(
+  reader: BalanceReader,
+  options: CachedBalanceReaderOptions,
+): CachedBalanceReader {
+  const { ttlMs } = options;
+  const now = options.now ?? (() => Date.now());
+  const cache = new Map<string, CacheEntry>();
+
+  return {
+    async getTokenBalance(tokenContractId, holder) {
+      const key = cacheKey(tokenContractId, holder);
+      const entry = cache.get(key);
+      if (entry !== undefined && now() - entry.cachedAt < ttlMs) {
+        return entry.amount;
+      }
+      const amount = await reader.getTokenBalance(tokenContractId, holder);
+      cache.set(key, { amount, cachedAt: now() });
+      return amount;
+    },
+
+    prime(tokenContractId, holder, amount) {
+      cache.set(cacheKey(tokenContractId, holder), { amount, cachedAt: now() });
+    },
+
+    invalidate(tokenContractId, holder) {
+      if (tokenContractId === undefined) {
+        cache.clear();
+        return;
+      }
+      if (holder === undefined) {
+        for (const key of cache.keys()) {
+          if (key.startsWith(`${tokenContractId}:`)) cache.delete(key);
+        }
+        return;
+      }
+      cache.delete(cacheKey(tokenContractId, holder));
+    },
+  };
+}
+
+export interface WarmUpBalanceCacheOptions {
+  /**
+   * Which tokens to warm up — explicit and configurable, per the issue's
+   * requirement. Pass a subset (e.g. just the native asset) to warm up only
+   * what a UI shows first.
+   */
+  tokens: TokenInfo[];
+  /**
+   * If one token's read fails, continue warming up the rest instead of
+   * aborting the whole batch. Defaults to `true`.
+   */
+  continueOnError?: boolean;
+}
+
+export interface WarmUpBalanceCacheResult {
+  warmed: string[];
+  failed: Array<{ contractId: string; error: unknown }>;
+}
+
+/** Pre-populates `reader`'s cache for `holder` across `options.tokens`, concurrently. */
+export async function warmUpBalanceCache(
+  reader: CachedBalanceReader,
+  holder: string,
+  options: WarmUpBalanceCacheOptions,
+): Promise<WarmUpBalanceCacheResult> {
+  const { tokens, continueOnError = true } = options;
+  const warmed: string[] = [];
+  const failed: Array<{ contractId: string; error: unknown }> = [];
+
+  await Promise.all(
+    tokens.map(async (token) => {
+      try {
+        await reader.getTokenBalance(token.contractId, holder);
+        warmed.push(token.contractId);
+      } catch (error) {
+        if (!continueOnError) throw error;
+        failed.push({ contractId: token.contractId, error });
+      }
+    }),
+  );
+
+  return { warmed, failed };
+}
+
+async function main() {
+  const xlm: TokenInfo = { symbol: "XLM", contractId: "CNATIVE", decimals: 7 };
+  const usdc: TokenInfo = { symbol: "USDC", contractId: "CUSDC", decimals: 7 };
+
+  const mockReader: BalanceReader = {
+    async getTokenBalance(contractId) {
+      console.log(`  (network read: ${contractId})`);
+      return contractId === "CNATIVE" ? 50_0000000n : 100_0000000n;
+    },
+  };
+
+  const cached = createCachedBalanceReader(mockReader, { ttlMs: 15_000 });
+
+  console.log("Warming up cache for [XLM, USDC]...");
+  const result = await warmUpBalanceCache(cached, "CHOLDER", { tokens: [xlm, usdc] });
+  console.log(`  warmed: ${result.warmed.join(", ")}`);
+
+  console.log("\nReading again — should be cache hits (no 'network read' log line):");
+  console.log(`  XLM: ${await cached.getTokenBalance("CNATIVE", "CHOLDER")}`);
+  console.log(`  USDC: ${await cached.getTokenBalance("CUSDC", "CHOLDER")}`);
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main();
+}


### PR DESCRIPTION
## Summary

closes #227
closes #230
closes #235
closes #231

Three self-contained `contrib/examples/` reference implementations, scoped entirely inside `contrib/` per CONTRIBUTING.md, plus #231 closed by investigation rather than code (see below). (Supersedes #322, which was correctly auto-closed for touching `src/` directly — that version was the real fix wired into the actual SDK modules, but this repo's contribution model requires standalone reference code instead. Disclosure comments explaining that trade-off are already on all 4 issues from that attempt.)

## Changes

- **`contrib/examples/issue-227-session-idle-timeout/`** — `checkIdleExpiry(session, idleTimeoutMs, now?)` demonstrates the idle-timeout check `session.ts`'s `restore()` would need: compares `now - lastActiveAt` against the timeout, with an exclusive boundary (idle for exactly the timeout is still valid) and never treats a future `lastActiveAt` (clock skew) as expired. `logIdleExpiration()` provides the debug log entry the issue asks for. 5 tests.
- **`contrib/examples/issue-230-passkey-challenge-tracker/`** — `ChallengeTracker` tracks single-use, TTL-bounded passkey challenges (`register()`/`consume()`), distinguishing `PasskeyAssertionExpiredError` (too old — ask the user to retry) from `PasskeyAssertionReplayedError` (already used — a genuine replay attempt worth logging/alerting on). 8 tests.
- **`contrib/examples/issue-235-balance-cache-warmup/`** — `createCachedBalanceReader` wraps a `BalanceReader`-shaped interface with a TTL cache (keyed by token+holder; a failed read is never cached); `warmUpBalanceCache()` pre-populates it across an explicit, caller-chosen asset list — configurable warm-up selection per the issue's requirement — continuing past individual failures by default. 13 tests. (See also the existing `local-balance-cache` example for a simpler cache without the warm-up helper.)
- **#231 — no code in this PR.** Investigated before starting: the underlying goal (scoping `mcp-x402-payer`'s credentials to payment-authorization only) is already more strongly satisfied by `packages/mcp-x402-payer`'s existing `createSessionKeySigner` + on-chain policy enforcement (`__check_auth`) than token-scoping alone would achieve — see the full comment on #231 for the reasoning and the one gap it doesn't cover (the layer-1 hot-wallet fallback). Linked here as `closes #231` so it doesn't sit open indefinitely; reopen it if a maintainer disagrees that this is sufficient.

Each example is fully self-contained — no import from `src/` — with its own README, a runnable CLI demo (`npx tsx <file>.ts`), and a vitest suite, matching the existing `contrib/examples/` convention.

## Test plan

- All 26 new tests passing: `npx vitest run contrib/examples/issue-227-session-idle-timeout contrib/examples/issue-230-passkey-challenge-tracker contrib/examples/issue-235-balance-cache-warmup`
- Each CLI demo runs and produces the expected output (verified manually, output included in review if useful).
- `npx tsc --noEmit`: 2 pre-existing errors unrelated to this PR (`src/balances.test.ts`, `src/tx-rpc.ts`), confirmed present on clean `upstream/dev` before this branch. Zero errors in any file this PR adds.
- Full `npx vitest run`: 1263/1279 passing — the 16 failures (6 files, all `contrib/examples/wallet-*`) are pre-existing and confirmed unrelated (`PasskeyBrowserRequiredError` in a non-browser test environment).

## Note on `closes` links and the default branch

This repo's default branch is `main`, but contributions target `dev` per CONTRIBUTING.md. GitHub only auto-closes linked issues when a PR merges into the *default* branch — so these `closes` lines won't fire automatically when this merges into `dev`. Flagging so a maintainer can close #227/#230/#235/#231 manually at merge time, or confirm they close naturally when `dev` is later merged into `main`.