### PR TITLE
contrib: add polling backoff, balance queue, fetch retries and poison detection

### DIFF
--- a/contrib/examples/balances-rpc-concurrency-backpressure/README.md
+++ b/contrib/examples/balances-rpc-concurrency-backpressure/README.md
@@ -1,0 +1,3 @@
+# Balances RPC Concurrency Backpressure (#243)
+
+Limits outstanding parallel balance requests to prevent overwhelming Soroban RPC endpoints.

--- a/contrib/examples/balances-rpc-concurrency-backpressure/balances-rpc-concurrency-backpressure.test.ts
+++ b/contrib/examples/balances-rpc-concurrency-backpressure/balances-rpc-concurrency-backpressure.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from "vitest";
+import { ConcurrentBalanceQueue } from "./balances-rpc-concurrency-backpressure";
+
+describe("Issue #243 — Balance RPC Concurrency Backpressure", () => {
+  it("limits concurrent executions to maxConcurrency", async () => {
+    const queue = new ConcurrentBalanceQueue(2);
+    let running = 0;
+    let maxRunningObserved = 0;
+
+    const task = async () => {
+      running++;
+      maxRunningObserved = Math.max(maxRunningObserved, running);
+      await new Promise((r) => setTimeout(r, 20));
+      running--;
+      return true;
+    };
+
+    await Promise.all([
+      queue.run(task),
+      queue.run(task),
+      queue.run(task),
+      queue.run(task),
+      queue.run(task),
+    ]);
+
+    expect(maxRunningObserved).toBeLessThanOrEqual(2);
+    expect(queue.runningCount).toBe(0);
+    expect(queue.pendingCount).toBe(0);
+  });
+});

--- a/contrib/examples/balances-rpc-concurrency-backpressure/balances-rpc-concurrency-backpressure.ts
+++ b/contrib/examples/balances-rpc-concurrency-backpressure/balances-rpc-concurrency-backpressure.ts
@@ -1,0 +1,37 @@
+/**
+ * Issue #243: Concurrency Limit and Backpressure Queue for Balance RPC Requests.
+ */
+
+export class ConcurrentBalanceQueue {
+  private activeCount = 0;
+  private readonly queue: Array<() => void> = [];
+
+  constructor(public readonly maxConcurrency: number = 4) {
+    if (maxConcurrency < 1) throw new Error("maxConcurrency must be at least 1");
+  }
+
+  async run<T>(task: () => Promise<T>): Promise<T> {
+    if (this.activeCount >= this.maxConcurrency) {
+      await new Promise<void>((resolve) => this.queue.push(resolve));
+    }
+
+    this.activeCount++;
+    try {
+      return await task();
+    } finally {
+      this.activeCount--;
+      if (this.queue.length > 0) {
+        const next = this.queue.shift();
+        next?.();
+      }
+    }
+  }
+
+  get pendingCount(): number {
+    return this.queue.length;
+  }
+
+  get runningCount(): number {
+    return this.activeCount;
+  }
+}

--- a/contrib/examples/tx-polling-retry-backoff/README.md
+++ b/contrib/examples/tx-polling-retry-backoff/README.md
@@ -1,0 +1,3 @@
+# Transaction Polling Retry Backoff (#241)
+
+Implements exponential backoff with jitter, retry caps, and debug logging for transaction status polling calls.

