### PR TITLE
feat(http-backend): injectable structured request logging hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,8 +108,25 @@ transactions to your backend, which does the sponsored submit.
 | `POST /wallet/connect` | Resolve the smart-account for a known passkey  |
 | `POST /wallet/submit`  | Submit an already-signed transaction           |
 
-You run a backend implementing these (holding your relayer/sponsor creds). Your
-backend must also allow your app's origin via CORS.
+### Logging
+
+`createHttpWalletBackend` accepts an optional third argument — a structured
+logging hook — invoked once per completed request (success and failure alike)
+with a `{ method, url, status, durationMs }` entry:
+
+```ts
+import { createHttpWalletBackend } from "vellar-sdk";
+
+const backend = createHttpWalletBackend("https://api.myapp.com", undefined, (log) => {
+  console.info(JSON.stringify(log)); // { method, url, status, durationMs }
+  // route, parse, or filter on log.status / log.url in your log pipeline
+});
+```
+
+The hook receives structured fields instead of free-form console output, so
+consumer log pipelines can parse and route on them directly. The two arguments
+after the URL are optional; pass `undefined` for the default `fetch` and only
+the hook.
 
 ## API
 
@@ -129,9 +146,9 @@ Returns a `VellarWallet`:
 
 ### Helpers
 
-| Export                         | Description                                                                              |
-| ------------------------------ | ---------------------------------------------------------------------------------------- |
-| `createHttpWalletBackend(url)` | An HTTP `backend` client for your gateway — pass straight to the config                  |
+| Export                                    | Description                                                                              |
+| ----------------------------------------- | ---------------------------------------------------------------------------------------- |
+| `createHttpWalletBackend(url, fetch?, log?)` | An HTTP `backend` client for your gateway — pass straight to the config. Optional third arg is a structured `{ method, url, status, durationMs }` logging hook — see [Logging](#logging) |
 | `TESTNET`                      | Testnet config: `rpcUrl`, `networkPassphrase`, `walletWasmHash`, `nativeTokenContractId` |
 | `MAINNET` / `mainnetConfig()`  | Mainnet config — see [Mainnet](#mainnet) (two values you must supply)                    |
 | `WalletApiError`               | Thrown by the HTTP backend on non-2xx responses (has `status`, `code`)                   |

--- a/src/http-backend.test.ts
+++ b/src/http-backend.test.ts
@@ -1,0 +1,149 @@
+import { describe, expect, it, vi } from "vitest";
+import { createHttpWalletBackend, WalletApiError, type RequestLog } from "./http-backend";
+
+function jsonResponse(status: number, body?: unknown): Response {
+  return new Response(body === undefined ? undefined : JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+describe("createHttpWalletBackend logging hook", () => {
+  const apiUrl = "https://gateway.example.com/";
+
+  it("invokes the hook with method, url, status, and duration on success", async () => {
+    const log = vi.fn<(log: RequestLog) => void>();
+    const backend = createHttpWalletBackend(
+      apiUrl,
+      vi.fn(async () => jsonResponse(200, { sessionId: "s1" })),
+      log,
+    );
+
+    await backend.submitWalletCreation({
+      keyId: "k1",
+      contractId: "C000",
+      network: "testnet",
+      signedTx: "xdr",
+    });
+
+    expect(log).toHaveBeenCalledTimes(1);
+    const entry = log.mock.calls[0]![0];
+    expect(entry.method).toBe("POST");
+    expect(entry.url).toBe("https://gateway.example.com/wallet/create");
+    expect(entry.status).toBe(200);
+    expect(entry.durationMs).toBeTypeOf("number");
+    expect(entry.durationMs).toBeGreaterThanOrEqual(0);
+  });
+
+  it("logs submitTransaction success with the right url", async () => {
+    const log = vi.fn<(log: RequestLog) => void>();
+    const backend = createHttpWalletBackend(
+      apiUrl,
+      vi.fn(async () => jsonResponse(200, { hash: "deadbeef" })),
+      log,
+    );
+
+    await backend.submitTransaction({ signedXdr: "xdr", network: "testnet" });
+
+    expect(log).toHaveBeenCalledTimes(1);
+    expect(log.mock.calls[0]![0]).toMatchObject({
+      method: "POST",
+      url: "https://gateway.example.com/wallet/submit",
+      status: 200,
+    });
+  });
+
+  it("logs a failure for /wallet/create and still throws WalletApiError", async () => {
+    const log = vi.fn<(log: RequestLog) => void>();
+    const backend = createHttpWalletBackend(
+      apiUrl,
+      vi.fn(async () => jsonResponse(500, { error: "sponsor down" })),
+      log,
+    );
+
+    await expect(
+      backend.submitWalletCreation({
+        keyId: "k1",
+        contractId: "C000",
+        network: "testnet",
+        signedTx: "xdr",
+      }),
+    ).rejects.toThrow(WalletApiError);
+
+    expect(log).toHaveBeenCalledTimes(1);
+    expect(log.mock.calls[0]![0]).toMatchObject({
+      method: "POST",
+      url: "https://gateway.example.com/wallet/create",
+      status: 500,
+    });
+    expect(log.mock.calls[0]![0].durationMs).toBeGreaterThanOrEqual(0);
+  });
+
+  it("logs a failure for /wallet/connect (non-404) and still throws", async () => {
+    const log = vi.fn<(log: RequestLog) => void>();
+    const backend = createHttpWalletBackend(
+      apiUrl,
+      vi.fn(async () => jsonResponse(401, { message: "unauthorized" })),
+      log,
+    );
+
+    await expect(
+      backend.lookupContractId({ keyId: "k1", network: "testnet" }),
+    ).rejects.toThrow("unauthorized");
+
+    expect(log).toHaveBeenCalledTimes(1);
+    expect(log.mock.calls[0]![0]).toMatchObject({
+      url: "https://gateway.example.com/wallet/connect",
+      status: 401,
+    });
+  });
+
+  it("logs a failure for /wallet/submit and still throws", async () => {
+    const log = vi.fn<(log: RequestLog) => void>();
+    const backend = createHttpWalletBackend(
+      apiUrl,
+      vi.fn(async () => jsonResponse(503, { error: "busy" })),
+      log,
+    );
+
+    await expect(
+      backend.submitTransaction({ signedXdr: "xdr", network: "testnet" }),
+    ).rejects.toThrow("busy");
+
+    expect(log).toHaveBeenCalledTimes(1);
+    expect(log.mock.calls[0]![0]).toMatchObject({
+      url: "https://gateway.example.com/wallet/submit",
+      status: 503,
+    });
+  });
+
+  it("logs the 404 lookup edge case and returns undefined (not an error)", async () => {
+    const log = vi.fn<(log: RequestLog) => void>();
+    const backend = createHttpWalletBackend(
+      apiUrl,
+      vi.fn(async () => jsonResponse(404)),
+      log,
+    );
+
+    await expect(
+      backend.lookupContractId({ keyId: "nope", network: "testnet" }),
+    ).resolves.toBeUndefined();
+
+    expect(log).toHaveBeenCalledTimes(1);
+    expect(log.mock.calls[0]![0]).toMatchObject({
+      url: "https://gateway.example.com/wallet/connect",
+      status: 404,
+    });
+  });
+
+  it("is a no-op (and does not throw) when no hook is supplied", async () => {
+    const backend = createHttpWalletBackend(
+      apiUrl,
+      vi.fn(async () => jsonResponse(500, { error: "boom" })),
+    );
+
+    await expect(
+      backend.lookupContractId({ keyId: "k1", network: "testnet" }),
+    ).rejects.toThrow(WalletApiError);
+  });
+});

--- a/src/http-backend.ts
+++ b/src/http-backend.ts
@@ -19,6 +19,26 @@ export class WalletApiError extends Error {
   }
 }
 
+export interface RequestLog {
+  /** HTTP method used for the request. */
+  method: string;
+  /** Full request URL (base + path). */
+  url: string;
+  /** HTTP status returned by the gateway. */
+  status: number;
+  /** Round-trip duration of the request, in milliseconds. */
+  durationMs: number;
+}
+
+/**
+ * Structured logging hook for HTTP-backend requests. If provided, it is
+ * invoked once per completed request (success and failure alike) with
+ * `method`, `url`, `status`, and `durationMs`, so consumer log pipelines can
+ * parse, filter, and route on structured fields instead of free-form console
+ * output.
+ */
+export type RequestLogHook = (log: RequestLog) => void;
+
 async function toApiError(res: Response): Promise<WalletApiError> {
   let payload: { error?: string; message?: string } | undefined;
   try {
@@ -57,21 +77,30 @@ export interface HttpWalletBackend {
  * "https://api.myapp.com"). Suitable to pass directly as
  * `createVellarWallet({ backend })`.
  *
- * @param apiUrl   Base URL of your Vellar-compatible gateway.
+ * @param apiUrl    Base URL of your Vellar-compatible gateway.
  * @param fetchImpl Optional fetch (defaults to the global fetch).
+ * @param logHook   Optional structured logging hook; called once per completed
+ *                  request with `{ method, url, status, durationMs }`. Omit it
+ *                  (or pass `undefined`) to disable logging.
  */
 export function createHttpWalletBackend(
   apiUrl: string,
   fetchImpl: typeof fetch = globalThis.fetch.bind(globalThis),
+  logHook?: RequestLogHook,
 ): HttpWalletBackend {
   const base = apiUrl.replace(/\/+$/, "");
 
-  const post = (path: string, body: unknown): Promise<Response> =>
-    fetchImpl(`${base}${path}`, {
+  const post = async (path: string, body: unknown): Promise<Response> => {
+    const url = `${base}${path}`;
+    const start = performance.now();
+    const res = await fetchImpl(url, {
       method: "POST",
       headers: { "content-type": "application/json" },
       body: JSON.stringify(body),
     });
+    logHook?.({ method: "POST", url, status: res.status, durationMs: performance.now() - start });
+    return res;
+  };
 
   return {
     async submitWalletCreation({ keyId, contractId, network, signedTx }) {


### PR DESCRIPTION
Closes #247

## Overview

`http-backend.ts` previously gave consumers no way to observe request telemetry
in their log pipelines. This PR introduces an **injectable, structured logging
hook** on `createHttpWalletBackend`. When supplied, the hook fires once per
completed request (success and failure alike) with a structured entry:

```
{ method: "POST", url: ".../wallet/create", status: 200, durationMs: 34.2 }
```

Consumers can parse, filter, and route on those fields instead of scraping
free-form console output. The change is fully **backwards-compatible** — the
hook is an optional third argument, so existing call sites keep working and any
code that omits it simply gets no logging.

## Why

The issue asks to replace plain-console failure logging with a structured hook.
Two notes worth surfacing up front:

- **Current code has no logging at all.** The committed `http-backend.ts` did
  not contain any `console.*` calls — the issue description described logging
  that wasn't actually there in this snapshot. This PR implements the *intent*:
  an injectable, parseable request-logging hook.
- **The hook logs every completed request, not only failures.** Logging only
  errors would make it impossible for consumer pipelines to derive error rates
  or latency distributions from a single source. Every entry is identical in
  shape, and `status` is included so consumers can filter for failures
  themselves.

## What changed

### `src/http-backend.ts`
- **Added** `export interface RequestLog { method, url, status, durationMs }` —
  the structured shape every log entry carries.
- **Added** `export type RequestLogHook = (log: RequestLog) => void` — the
  injectable hook signature.
- **Changed** `createHttpWalletBackend(apiUrl, fetchImpl?, logHook?)` to accept
  the optional hook (third positional argument — no breaking change to the
  existing two-arg signature).
- **Internally** the `post` helper now wraps each `fetch` in
  `performance.now()` timing and calls `logHook?.({ method, url, status,
  durationMs })` once a response is received, before the caller inspects the
  status. Durations are real measured round-trip times in milliseconds.

### `src/http-backend.test.ts` (new) — 7 tests
| # | Test | What it verifies |
|---|------|------------------|
| 1 | `invokes the hook ... on success` | hook called once; asserts `method`, `url`, `status`, `durationMs` all present and correct on `/wallet/create` |
| 2 | `logs submitTransaction success` | `/wallet/submit` success logs the expected url + status |
| 3 | `logs a failure for /wallet/create` | 500 on create -> hook logs status 500, error still throws `WalletApiError` |
| 4 | `logs a failure for /wallet/connect` | 401 on connect -> hook logs status 401, error message preserved |
| 5 | `logs a failure for /wallet/submit` | 503 on submit -> hook logs status 503, error message preserved |
| 6 | `logs the 404 lookup edge case` | `lookupContractId` 404 -> hook logs status 404, method still returns `undefined` (not an error) |
| 7 | `is a no-op when no hook is supplied` | omitting the hook produces no log call and no crash while errors still throw |

### `README.md`
- **New "Logging" section** under "Your backend" documenting the hook
  interface with a code example.
- **Updated Helpers table** to note the optional third argument.

## Design decisions

1. **Optional third positional arg, not a breaking options object.**
   `createHttpWalletBackend(url, fetchImpl)` is a documented two-arg API; making
   the hook a third optional arg avoids breaking anyone. (An options object is a
   clean follow-up if more knobs are added later.)
2. **Log after the response, regardless of outcome.** Because every branch
   (`create`, `connect`, `submit`) funnels through the same `post` helper, all
   of them get uniform logging for free — success, `WalletApiError` failures,
   and the `404 -> undefined` path.
3. **`durationMs` via `performance.now()`.** Precise, monotonic, and available
   in both browsers and the Node globals this SDK targets.
4. **Metadata only, never bodies.** No request or response payloads are passed
   to the hook — only `method`, `url`, `status`, `durationMs`.
5. **Type-safe hook.** `RequestLog` is exported, so consumers get autocomplete
   and type-checking on the entry they receive.

## Acceptance criteria -> coverage

| Criteria | Satisfied by |
|----------|--------------|
| ✅ Switch to an **injectable structured logging hook** | `RequestLogHook` param on `createHttpWalletBackend`; no-hook path tested (#7); interface exported |
| ✅ Include **method, url, status, and duration** in each log call | `RequestLog` fields; asserted in tests #1-#6 |
| ✅ Add a **test verifying the hook receives expected fields** | Test #1 asserts all four fields; #2-#6 assert the subset relevant to each branch |
| ✅ **Update the README** with the new interface | New "Logging" section + Helpers table row |

## Verification

**Tests** — `npm test`
```
Test Files  31 passed (31)
     Tests  521 passed (521)
```
Including the new `src/http-backend.test.ts` (**7 tests passed**).

**Typecheck** — `npm run typecheck` (both `tsc --noEmit` and the
`packages/mcp-x402-payer` project) -> **clean**. This repo defines no lint
script.

**Coverage** — Not generated. The repo has **no coverage provider installed**
(no `@vitest/coverage-v8`) and `vitest.config.ts` defines no coverage config or
threshold, so `--coverage` would require adding a dev dependency (out of scope
here). The 7 tests directly exercise every branch of the changed file, including
each failure path and the edge case in the acceptance criteria. Happy to add
coverage tooling as a follow-up if desired.

## Edge cases handled

- `lookupContractId` returning `404` -> logged at `status: 404`, still returns
  `undefined` (no spurious error, no spurious log shape change).
- Omitted hook -> silent no-op, no crash, errors still propagate normally.
- URL with trailing slash -> normalized, so `url` is always the exact requested
  URL.
- Non-JSON error bodies -> `WalletApiError` still carries a sensible generic
  message (pre-existing behavior, unchanged).

## Known limitation / honest follow-up

- **Network-level fetch rejections are not logged.** If `fetch` itself rejects
  (DNS failure, connection reset) there is no HTTP `status`, and the required
  `status` field is numeric. Those are intentionally not logged in this pass. A
  small follow-up could log them with a sentinel (e.g. `status: 0`) or make
  `status` nullable — your call on the desired consumer contract.

## Security note

No secrets, keys, or PII are introduced. The hook receives only request
metadata (`method`, `url`, `status`, `durationMs`) — never request/response
bodies, headers, or auth material. The gateway `apiUrl` handling and `fetchImpl`
injection are unchanged. This PR contains no credentials; the temporary PAT used
to push/open this PR should be rotated/revoked after it is used.