--- a/contrib/examples/tx-polling-retry-backoff/tx-polling-retry-backoff.test.ts
+++ b/contrib/examples/tx-polling-retry-backoff/tx-polling-retry-backoff.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect, vi } from "vitest";
+import { pollWithBackoff } from "./tx-polling-retry-backoff";
+
+describe("Issue #241 — Transaction Polling Retry with Backoff", () => {
+  it("resolves when polling function succeeds after retries", async () => {
+    let callCount = 0;
+    const retryLogs: number[] = [];
+
+    const result = await pollWithBackoff(
+      async () => {
+        callCount++;
+        if (callCount < 3) return null;
+        return { status: "success", txHash: "abc123" };
+      },
+      {
+        initialDelayMs: 10,
+        maxDelayMs: 50,
+        jitter: false,
+        onRetry: (attempt, delay) => retryLogs.push(attempt),
+      }
+    );
+
+    expect(result.status).toBe("success");
+    expect(callCount).toBe(3);
+    expect(retryLogs.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it("throws error when max attempts are exceeded", async () => {
+    await expect(
+      pollWithBackoff(async () => null, {
+        initialDelayMs: 5,
+        maxAttempts: 3,
+        jitter: false,
+      })
+    ).rejects.toThrow(/exceeded maximum attempts/);
+  });
+});

--- a/contrib/examples/tx-polling-retry-backoff/tx-polling-retry-backoff.ts
+++ b/contrib/examples/tx-polling-retry-backoff/tx-polling-retry-backoff.ts
@@ -1,0 +1,59 @@
+/**
+ * Issue #241: Exponential Backoff Polling with Jitter for Transaction Status.
+ */
+
+export interface PollingRetryOptions {
+  initialDelayMs?: number;
+  maxDelayMs?: number;
+  backoffFactor?: number;
+  maxAttempts?: number;
+  totalTimeoutMs?: number;
+  jitter?: boolean;
+  onRetry?: (attempt: number, delayMs: number, reason?: Error) => void;
+}
+
+export async function pollWithBackoff<T>(
+  pollFn: (attempt: number) => Promise<T | null | undefined>,
+  options: PollingRetryOptions = {}
+): Promise<T> {
+  const initialDelay = options.initialDelayMs ?? 100;
+  const maxDelay = options.maxDelayMs ?? 2000;
+  const factor = options.backoffFactor ?? 1.5;
+  const maxAttempts = options.maxAttempts ?? 10;
+  const totalTimeout = options.totalTimeoutMs ?? 15000;
+  const useJitter = options.jitter ?? true;
+
+  const startTime = Date.now();
+  let attempt = 0;
+  let currentDelay = initialDelay;
+
+  while (attempt < maxAttempts) {
+    attempt++;
+    if (Date.now() - startTime > totalTimeout) {
+      throw new Error(`Polling timed out after ${totalTimeout}ms across ${attempt} attempts`);
+    }
+
+    try {
+      const result = await pollFn(attempt);
+      if (result !== null && result !== undefined) {
+        return result;
+      }
+    } catch (err) {
+      // transient polling error -> retry
+      options.onRetry?.(attempt, currentDelay, err instanceof Error ? err : new Error(String(err)));
+    }
+
+    if (attempt >= maxAttempts) {
+      break;
+    }
+
+    const jitterOffset = useJitter ? (Math.random() * 0.4 - 0.2) * currentDelay : 0;
+    const actualDelay = Math.min(maxDelay, Math.max(10, currentDelay + jitterOffset));
+
+    options.onRetry?.(attempt, actualDelay);
+    await new Promise((resolve) => setTimeout(resolve, actualDelay));
+    currentDelay = Math.min(maxDelay, currentDelay * factor);
+  }
+
+  throw new Error(`Transaction status polling exceeded maximum attempts (${maxAttempts})`);
+}

--- a/contrib/examples/x402-fetch-transient-retries/README.md
+++ b/contrib/examples/x402-fetch-transient-retries/README.md
@@ -1,0 +1,3 @@
+# x402 Client Transient Fetch Retries (#244)
+
+Automatically retries transient network and server errors (502/503/504) while failing fast on permanent client errors (400/401/403).

--- a/contrib/examples/x402-fetch-transient-retries/x402-fetch-transient-retries.test.ts
+++ b/contrib/examples/x402-fetch-transient-retries/x402-fetch-transient-retries.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect, vi } from "vitest";
+import {
+  fetchWithTransientRetry,
+  TransientFetchError,
+  PermanentFetchError,
+} from "./x402-fetch-transient-retries";
+
+describe("Issue #244 — x402 Transient Fetch Retries", () => {
+  it("retries on transient failure and succeeds", async () => {
+    let tries = 0;
+    const retrySpy = vi.fn();
+
+    const result = await fetchWithTransientRetry(
+      async () => {
+        tries++;
+        if (tries < 3) throw new TransientFetchError("503 Service Unavailable");
+        return { data: "ok" };
+      },
+      { maxRetries: 3, initialDelayMs: 5, onRetry: retrySpy }
+    );
+
+    expect(result.data).toBe("ok");
+    expect(tries).toBe(3);
+    expect(retrySpy).toHaveBeenCalledTimes(2);
+  });
+
+  it("fails immediately on permanent error without retrying", async () => {
+    let tries = 0;
+    await expect(
+      fetchWithTransientRetry(
+        async () => {
+          tries++;
+          throw new Error("400 Bad Request — Invalid Address");
+        },
+        { maxRetries: 3 }
+      )
+    ).rejects.toThrow(PermanentFetchError);
+
+    expect(tries).toBe(1);
+  });
+});

--- a/contrib/examples/x402-fetch-transient-retries/x402-fetch-transient-retries.ts
+++ b/contrib/examples/x402-fetch-transient-retries/x402-fetch-transient-retries.ts
@@ -1,0 +1,57 @@
+/**
+ * Issue #244: Retry Semantics for Transient x402-Client Resource Fetches.
+ */
+
+export class TransientFetchError extends Error {
+  constructor(message: string, public readonly status?: number) {
+    super(message);
+    this.name = "TransientFetchError";
+  }
+}
+
+export class PermanentFetchError extends Error {
+  constructor(message: string, public readonly status?: number) {
+    super(message);
+    this.name = "PermanentFetchError";
+  }
+}
+
+export interface FetchRetryOptions {
+  maxRetries?: number;
+  initialDelayMs?: number;
+  onRetry?: (attempt: number, error: Error) => void;
+}
+
+export async function fetchWithTransientRetry<T>(
+  fetchFn: () => Promise<T>,
+  options: FetchRetryOptions = {}
+): Promise<T> {
+  const maxRetries = options.maxRetries ?? 3;
+  let delay = options.initialDelayMs ?? 50;
+
+  for (let attempt = 1; attempt <= maxRetries + 1; attempt++) {
+    try {
+      return await fetchFn();
+    } catch (err) {
+      const error = err instanceof Error ? err : new Error(String(err));
+
+      // Check if transient error (e.g. 502, 503, 504, network timeout)
+      const isTransient =
+        error instanceof TransientFetchError ||
+        /network|timeout|econnreset|502|503|504/i.test(error.message);
+
+      if (!isTransient || attempt > maxRetries) {
+        if (!isTransient) {
+          throw new PermanentFetchError(`Permanent failure: ${error.message}`);
+        }
+        throw error;
+      }
+
+      options.onRetry?.(attempt, error);
+      await new Promise((r) => setTimeout(r, delay));
+      delay *= 2;
+    }
+  }
+
+  throw new Error("Max retries reached");
+}

--- a/contrib/examples/x402-poison-response-detector/README.md
+++ b/contrib/examples/x402-poison-response-detector/README.md
@@ -1,0 +1,3 @@
+# x402 Poison Response Detection (#246)
+
+Identifies unrecoverable malformed responses from resource endpoints after repeated consecutive parse failures, preventing endless deserialization loops.

--- a/contrib/examples/x402-poison-response-detector/x402-poison-response-detector.test.ts
+++ b/contrib/examples/x402-poison-response-detector/x402-poison-response-detector.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect, vi } from "vitest";
+import { PoisonResponseDetector, PoisonResponseError } from "./x402-poison-response-detector";
+
+describe("Issue #246 — x402 Poison Response Detection", () => {
+  it("throws PoisonResponseError when consecutive parse failures reach threshold", () => {
+    const logger = vi.fn();
+    const detector = new PoisonResponseDetector(3, logger);
+
+    detector.recordParseFailure("https://seller.test/api", "Invalid JSON syntax");
+    expect(detector.getFailures("https://seller.test/api")).toBe(1);
+
+    detector.recordParseFailure("https://seller.test/api", "Corrupted payload");
+    expect(detector.getFailures("https://seller.test/api")).toBe(2);
+
+    expect(() =>
+      detector.recordParseFailure("https://seller.test/api", "Empty body")
+    ).toThrow(PoisonResponseError);
+
+    expect(logger).toHaveBeenCalledWith("https://seller.test/api", 3);
+  });
+
+  it("resets failure counter on parse success", () => {
+    const detector = new PoisonResponseDetector(3);
+
+    detector.recordParseFailure("https://seller.test/api", "Bad format");
+    expect(detector.getFailures("https://seller.test/api")).toBe(1);
+
+    detector.recordParseSuccess("https://seller.test/api");
+    expect(detector.getFailures("https://seller.test/api")).toBe(0);
+  });
+});

--- a/contrib/examples/x402-poison-response-detector/x402-poison-response-detector.ts
+++ b/contrib/examples/x402-poison-response-detector/x402-poison-response-detector.ts
@@ -1,0 +1,37 @@
+/**
+ * Issue #246: Poison Response Detection for Malformed x402 Payment Responses.
+ */
+
+export class PoisonResponseError extends Error {
+  constructor(public readonly endpoint: string, public readonly failureCount: number, message: string) {
+    super(`[POISON_RESPONSE] Endpoint ${endpoint} returned ${failureCount} consecutive unparseable responses: ${message}`);
+    this.name = "PoisonResponseError";
+  }
+}
+
+export class PoisonResponseDetector {
+  private readonly failureCounts = new Map<string, number>();
+
+  constructor(
+    public readonly maxParseFailures = 3,
+    private readonly onPoisonDetected?: (endpoint: string, count: number) => void
+  ) {}
+
+  recordParseFailure(endpoint: string, reason: string): void {
+    const current = (this.failureCounts.get(endpoint) ?? 0) + 1;
+    this.failureCounts.set(endpoint, current);
+
+    if (current >= this.maxParseFailures) {
+      this.onPoisonDetected?.(endpoint, current);
+      throw new PoisonResponseError(endpoint, current, reason);
+    }
+  }
+
+  recordParseSuccess(endpoint: string): void {
+    this.failureCounts.delete(endpoint);
+  }
+
+  getFailures(endpoint: string): number {
+    return this.failureCounts.get(endpoint) ?? 0;
+  }
+}


### PR DESCRIPTION
## Summary

Adds reference implementations and unit tests scoped to `contrib/examples/` resolving 4 assigned Wave issues:

1. **Transaction Polling Retry Backoff (#241)**: `contrib/examples/tx-polling-retry-backoff/`
2. **Balance RPC Concurrency Backpressure (#243)**: `contrib/examples/balances-rpc-concurrency-backpressure/`
3. **x402 Transient Fetch Retries (#244)**: `contrib/examples/x402-fetch-transient-retries/`
4. **x402 Poison Response Detection (#246)**: `contrib/examples/x402-poison-response-detector/`

## Linked Issues

- Closes #241
- Closes #243
- Closes #244
- Closes #246