### PR TITLE
x402 confirmation threshold, policy template cache, exactly-once payments, batch ordering

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,41 @@ const { hash } = await vellar.pay({
 `pay()` simulates **before** the passkey prompt, so failures (e.g. insufficient
 balance) surface without asking the user to sign.
 
+### Exactly-once submission guard
+
+Pass a stable `paymentId` to avoid a duplicate on-chain submission if `pay()`
+is called twice for the same logical payment — e.g. a double-tap on a submit
+button, or your own retry after a slow or ambiguous response:
+
+```ts
+const { hash } = await vellar.pay({
+  to: "CDEST...",
+  amount: 5_0000000n,
+  token: { contractId: TESTNET.nativeTokenContractId, symbol: "XLM", decimals: 7 },
+  paymentId: "checkout-session-42", // your own id — stable across retries of the SAME payment
+});
+```
+
+- Two `pay()` calls with the **same** `paymentId` resolve to the **same**
+  result: the second call returns the first call's outcome (or shares its
+  in-flight attempt, if the first hasn't settled yet) instead of signing and
+  submitting again.
+- Omit `paymentId` to opt out — every call submits independently, matching
+  behavior before this guard existed.
+- **Scope and limits:** this is an in-memory guard scoped to one
+  `VellarWallet`/`createPaymentClient` instance's lifetime. It does **not**
+  survive a page reload, and it does **not** coordinate across two separate
+  wallet instances (e.g. two tabs). It also isn't itself an on-chain
+  guarantee — it prevents *this SDK instance* from signing/submitting twice,
+  but ultimate exactly-once delivery of the underlying transaction still
+  depends on your backend/relayer's own handling of a resubmitted signed XDR.
+  Reusing the same `paymentId` for two genuinely different payments (different
+  amount, recipient, etc.) is a caller error: the guard keys purely on the id,
+  so it will incorrectly return the first payment's result for the second.
+- A **failed** submission (e.g. a transient relayer error) does not
+  permanently lock the id — retrying `pay()` with the same `paymentId` after
+  a failure submits fresh.
+
 ## Your backend
 
 Submission is fee-sponsored, which requires an OpenZeppelin Relayer API key and

--- a/src/client.test.ts
+++ b/src/client.test.ts
@@ -113,6 +113,29 @@ describe("createVellarWallet", () => {
     expect(result.hash).toBe("txhash-abc");
   });
 
+  it("pay() with the same paymentId across two calls submits only once (#240)", async () => {
+    const { wallet, kit, backend } = build();
+    await wallet.connect();
+
+    const first = await wallet.pay({ to: "CDEST", amount: 5n, token, paymentId: "pay-1" });
+    const second = await wallet.pay({ to: "CDEST", amount: 5n, token, paymentId: "pay-1" });
+
+    expect(first).toEqual(second);
+    expect(kit.sign).toHaveBeenCalledTimes(1);
+    expect(backend.submitTransaction).toHaveBeenCalledTimes(1);
+  });
+
+  it("pay() without a paymentId submits independently each call (unchanged default behavior)", async () => {
+    const { wallet, kit, backend } = build();
+    await wallet.connect();
+
+    await wallet.pay({ to: "CDEST", amount: 5n, token });
+    await wallet.pay({ to: "CDEST", amount: 5n, token });
+
+    expect(kit.sign).toHaveBeenCalledTimes(2);
+    expect(backend.submitTransaction).toHaveBeenCalledTimes(2);
+  });
+
   it("rejects a payment to an invalid address before signing", async () => {
     const { wallet, kit } = build({ isValidAddress: () => false });
     await wallet.connect();

--- a/src/client.ts
+++ b/src/client.ts
@@ -105,6 +105,16 @@ export interface PayInput {
   amount: bigint;
   /** The token to send (contract id + decimals). */
   token: TokenInfo;
+  /**
+   * Client-generated idempotency key for the exactly-once submission guard
+   * (#240) — see `PreparedPayment.confirm`'s doc comment in
+   * payments-client.ts for the full scope/limits. Pass a stable id (e.g.
+   * derived from the triggering UI action) so a retried/double-submitted
+   * `pay()` call for the same logical payment resolves to the same result
+   * instead of submitting twice. Omit to opt out (each call submits
+   * independently).
+   */
+  paymentId?: string;
 }
 
 /**
@@ -274,7 +284,7 @@ export function createVellarWallet(config: VellarWalletConfig): VellarWallet {
       return session;
     },
 
-    async pay({ to, amount, token }) {
+    async pay({ to, amount, token, paymentId }) {
       if (!session) {
         throw new WalletNotReadyError("Call create() or connect() before pay()");
       }
@@ -283,6 +293,7 @@ export function createVellarWallet(config: VellarWalletConfig): VellarWallet {
         to,
         token,
         amount,
+        paymentId,
       });
       return prepared.confirm();
     },

--- a/src/payments-client.ts
+++ b/src/payments-client.ts
@@ -39,7 +39,23 @@ export class InvalidRecipientError extends Error {
 
 export interface PreparedPayment {
   review: PaymentReview;
-  /** Sign with the passkey and submit. Only ever call after explicit user approval. */
+  /**
+   * Sign with the passkey and submit. Only ever call after explicit user
+   * approval.
+   *
+   * Exactly-once guarantee (#240): when `preparePayment` was given a
+   * `paymentId`, calling `confirm()` more than once for that same id — e.g.
+   * a UI double-submit, or a consumer's own retry after a slow/uncertain
+   * response — returns the SAME in-flight promise or cached result rather
+   * than signing/submitting again. This is a same-instance, in-memory guard
+   * (scoped to one `PaymentClient`, cleared on reload); it does not survive
+   * a page refresh or protect against two independent `PaymentClient`
+   * instances. It also does not by itself guarantee the underlying
+   * transaction only lands on-chain once — that still depends on the
+   * backend/relayer's own idempotency for a given signed XDR. See the
+   * "Exactly-once guard" section of the payments doc for the full scope and
+   * limits of this guarantee.
+   */
   confirm(): Promise<{ hash: string }>;
 }
 
@@ -49,6 +65,15 @@ export interface PaymentClient {
     to: string;
     token: TokenInfo;
     amount: bigint;
+    /**
+     * Client-generated idempotency key for the exactly-once submission guard
+     * (#240). Omit to opt out (each `confirm()` call submits independently,
+     * the pre-#240 behavior). Reusing the same id for two DIFFERENT payments
+     * (different amount/recipient/etc.) is a caller error — the guard keys
+     * purely on the id, not on payment content, so it would incorrectly
+     * short-circuit the second one to the first one's result.
+     */
+    paymentId?: string;
   }): Promise<PreparedPayment>;
 }
 
@@ -65,8 +90,20 @@ export interface PaymentClientOptions {
 export function createPaymentClient(options: PaymentClientOptions): PaymentClient {
   const signedToXdr = options.signedToXdr ?? defaultSignedToXdr;
 
+  // Exactly-once submission guard (#240), keyed on the caller-supplied
+  // paymentId. Tracks the IN-FLIGHT/settled confirm() promise per id, scoped
+  // to this PaymentClient instance's lifetime (in-memory; not durable across
+  // reloads — see PreparedPayment.confirm's doc comment for the full scope).
+  //
+  // A promise, not just a boolean "already submitted" flag, so a duplicate
+  // confirm() call that arrives WHILE the first is still submitting shares
+  // that same in-flight attempt instead of racing a second submission before
+  // the first has even resolved — sharing the resolved/rejected outcome
+  // either way once it settles.
+  const submissionsByPaymentId = new Map<string, Promise<{ hash: string }>>();
+
   return {
-    async preparePayment({ from, to, token, amount }) {
+    async preparePayment({ from, to, token, amount, paymentId }) {
       if (!options.isValidAddress(to)) {
         throw new InvalidRecipientError(`"${to}" is not a valid Stellar address`);
       }
@@ -87,12 +124,35 @@ export function createPaymentClient(options: PaymentClientOptions): PaymentClien
 
       return {
         review,
-        async confirm() {
-          const signed = (await options.kit.sign(tx)) ?? tx;
-          return options.backend.submitTransaction({
-            signedXdr: signedToXdr(signed),
-            network: options.network,
-          });
+        confirm() {
+          if (paymentId !== undefined) {
+            const existing = submissionsByPaymentId.get(paymentId);
+            if (existing) return existing;
+          }
+
+          const submission = (async () => {
+            const signed = (await options.kit.sign(tx)) ?? tx;
+            return options.backend.submitTransaction({
+              signedXdr: signedToXdr(signed),
+              network: options.network,
+            });
+          })();
+
+          if (paymentId !== undefined) {
+            submissionsByPaymentId.set(paymentId, submission);
+            // A REJECTED submission must not permanently block retries under
+            // the same id — a failed attempt (e.g. transient relayer error)
+            // is not "already submitted", and the whole point of an
+            // idempotency key is to let the caller safely retry. Only a
+            // resolved (successful) submission should keep the cached entry.
+            submission.catch(() => {
+              if (submissionsByPaymentId.get(paymentId) === submission) {
+                submissionsByPaymentId.delete(paymentId);
+              }
+            });
+          }
+
+          return submission;
         },
       };
     },

--- a/src/payments.test.ts
+++ b/src/payments.test.ts
@@ -157,3 +157,131 @@ describe("PreparedPayment.confirm", () => {
     await expect(prepared.confirm()).rejects.toThrow("relayer down");
   });
 });
+
+// #240: exactly-once submission guard, keyed on a client-generated paymentId.
+describe("PreparedPayment.confirm — exactly-once submission guard (#240)", () => {
+  it("submits once for two sequential confirm() calls with the same paymentId", async () => {
+    const { client, sign, submitTransaction } = clientWith();
+    const prepared = await client.preparePayment({
+      from: FROM,
+      to: TO,
+      token: xlm,
+      amount: 5n,
+      paymentId: "pay-1",
+    });
+
+    const first = await prepared.confirm();
+    const second = await prepared.confirm();
+
+    expect(first).toEqual({ hash: "txhash" });
+    expect(second).toEqual({ hash: "txhash" });
+    expect(sign).toHaveBeenCalledTimes(1);
+    expect(submitTransaction).toHaveBeenCalledTimes(1);
+  });
+
+  it("de-duplicates CONCURRENT confirm() calls (a UI double-submit) into one submission", async () => {
+    let resolveSign!: (v: { toXDR(): string }) => void;
+    const sign = vi.fn(() => new Promise<{ toXDR(): string }>((r) => (resolveSign = r)));
+    const submitTransaction = vi.fn().mockResolvedValue({ hash: "txhash" });
+    const { client } = clientWith({ kit: { sign }, backend: { submitTransaction } });
+    const prepared = await client.preparePayment({
+      from: FROM,
+      to: TO,
+      token: xlm,
+      amount: 5n,
+      paymentId: "pay-2",
+    });
+
+    // Two calls fired back-to-back, before the first has resolved.
+    const p1 = prepared.confirm();
+    const p2 = prepared.confirm();
+    resolveSign({ toXDR: () => "signed-xdr" });
+
+    const [r1, r2] = await Promise.all([p1, p2]);
+    expect(r1).toEqual({ hash: "txhash" });
+    expect(r2).toEqual({ hash: "txhash" });
+    expect(sign).toHaveBeenCalledTimes(1);
+    expect(submitTransaction).toHaveBeenCalledTimes(1);
+  });
+
+  it("submits independently each call when no paymentId is given (opt-out, unchanged pre-#240 behavior)", async () => {
+    const { client, sign, submitTransaction } = clientWith();
+    const prepared = await client.preparePayment({ from: FROM, to: TO, token: xlm, amount: 5n });
+
+    await prepared.confirm();
+    await prepared.confirm();
+
+    expect(sign).toHaveBeenCalledTimes(2);
+    expect(submitTransaction).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not permanently block retries after a FAILED submission under the same paymentId", async () => {
+    const submitTransaction = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("relayer down"))
+      .mockResolvedValueOnce({ hash: "txhash-retry" });
+    const { client, sign } = clientWith({ backend: { submitTransaction } });
+    const prepared = await client.preparePayment({
+      from: FROM,
+      to: TO,
+      token: xlm,
+      amount: 5n,
+      paymentId: "pay-3",
+    });
+
+    await expect(prepared.confirm()).rejects.toThrow("relayer down");
+    await expect(prepared.confirm()).resolves.toEqual({ hash: "txhash-retry" });
+    expect(sign).toHaveBeenCalledTimes(2);
+    expect(submitTransaction).toHaveBeenCalledTimes(2);
+  });
+
+  it("keeps distinct paymentIds fully independent — each submits its own payment", async () => {
+    const { client, sign, submitTransaction } = clientWith();
+    const first = await client.preparePayment({
+      from: FROM,
+      to: TO,
+      token: xlm,
+      amount: 5n,
+      paymentId: "pay-a",
+    });
+    const second = await client.preparePayment({
+      from: FROM,
+      to: TO,
+      token: xlm,
+      amount: 7n,
+      paymentId: "pay-b",
+    });
+
+    await first.confirm();
+    await second.confirm();
+
+    expect(sign).toHaveBeenCalledTimes(2);
+    expect(submitTransaction).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not share submission state across separate PaymentClient instances", async () => {
+    const { client: clientA, submitTransaction: submitA } = clientWith();
+    const { client: clientB, submitTransaction: submitB } = clientWith();
+
+    const preparedA = await clientA.preparePayment({
+      from: FROM,
+      to: TO,
+      token: xlm,
+      amount: 5n,
+      paymentId: "shared-id",
+    });
+    const preparedB = await clientB.preparePayment({
+      from: FROM,
+      to: TO,
+      token: xlm,
+      amount: 5n,
+      paymentId: "shared-id",
+    });
+
+    await preparedA.confirm();
+    await preparedB.confirm();
+
+    expect(submitA).toHaveBeenCalledTimes(1);
+    expect(submitB).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/policy-client.test.ts
+++ b/src/policy-client.test.ts
@@ -41,6 +41,150 @@ describe("createPolicyClient", () => {
     expect(fetchMock.mock.calls[0]![0]).toBe("https://api.test/policies/templates");
   });
 
+  it("caches listTemplates() — a second call does not re-fetch", async () => {
+    const fetchMock = vi.fn<typeof fetch>(async () =>
+      jsonResponse([
+        { type: "spending_limit", title: "Spending limit", description: "", enforcement: { kind: "none" } },
+      ]),
+    );
+    const client = createPolicyClient({ apiUrl: "https://api.test", network: "testnet", fetch: fetchMock });
+
+    const first = await client.listTemplates();
+    const second = await client.listTemplates();
+
+    expect(second).toEqual(first);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("de-duplicates concurrent listTemplates() calls into one request", async () => {
+    const fetchMock = vi.fn<typeof fetch>(async () =>
+      jsonResponse([
+        { type: "spending_limit", title: "Spending limit", description: "", enforcement: { kind: "none" } },
+      ]),
+    );
+    const client = createPolicyClient({ apiUrl: "https://api.test", network: "testnet", fetch: fetchMock });
+
+    const [a, b, c] = await Promise.all([
+      client.listTemplates(),
+      client.listTemplates(),
+      client.listTemplates(),
+    ]);
+
+    expect(a).toEqual(b);
+    expect(b).toEqual(c);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("generate() invalidates the templates cache — a subsequent listTemplates() re-fetches", async () => {
+    const fetchMock = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(
+        jsonResponse([
+          { type: "spending_limit", title: "Spending limit", description: "", enforcement: { kind: "none" } },
+        ]),
+      )
+      .mockResolvedValueOnce(jsonResponse({ policy: { id: "p1", status: "generated" } }))
+      .mockResolvedValueOnce(
+        jsonResponse([
+          { type: "spending_limit", title: "Spending limit (updated)", description: "", enforcement: { kind: "none" } },
+        ]),
+      );
+    const client = createPolicyClient({ apiUrl: "https://api.test", network: "testnet", fetch: fetchMock });
+
+    await client.listTemplates(); // populates the cache
+    await client.generate(definition); // should invalidate it
+    const templates = await client.listTemplates(); // should re-fetch, not read stale cache
+
+    expect(templates[0]!.title).toBe("Spending limit (updated)");
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+  });
+
+  it("refreshTemplates() invalidates the cache and re-fetches even without an intervening mutation", async () => {
+    const fetchMock = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(
+        jsonResponse([
+          { type: "spending_limit", title: "Spending limit", description: "", enforcement: { kind: "none" } },
+        ]),
+      )
+      .mockResolvedValueOnce(
+        jsonResponse([
+          { type: "spending_limit", title: "Spending limit v2", description: "", enforcement: { kind: "none" } },
+        ]),
+      );
+    const client = createPolicyClient({ apiUrl: "https://api.test", network: "testnet", fetch: fetchMock });
+
+    await client.listTemplates();
+    const refreshed = await client.refreshTemplates();
+
+    expect(refreshed[0]!.title).toBe("Spending limit v2");
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("fires onCacheInvalidated with reason 'template-update' when generate() invalidates a populated cache", async () => {
+    const fetchMock = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(jsonResponse([]))
+      .mockResolvedValueOnce(jsonResponse({ policy: { id: "p1", status: "generated" } }));
+    const onCacheInvalidated = vi.fn();
+    const fixedNow = () => new Date("2026-01-01T00:00:00.000Z");
+    const client = createPolicyClient({
+      apiUrl: "https://api.test",
+      network: "testnet",
+      fetch: fetchMock,
+      onCacheInvalidated,
+      now: fixedNow,
+    });
+
+    await client.listTemplates(); // populate the cache first
+    await client.generate(definition);
+
+    expect(onCacheInvalidated).toHaveBeenCalledTimes(1);
+    expect(onCacheInvalidated).toHaveBeenCalledWith({
+      cache: "templates",
+      reason: "template-update",
+      at: "2026-01-01T00:00:00.000Z",
+    });
+  });
+
+  it("fires onCacheInvalidated with reason 'explicit-refresh' from refreshTemplates()", async () => {
+    const fetchMock = vi.fn<typeof fetch>(async () => jsonResponse([]));
+    const onCacheInvalidated = vi.fn();
+    const client = createPolicyClient({
+      apiUrl: "https://api.test",
+      network: "testnet",
+      fetch: fetchMock,
+      onCacheInvalidated,
+    });
+
+    await client.listTemplates();
+    await client.refreshTemplates();
+
+    expect(onCacheInvalidated).toHaveBeenCalledTimes(1);
+    expect(onCacheInvalidated.mock.calls[0]![0]).toMatchObject({
+      cache: "templates",
+      reason: "explicit-refresh",
+    });
+  });
+
+  it("does not fire onCacheInvalidated when generate() runs before the cache was ever populated", async () => {
+    const fetchMock = vi.fn<typeof fetch>(async () =>
+      jsonResponse({ policy: { id: "p1", status: "generated" } }),
+    );
+    const onCacheInvalidated = vi.fn();
+    const client = createPolicyClient({
+      apiUrl: "https://api.test",
+      network: "testnet",
+      fetch: fetchMock,
+      onCacheInvalidated,
+    });
+
+    // No listTemplates() call first — nothing was ever cached.
+    await client.generate(definition);
+
+    expect(onCacheInvalidated).not.toHaveBeenCalled();
+  });
+
   it("generate() posts the definition + network and returns the policy", async () => {
     const fetchMock = vi.fn<typeof fetch>(async () =>
       jsonResponse({ policy: { id: "p1", status: "generated" } }),

--- a/src/policy-client.ts
+++ b/src/policy-client.ts
@@ -51,6 +51,24 @@ function buildListQuery(filters?: PolicyListFilters): string {
   return qs ? `?${qs}` : "";
 }
 
+/**
+ * Fired when the local `listTemplates()` cache is invalidated (#232). Purely
+ * observational — invalidation happens regardless of whether a listener is
+ * attached. Injectable rather than a hardcoded `console.debug` call, matching
+ * this SDK's existing seams (`fetch`, `webAuthn`) so a host can route it into
+ * its own logger, or ignore it entirely.
+ */
+export interface CacheInvalidationEvent {
+  /** What was invalidated. Only "templates" exists today; the union leaves
+   * room for future cached endpoints without a breaking change to the type. */
+  cache: "templates";
+  /** Why: an explicit `refreshTemplates()` call, or a mutation this client
+   * made that could have changed template data server-side. */
+  reason: "explicit-refresh" | "template-update";
+  /** When the invalidation happened. */
+  at: string;
+}
+
 export interface PolicyClientOptions {
   /** Gateway base URL (e.g. https://api.myapp.com). */
   apiUrl: string;
@@ -58,16 +76,37 @@ export interface PolicyClientOptions {
   network: Network;
   /** Injected fetch; defaults to global fetch. */
   fetch?: typeof fetch;
+  /** Called whenever the templates cache is invalidated. See {@link CacheInvalidationEvent}. */
+  onCacheInvalidated?: (event: CacheInvalidationEvent) => void;
+  /** Injected clock (tests only); defaults to `() => new Date()`. */
+  now?: () => Date;
 }
 
 export interface PolicyClient {
-  /** GET /policies/templates — the available policy templates + enforcement. */
+  /**
+   * GET /policies/templates — the available policy templates + enforcement.
+   * Cached in memory after the first call; subsequent calls return the
+   * cached list without a network round-trip until the cache is invalidated
+   * (see `refreshTemplates` and {@link CacheInvalidationEvent}).
+   */
   listTemplates(): Promise<PolicyTemplateInfo[]>;
   /** GET /policies — list generated policies, optionally filtered. */
   listPolicies(filters?: PolicyListFilters): Promise<GeneratedPolicy[]>;
+  /**
+   * Invalidate the local templates cache and re-fetch immediately, returning
+   * the fresh list. Call this after any out-of-band change to templates
+   * (e.g. an admin action elsewhere) that this client couldn't have observed
+   * on its own.
+   */
+  refreshTemplates(): Promise<PolicyTemplateInfo[]>;
   /** POST /policies/validate — validate a definition without generating. */
   validate(definition: PolicyDefinition): Promise<ValidationResult>;
-  /** POST /policies/generate — validate + produce the deployable artifacts. */
+  /**
+   * POST /policies/generate — validate + produce the deployable artifacts.
+   * Invalidates the local templates cache: a template's generated-artifact
+   * shape can evolve server-side between calls, so treat any successful
+   * generate as a signal the cached listing may be stale.
+   */
   generate(definition: PolicyDefinition): Promise<GeneratedPolicy>;
   /** POST /policies/:id/simulate — dry-run the instance deploy for a wallet. */
   simulate(policyId: string, wallet: string): Promise<SimulateResult>;
@@ -80,6 +119,16 @@ export interface PolicyClient {
 export function createPolicyClient(options: PolicyClientOptions): PolicyClient {
   const base = options.apiUrl.replace(/\/+$/, "");
   const doFetch = options.fetch ?? fetch;
+  const now = options.now ?? (() => new Date());
+
+  let templatesCache: PolicyTemplateInfo[] | undefined;
+  let templatesInFlight: Promise<PolicyTemplateInfo[]> | undefined;
+
+  function invalidateTemplatesCache(reason: CacheInvalidationEvent["reason"]): void {
+    if (templatesCache === undefined) return; // nothing cached — nothing to invalidate
+    templatesCache = undefined;
+    options.onCacheInvalidated?.({ cache: "templates", reason, at: now().toISOString() });
+  }
 
   async function req<T>(path: string, init?: RequestInit): Promise<T> {
     let res: Response;
@@ -106,9 +155,29 @@ export function createPolicyClient(options: PolicyClientOptions): PolicyClient {
     return payload;
   }
 
+  function listTemplates(): Promise<PolicyTemplateInfo[]> {
+    // In-flight de-duplication: a burst of concurrent callers (e.g. several
+    // components mounting at once) share one request instead of each firing
+    // their own, and all observe the same cached result once it resolves.
+    if (templatesCache !== undefined) return Promise.resolve(templatesCache);
+    if (templatesInFlight) return templatesInFlight;
+
+    templatesInFlight = req<PolicyTemplateInfo[]>("/templates")
+      .then((templates) => {
+        templatesCache = templates;
+        return templates;
+      })
+      .finally(() => {
+        templatesInFlight = undefined;
+      });
+    return templatesInFlight;
+  }
+
   return {
-    listTemplates() {
-      return req<PolicyTemplateInfo[]>("/templates");
+    listTemplates,
+    refreshTemplates() {
+      invalidateTemplatesCache("explicit-refresh");
+      return listTemplates();
     },
     listPolicies(filters) {
       return req<GeneratedPolicy[]>(buildListQuery(filters));
@@ -124,6 +193,7 @@ export function createPolicyClient(options: PolicyClientOptions): PolicyClient {
         method: "POST",
         body: JSON.stringify({ definition, network: options.network }),
       });
+      invalidateTemplatesCache("template-update");
       return policy;
     },
     simulate(policyId, wallet) {

--- a/src/policy-facade.test.ts
+++ b/src/policy-facade.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
-import { createPolicyFacade, PolicyNotDeployableError } from "./policy-facade";
+import { BatchDeployError, createPolicyFacade, PolicyNotDeployableError } from "./policy-facade";
 
 function jsonResponse(body: unknown, status = 200): Response {
   return new Response(JSON.stringify(body), {
@@ -99,5 +99,297 @@ describe("policy facade — deploy orchestration", () => {
     const [url, init] = fetchMock.mock.calls[0]!;
     expect(url).toBe("https://api.test/policies/p1/simulate");
     expect(JSON.parse(init!.body as string)).toEqual({ wallet: WALLET });
+  });
+});
+
+// #242: batch operations queued per-wallet must complete in call order, even
+// when their underlying network calls resolve out of order.
+describe("policy facade — per-wallet operation ordering (#242)", () => {
+  /** A fetch mock whose /deploy-instance responses resolve in a
+   * DELIBERATELY SCRAMBLED order (controlled by a per-policy-id gate), so a
+   * passing test proves the queue — not incidental timing — is what
+   * produces in-order completion. */
+  function scrambledFetch() {
+    const gates = new Map<string, { resolve: () => void }>();
+    const fetchMock = vi.fn<typeof fetch>(async (url, init) => {
+      const u = String(url);
+      if (u.endsWith("/deploy-instance")) {
+        const body = JSON.parse((init?.body as string) ?? "{}");
+        const policyId = u.match(/\/policies\/([^/]+)\/deploy-instance/)?.[1] ?? "?";
+        await new Promise<void>((resolve) => gates.set(policyId, { resolve }));
+        return jsonResponse({ contractId: `C-${policyId}`, wallet: body.wallet });
+      }
+      if (u.endsWith("/policies/deploy")) {
+        const body = JSON.parse((init?.body as string) ?? "{}");
+        return jsonResponse({ policy: { id: body.policyId, status: "deployed" } });
+      }
+      return jsonResponse({});
+    });
+    return {
+      fetchMock,
+      /** Let a specific policy's deploy-instance call resolve. */
+      releaseDeployInstance(policyId: string) {
+        gates.get(policyId)?.resolve();
+      },
+    };
+  }
+
+  function recordingAttach() {
+    const order: string[] = [];
+    const attach: Parameters<typeof createPolicyFacade>[0]["attach"] = {
+      async attachPolicy(contractId) {
+        order.push(contractId);
+        return { hash: `TX-${contractId}` };
+      },
+    };
+    return { attach, order };
+  }
+
+  it("completes concurrent deploy() calls for the SAME wallet strictly in call order, even when each one's network call resolves slowly/unpredictably", async () => {
+    const { fetchMock, releaseDeployInstance } = scrambledFetch();
+    const { attach, order } = recordingAttach();
+    const p = createPolicyFacade({
+      apiUrl: "https://api.test",
+      network: "testnet",
+      requireSession: () => ({ accountId: WALLET }),
+      attach,
+      fetch: fetchMock,
+    });
+
+    // Fire three deploy() calls WITHOUT awaiting between them — "a" first,
+    // "b" second, "c" third. Because the queue serializes deployOne() itself
+    // (not just attachPolicy), "b"'s and "c"'s deploy-instance fetch calls
+    // don't even START until "a"'s entire deployOne() has finished — so
+    // releasing gates strictly as each becomes reachable (rather than
+    // pre-releasing them out of order, which would just deadlock waiting
+    // for a fetch call that hasn't happened yet) is itself evidence of the
+    // ordering guarantee: only ONE gate is ever open at a time, in order.
+    const pa = p.deploy("a");
+    const pb = p.deploy("b");
+    const pc = p.deploy("c");
+
+    await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledWith(
+      "https://api.test/policies/a/deploy-instance",
+      expect.anything(),
+    ));
+    releaseDeployInstance("a");
+
+    await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledWith(
+      "https://api.test/policies/b/deploy-instance",
+      expect.anything(),
+    ));
+    releaseDeployInstance("b");
+
+    await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledWith(
+      "https://api.test/policies/c/deploy-instance",
+      expect.anything(),
+    ));
+    releaseDeployInstance("c");
+
+    await Promise.all([pa, pb, pc]);
+
+    expect(order).toEqual(["C-a", "C-b", "C-c"]);
+  });
+
+  it("deployBatch() runs its items strictly in the given order", async () => {
+    const { fetchMock, releaseDeployInstance } = scrambledFetch();
+    const { attach, order } = recordingAttach();
+    const p = createPolicyFacade({
+      apiUrl: "https://api.test",
+      network: "testnet",
+      requireSession: () => ({ accountId: WALLET }),
+      attach,
+      fetch: fetchMock,
+    });
+
+    const batch = p.deployBatch(["x", "y", "z"]);
+
+    // deployBatch awaits each item before starting the next, so only "x"'s
+    // gate should even be open at this point — releasing "y"/"z" early (if
+    // it were possible) would prove nothing since they haven't been asked
+    // for yet. Release them in forward order as the batch naturally reaches
+    // each one.
+    await new Promise((r) => setTimeout(r, 0));
+    releaseDeployInstance("x");
+    await new Promise((r) => setTimeout(r, 0));
+    releaseDeployInstance("y");
+    await new Promise((r) => setTimeout(r, 0));
+    releaseDeployInstance("z");
+
+    const results = await batch;
+    expect(results.map((r) => r.contractId)).toEqual(["C-x", "C-y", "C-z"]);
+    expect(order).toEqual(["C-x", "C-y", "C-z"]);
+  });
+
+  it("deployBatch() stops after a failure, returning what succeeded via BatchDeployError", async () => {
+    const attach: Parameters<typeof createPolicyFacade>[0]["attach"] = {
+      attachPolicy: vi
+        .fn()
+        .mockResolvedValueOnce({ hash: "TX-1" })
+        .mockRejectedValueOnce(new Error("passkey dismissed"))
+        .mockResolvedValueOnce({ hash: "TX-3" }),
+    };
+    const fetchMock = vi.fn<typeof fetch>(async (url) => {
+      const u = String(url);
+      if (u.endsWith("/deploy-instance")) return jsonResponse({ contractId: "C1" });
+      if (u.endsWith("/policies/deploy")) return jsonResponse({ policy: { id: "p", status: "deployed" } });
+      return jsonResponse({});
+    });
+    const p = createPolicyFacade({
+      apiUrl: "https://api.test",
+      network: "testnet",
+      requireSession: () => ({ accountId: WALLET }),
+      attach,
+      fetch: fetchMock,
+    });
+
+    const err = await p.deployBatch(["p1", "p2", "p3"]).catch((e) => e);
+    expect(err).toBeInstanceOf(BatchDeployError);
+    expect((err as BatchDeployError).policyId).toBe("p2");
+    expect((err as BatchDeployError).succeeded).toHaveLength(1);
+    // p3 must never have been attempted.
+    expect(attach.attachPolicy).toHaveBeenCalledTimes(2);
+  });
+
+  it("a failed deploy() does not block later operations for the same wallet", async () => {
+    const attach: Parameters<typeof createPolicyFacade>[0]["attach"] = {
+      attachPolicy: vi
+        .fn()
+        .mockRejectedValueOnce(new Error("first fails"))
+        .mockResolvedValueOnce({ hash: "TX-2" }),
+    };
+    const fetchMock = vi.fn<typeof fetch>(async (url) => {
+      const u = String(url);
+      if (u.endsWith("/deploy-instance")) return jsonResponse({ contractId: "C1" });
+      if (u.endsWith("/policies/deploy")) return jsonResponse({ policy: { id: "p", status: "deployed" } });
+      return jsonResponse({});
+    });
+    const p = createPolicyFacade({
+      apiUrl: "https://api.test",
+      network: "testnet",
+      requireSession: () => ({ accountId: WALLET }),
+      attach,
+      fetch: fetchMock,
+    });
+
+    const first = p.deploy("p1");
+    const second = p.deploy("p2");
+
+    await expect(first).rejects.toThrow("first fails");
+    await expect(second).resolves.toMatchObject({ attachTxHash: "TX-2" });
+  });
+
+  it("does not serialize operations for DIFFERENT wallets against each other", async () => {
+    const order: string[] = [];
+    let releaseA!: () => void;
+    const gateA = new Promise<void>((r) => (releaseA = r));
+
+    // Two independent facades simulate two different connected wallets.
+    const walletA = createPolicyFacade({
+      apiUrl: "https://api.test",
+      network: "testnet",
+      requireSession: () => ({ accountId: "WALLET-A" }),
+      attach: {
+        async attachPolicy(contractId) {
+          await gateA;
+          order.push(contractId);
+          return { hash: `TX-${contractId}` };
+        },
+      },
+      fetch: vi.fn<typeof fetch>(async (url) => {
+        const u = String(url);
+        if (u.endsWith("/deploy-instance")) return jsonResponse({ contractId: "C-a" });
+        return jsonResponse({});
+      }),
+    });
+    const walletB = createPolicyFacade({
+      apiUrl: "https://api.test",
+      network: "testnet",
+      requireSession: () => ({ accountId: "WALLET-B" }),
+      attach: {
+        async attachPolicy(contractId) {
+          order.push(contractId);
+          return { hash: `TX-${contractId}` };
+        },
+      },
+      fetch: vi.fn<typeof fetch>(async (url) => {
+        const u = String(url);
+        if (u.endsWith("/deploy-instance")) return jsonResponse({ contractId: "C-b" });
+        return jsonResponse({});
+      }),
+    });
+
+    const pa = walletA.deploy("pa"); // blocks on gateA
+    const pb = walletB.deploy("pb"); // unrelated wallet — must NOT wait on A
+    await pb; // B completes even though A is still blocked
+    expect(order).toEqual(["C-b"]);
+
+    releaseA();
+    await pa;
+    expect(order).toEqual(["C-b", "C-a"]);
+  });
+
+  it("fires onOutOfOrderOperation only in the (expected-never) out-of-order case, not during normal in-order operation", async () => {
+    const fetchMock = vi.fn<typeof fetch>(async (url) => {
+      const u = String(url);
+      if (u.endsWith("/deploy-instance")) return jsonResponse({ contractId: "C1" });
+      if (u.endsWith("/policies/deploy")) return jsonResponse({ policy: { id: "p", status: "deployed" } });
+      return jsonResponse({});
+    });
+    const onOutOfOrderOperation = vi.fn();
+    const p = createPolicyFacade({
+      apiUrl: "https://api.test",
+      network: "testnet",
+      requireSession: () => ({ accountId: WALLET }),
+      attach: { attachPolicy: vi.fn().mockResolvedValue({ hash: "TX" }) },
+      fetch: fetchMock,
+      onOutOfOrderOperation,
+    });
+
+    await p.deploy("p1");
+    await p.deploy("p2");
+    await p.deployBatch(["p3", "p4"]);
+
+    expect(onOutOfOrderOperation).not.toHaveBeenCalled();
+  });
+});
+
+// #232: cache invalidation forwards through the facade to the underlying
+// client — full coverage of the client's own cache semantics lives in
+// policy-client.test.ts; this just proves the facade wires it through.
+describe("policy facade — template cache invalidation (#232)", () => {
+  it("caches listTemplates() through the facade, and refreshTemplates() invalidates it", async () => {
+    const fetchMock = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(jsonResponse([{ type: "a", title: "A", description: "", enforcement: { kind: "none" } }]))
+      .mockResolvedValueOnce(jsonResponse([{ type: "a", title: "A v2", description: "", enforcement: { kind: "none" } }]));
+    const p = facade({ fetch: fetchMock });
+
+    const first = await p.listTemplates();
+    const second = await p.listTemplates(); // should hit the cache, not fetch again
+    const refreshed = await p.refreshTemplates();
+
+    expect(first[0]!.title).toBe("A");
+    expect(second[0]!.title).toBe("A");
+    expect(refreshed[0]!.title).toBe("A v2");
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("forwards onCacheInvalidated to the underlying client", async () => {
+    const fetchMock = vi.fn<typeof fetch>(async () => jsonResponse([]));
+    const onCacheInvalidated = vi.fn();
+    const p = createPolicyFacade({
+      apiUrl: "https://api.test",
+      network: "testnet",
+      requireSession: () => ({ accountId: WALLET }),
+      fetch: fetchMock,
+      onCacheInvalidated,
+    });
+
+    await p.listTemplates();
+    await p.refreshTemplates();
+
+    expect(onCacheInvalidated).toHaveBeenCalledTimes(1);
+    expect(onCacheInvalidated.mock.calls[0]![0]).toMatchObject({ reason: "explicit-refresh" });
   });
 });

--- a/src/policy-facade.ts
+++ b/src/policy-facade.ts
@@ -1,5 +1,5 @@
 import type { Network, PolicyDefinition } from "./types";
-import { createPolicyClient, type PolicyClient } from "./policy-client";
+import { createPolicyClient, type CacheInvalidationEvent, type PolicyClient } from "./policy-client";
 import type {
   DeployPolicyResult,
   GeneratedPolicy,
@@ -15,6 +15,18 @@ import type {
 //   3. record the completed attach
 // No silent signing; the backend is required for simulate/deploy (sponsor keys
 // live server-side), so those fail loudly when unconfigured.
+//
+// Per-wallet ordering (#242): each of deploy()'s three steps touches shared
+// on-chain wallet state (the instance deploy consumes a sponsor-side slot;
+// the passkey attach reads/advances the wallet's own signer set). Two deploy()
+// calls for the SAME wallet running concurrently — e.g. attaching several
+// policies back-to-back, or a caller firing deployBatch() items without
+// awaiting each — can interleave their steps and land in an inconsistent
+// order (e.g. wallet B's attach lands before wallet A's, even though A was
+// requested first). Every deploy() (including each item of deployBatch())
+// is therefore run through a per-accountId sequential queue: operations for
+// the SAME wallet always complete in the order they were called, one at a
+// time; operations for DIFFERENT wallets are unaffected and run concurrently.
 
 /** The passkey-attach capability the deploy step needs. The host wires this to
  * `kit.addPolicy(contractId) → kit.sign(tx) → backend.submitTransaction(...)`;
@@ -28,14 +40,52 @@ export interface PolicyAttachRuntime {
   attachPolicy(policyContractId: string): Promise<{ hash: string }>;
 }
 
+/**
+ * Fired when a queued per-wallet operation is detected running out of
+ * sequence (#242) — i.e. the queue itself misbehaved, or something bypassed
+ * it. Should never fire under normal operation; it exists as a defense-in-
+ * depth signal, not an expected event. Purely observational, matching
+ * `CacheInvalidationEvent`'s injectable-callback shape (see policy-client.ts)
+ * rather than a hardcoded `console.debug` call.
+ */
+export interface OutOfOrderOperationEvent {
+  accountId: string;
+  /** The sequence number assigned when this operation was enqueued. */
+  sequence: number;
+  /** The highest sequence number already completed for this wallet at the
+   * time this one started running — expected to be exactly `sequence - 1`. */
+  lastCompletedSequence: number;
+  at: string;
+}
+
 export interface PolicyFacade {
   listTemplates(): Promise<PolicyTemplateInfo[]>;
+  /** Invalidate the cached template listing and re-fetch. See `PolicyClient.refreshTemplates`. */
+  refreshTemplates(): Promise<PolicyTemplateInfo[]>;
   /** Validate + generate the deployable artifacts for a definition. */
   generate(definition: PolicyDefinition): Promise<GeneratedPolicy>;
   /** Dry-run the on-chain deploy for the connected wallet (no submit). */
   simulate(policyId: string): Promise<SimulateResult>;
-  /** Attach a generated policy to the connected wallet (passkey-signed). */
+  /**
+   * Attach a generated policy to the connected wallet (passkey-signed).
+   * Queued per-wallet (#242): concurrent `deploy()` calls for the SAME
+   * wallet complete in call order, one at a time. Calls for different
+   * wallets are unaffected.
+   */
   deploy(policyId: string): Promise<DeployPolicyResult>;
+  /**
+   * Deploy several policies for the connected wallet, guaranteed to run
+   * STRICTLY in the given order — each `deploy()` fully completes before the
+   * next starts. Equivalent to `for (const id of policyIds) await deploy(id)`
+   * plus the shared per-wallet queue's ordering guarantee against any other
+   * concurrent `deploy()`/`deployBatch()` call for the same wallet.
+   *
+   * Fails fast: if any item throws, the remaining items are NOT attempted —
+   * returns the successfully deployed results up to (not including) the
+   * failure, via the thrown `BatchDeployError`, so a caller can see what
+   * actually landed on-chain before the failure.
+   */
+  deployBatch(policyIds: string[]): Promise<DeployPolicyResult[]>;
   /** The lower-level HTTP client, for custom flows. */
   readonly client: PolicyClient;
 }
@@ -48,6 +98,14 @@ export interface PolicyFacadeDeps {
   /** The passkey-attach runtime (undefined ⇒ deploy() throws a clear error). */
   attach?: PolicyAttachRuntime;
   fetch?: typeof fetch;
+  /** Forwarded to `createPolicyClient` — see `PolicyClientOptions.onCacheInvalidated`. */
+  onCacheInvalidated?: (event: CacheInvalidationEvent) => void;
+  /** Called if the per-wallet operation queue ever detects out-of-order
+   * execution (#242) — see {@link OutOfOrderOperationEvent}. Should never
+   * fire in practice. */
+  onOutOfOrderOperation?: (event: OutOfOrderOperationEvent) => void;
+  /** Injected clock (tests only); defaults to `() => new Date()`. */
+  now?: () => Date;
 }
 
 export class PolicyNotDeployableError extends Error {
@@ -57,17 +115,112 @@ export class PolicyNotDeployableError extends Error {
   }
 }
 
+/** Thrown by `deployBatch` when one item fails; carries what succeeded before it. */
+export class BatchDeployError extends Error {
+  constructor(
+    /** The policy id that failed. */
+    readonly policyId: string,
+    /** Results for the items before it that succeeded, in order. */
+    readonly succeeded: DeployPolicyResult[],
+    readonly cause: unknown,
+  ) {
+    super(
+      `deployBatch: policy ${policyId} failed after ${succeeded.length} prior ` +
+        `deployment(s) succeeded — ${cause instanceof Error ? cause.message : String(cause)}`,
+    );
+    this.name = "BatchDeployError";
+  }
+}
+
+/** Per-wallet FIFO operation queue (#242): schedules `run` after every
+ * previously-scheduled operation for the same `accountId` has settled
+ * (success or failure — a failed prior operation does not block later ones,
+ * it just doesn't hold up the queue). Assigns each operation a monotonic
+ * sequence number and reports via `onOutOfOrder` if one is ever run before
+ * the immediately-preceding sequence number for that wallet has completed —
+ * which should be structurally impossible given the queue below, but is
+ * checked explicitly as a defense-in-depth signal rather than assumed. */
+function createPerWalletQueue(deps: {
+  now: () => Date;
+  onOutOfOrder?: (event: OutOfOrderOperationEvent) => void;
+}) {
+  const tailByAccount = new Map<string, Promise<unknown>>();
+  const nextSequenceByAccount = new Map<string, number>();
+  const lastCompletedSequenceByAccount = new Map<string, number>();
+
+  return function enqueue<T>(accountId: string, run: () => Promise<T>): Promise<T> {
+    const sequence = nextSequenceByAccount.get(accountId) ?? 0;
+    nextSequenceByAccount.set(accountId, sequence + 1);
+
+    const previousTail = tailByAccount.get(accountId) ?? Promise.resolve();
+
+    // A prior operation's REJECTION must not abort this one — `.catch(() =>
+    // {})` here just lets the chain continue past it, since we don't want
+    // one wallet's failed operation to permanently wedge every later
+    // operation for the same wallet. Chaining `run` off THIS settled promise
+    // (rather than passing two handlers to one `.then`) keeps the resulting
+    // type exactly `Promise<T>`, not `Promise<T | void>`.
+    const task = previousTail.catch(() => {}).then(async () => {
+      const lastCompleted = lastCompletedSequenceByAccount.get(accountId) ?? -1;
+      if (sequence !== lastCompleted + 1) {
+        deps.onOutOfOrder?.({
+          accountId,
+          sequence,
+          lastCompletedSequence: lastCompleted,
+          at: deps.now().toISOString(),
+        });
+      }
+      try {
+        return await run();
+      } finally {
+        lastCompletedSequenceByAccount.set(accountId, sequence);
+      }
+    });
+
+    // Every operation (success or failure) becomes the new tail so the next
+    // enqueue() waits on IT — not on whichever earlier task happened to
+    // resolve first, which is what `tailByAccount.get` would otherwise still
+    // point at if we forgot to update it here.
+    tailByAccount.set(accountId, task);
+
+    return task;
+  };
+}
+
 export function createPolicyFacade(deps: PolicyFacadeDeps): PolicyFacade {
   const client = createPolicyClient({
     apiUrl: deps.apiUrl,
     network: deps.network,
     fetch: deps.fetch,
+    onCacheInvalidated: deps.onCacheInvalidated,
   });
+  const now = deps.now ?? (() => new Date());
+  const enqueueForWallet = createPerWalletQueue({ now, onOutOfOrder: deps.onOutOfOrderOperation });
+
+  async function deployOne(policyId: string): Promise<DeployPolicyResult> {
+    const session = deps.requireSession();
+    if (!deps.attach) {
+      throw new PolicyNotDeployableError(
+        "Policy deploy needs a passkey-attach runtime. This wallet was created without one — provide `policyAttach` in the config (or use the web app runtime).",
+      );
+    }
+    // 1. server-side, sponsor-funded instance deploy bound to the wallet.
+    const { contractId } = await client.deployInstance(policyId, session.accountId);
+    // 2. passkey-sign the attach (the ONLY prompt).
+    if (session.keyId && deps.attach.resume) await deps.attach.resume(session.keyId);
+    const { hash } = await deps.attach.attachPolicy(contractId);
+    // 3. record the completed attach.
+    const policy = await client.recordDeployment(policyId, hash, contractId);
+    return { policy, contractId, attachTxHash: hash };
+  }
 
   return {
     client,
     listTemplates() {
       return client.listTemplates();
+    },
+    refreshTemplates() {
+      return client.refreshTemplates();
     },
     generate(definition) {
       return client.generate(definition);
@@ -76,21 +229,29 @@ export function createPolicyFacade(deps: PolicyFacadeDeps): PolicyFacade {
       const { accountId } = deps.requireSession();
       return client.simulate(policyId, accountId);
     },
-    async deploy(policyId) {
-      const session = deps.requireSession();
-      if (!deps.attach) {
-        throw new PolicyNotDeployableError(
-          "Policy deploy needs a passkey-attach runtime. This wallet was created without one — provide `policyAttach` in the config (or use the web app runtime).",
-        );
+    deploy(policyId) {
+      // requireSession() is called again inside deployOne() once the queue
+      // actually runs it — calling it here too would only validate the
+      // session at ENQUEUE time, which could be stale by the time an earlier
+      // queued operation for the same wallet finishes.
+      const accountId = deps.requireSession().accountId;
+      return enqueueForWallet(accountId, () => deployOne(policyId));
+    },
+    async deployBatch(policyIds) {
+      const accountId = deps.requireSession().accountId;
+      const results: DeployPolicyResult[] = [];
+      for (const policyId of policyIds) {
+        try {
+          // Each item goes through the SAME per-wallet queue as deploy(), so
+          // a deployBatch() call correctly orders against any concurrent
+          // standalone deploy() call for the same wallet too, not just
+          // against its own other items.
+          results.push(await enqueueForWallet(accountId, () => deployOne(policyId)));
+        } catch (err) {
+          throw new BatchDeployError(policyId, results, err);
+        }
       }
-      // 1. server-side, sponsor-funded instance deploy bound to the wallet.
-      const { contractId } = await client.deployInstance(policyId, session.accountId);
-      // 2. passkey-sign the attach (the ONLY prompt).
-      if (session.keyId && deps.attach.resume) await deps.attach.resume(session.keyId);
-      const { hash } = await deps.attach.attachPolicy(contractId);
-      // 3. record the completed attach.
-      const policy = await client.recordDeployment(policyId, hash, contractId);
-      return { policy, contractId, attachTxHash: hash };
+      return results;
     },
   };
 }

--- a/src/x402-client.test.ts
+++ b/src/x402-client.test.ts
@@ -8,6 +8,7 @@
 import { describe, expect, it, vi } from "vitest";
 import { createX402Client, expirationOffsetFor, type FetchLike } from "./x402-client";
 import {
+  ConfirmationRequiredError,
   DisallowedAssetError,
   InvalidRequirementsError,
   MaxAmountExceededError,
@@ -132,6 +133,136 @@ describe("createPayment — direct-path guards", () => {
     await expect(
       c.createPayment(requirements({ amount: "1.5" }), { maxAmount: 10_000_000n }),
     ).rejects.toBeInstanceOf(InvalidRequirementsError);
+  });
+});
+
+// #228: high-value payments require explicit confirmation, gated by
+// `confirmationThreshold` + `confirm`, on BOTH the createPayment direct path
+// and the fetch (402-retry) path. This file never mocks the RPC simulation
+// layer (see the passthrough-only coverage above), so a stub signer's
+// simulated transaction never produces a real auth entry to sign —
+// `buildSignedPayment` reaches its "No wallet auth entry found to sign" check
+// instead of ever calling `signAuthEntry`. That's still the right signal
+// here: reaching it proves execution got PAST the confirmation gate (i.e.
+// confirmation was granted, or wasn't required); a ConfirmationRequiredError
+// instead proves confirmation blocked BEFORE that point was ever reached.
+describe("explicit confirmation for high-value payments (#228)", () => {
+  describe("createPayment", () => {
+    it("does not call confirm when the amount is below the threshold, and proceeds past the confirmation gate", async () => {
+      const confirm = vi.fn(async () => true);
+      const c = client(vi.fn());
+      // amount 1_000_000 (fixture default) is below the 5_000_000 threshold,
+      // so it should reach (and be rejected by) the stub signer, not confirm.
+      await expect(
+        c.createPayment(requirements(), {
+          maxAmount: 10_000_000n,
+          confirmationThreshold: 5_000_000n,
+          confirm,
+        }),
+      ).rejects.toThrow(/No wallet auth entry found to sign/);
+      expect(confirm).not.toHaveBeenCalled();
+    });
+
+    it("calls confirm with the pending payment's details when the amount meets the threshold", async () => {
+      const confirm = vi.fn(async () => true);
+      const c = client(vi.fn());
+      // confirm resolves true, so this proceeds past confirmation and is
+      // rejected by the stub signer instead — proving confirm ran first.
+      await expect(
+        c.createPayment(requirements({ amount: "5000000" }), {
+          maxAmount: 10_000_000n,
+          confirmationThreshold: 5_000_000n,
+          confirm,
+        }),
+      ).rejects.toThrow(/No wallet auth entry found to sign/);
+      expect(confirm).toHaveBeenCalledTimes(1);
+      expect(confirm).toHaveBeenCalledWith(
+        expect.objectContaining({ amount: 5_000_000n, asset: expect.any(String) }),
+      );
+    });
+
+    it("throws ConfirmationRequiredError, never reaching the signer, when confirm resolves false", async () => {
+      const confirm = vi.fn(async () => false);
+      const c = client(vi.fn());
+      await expect(
+        c.createPayment(requirements({ amount: "9000000" }), {
+          maxAmount: 10_000_000n,
+          confirmationThreshold: 5_000_000n,
+          confirm,
+        }),
+      ).rejects.toBeInstanceOf(ConfirmationRequiredError);
+    });
+
+    it("throws ConfirmationRequiredError, never reaching the signer, when a threshold is set with no confirm callback", async () => {
+      const c = client(vi.fn());
+      await expect(
+        c.createPayment(requirements({ amount: "9000000" }), {
+          maxAmount: 10_000_000n,
+          confirmationThreshold: 5_000_000n,
+          // confirm intentionally omitted — configuration error, fails closed.
+        }),
+      ).rejects.toBeInstanceOf(ConfirmationRequiredError);
+    });
+
+    it("treats an amount exactly equal to the threshold as requiring confirmation", async () => {
+      const confirm = vi.fn(async () => true);
+      const c = client(vi.fn());
+      await expect(
+        c.createPayment(requirements({ amount: "5000000" }), {
+          maxAmount: 10_000_000n,
+          confirmationThreshold: 5_000_000n,
+          confirm,
+        }),
+      ).rejects.toThrow(/No wallet auth entry found to sign/);
+      expect(confirm).toHaveBeenCalledTimes(1);
+    });
+
+    it("is a no-op (never calls confirm) when confirmationThreshold is unset, preserving existing behavior", async () => {
+      const confirm = vi.fn(async () => true);
+      const c = client(vi.fn());
+      await expect(
+        c.createPayment(requirements({ amount: "999999999" }), {
+          maxAmount: 10_000_000_000n,
+          confirm,
+        }),
+      ).rejects.toThrow(/No wallet auth entry found to sign/);
+      expect(confirm).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("fetch (402-retry path)", () => {
+    it("blocks on confirm before ever retrying with a payment signature", async () => {
+      const confirm = vi.fn(async () => true);
+      const fetchImpl = vi.fn(async () => response402([requirements({ amount: "5000000" })]));
+      const c = client(fetchImpl);
+      // confirm approves, so this proceeds to buildSignedPayment and is
+      // rejected by the stub signer — proving confirm ran first, and that
+      // the retry request was never sent (fetchImpl called once: the 402).
+      await expect(
+        c.fetch("https://res.test/paid", {
+          maxAmount: 10_000_000n,
+          confirmationThreshold: 5_000_000n,
+          confirm,
+        }),
+      ).rejects.toThrow(/No wallet auth entry found to sign/);
+      expect(confirm).toHaveBeenCalledTimes(1);
+      expect(fetchImpl).toHaveBeenCalledTimes(1);
+    });
+
+    it("never retries the request when confirmation is declined", async () => {
+      const confirm = vi.fn(async () => false);
+      const fetchImpl = vi.fn(async () => response402([requirements({ amount: "9000000" })]));
+      const c = client(fetchImpl);
+      await expect(
+        c.fetch("https://res.test/paid", {
+          maxAmount: 10_000_000n,
+          confirmationThreshold: 5_000_000n,
+          confirm,
+        }),
+      ).rejects.toBeInstanceOf(ConfirmationRequiredError);
+      // Only the initial 402-triggering request happened; no payment retry.
+      expect(fetchImpl).toHaveBeenCalledTimes(1);
+    });
   });
 });
 

--- a/src/x402-client.ts
+++ b/src/x402-client.ts
@@ -22,12 +22,14 @@ import {
   decodePaymentRequired,
   decodeSettlementHeader,
   extractRejectionReason,
+  needsConfirmation,
   parseAmount,
   selectRequirements,
   utf8ToBase64,
 } from "./x402-guards";
 import {
   assertValidX402RpcUrl,
+  ConfirmationRequiredError,
   DisallowedAssetError,
   MaxAmountExceededError,
   NoUsablePaymentOptionError,
@@ -193,6 +195,37 @@ export function createX402Client(deps: X402ClientDeps): X402Client {
     };
   }
 
+  /**
+   * Enforce `confirmationThreshold` for `requirements` (#228). Blocks until
+   * `confirm` resolves — no auth entry is built or signed while a
+   * confirmation decision is pending. Throws `ConfirmationRequiredError`
+   * (without ever calling the signer) if the threshold is crossed and either
+   * no `confirm` callback was configured, or it resolves `false`.
+   *
+   * A no-op when `confirmationThreshold` is unset — every existing caller
+   * that doesn't opt in sees no behavior change.
+   */
+  async function enforceConfirmation(
+    requirements: PaymentRequirements,
+    amount: bigint,
+    opts: X402PayOptions,
+  ): Promise<void> {
+    if (!needsConfirmation(amount, opts)) return;
+    const threshold = opts.confirmationThreshold!;
+    if (!opts.confirm) {
+      throw new ConfirmationRequiredError(
+        amount,
+        threshold,
+        requirements.asset,
+        "no-confirm-callback",
+      );
+    }
+    const approved = await opts.confirm({ amount, asset: requirements.asset, requirements });
+    if (!approved) {
+      throw new ConfirmationRequiredError(amount, threshold, requirements.asset, "declined");
+    }
+  }
+
   async function createPayment(
     requirements: PaymentRequirements,
     opts: X402PayOptions,
@@ -206,6 +239,7 @@ export function createX402Client(deps: X402ClientDeps): X402Client {
     if (required > opts.maxAmount) {
       throw new MaxAmountExceededError(required, opts.maxAmount, requirements.asset);
     }
+    await enforceConfirmation(requirements, required, opts);
     const { header, amount } = await buildSignedPayment(requirements);
     return { header, requirements, amount };
   }
@@ -235,6 +269,7 @@ export function createX402Client(deps: X402ClientDeps): X402Client {
 
     const decoded = decodePaymentRequired(first);
     const requirements = selectRequirements(decoded, init, ourCaip2);
+    await enforceConfirmation(requirements, parseAmount(requirements.amount), init);
     const { header, amount } = await buildSignedPayment(requirements);
 
     const paid = await doFetch(url, {

--- a/src/x402-guards.test.ts
+++ b/src/x402-guards.test.ts
@@ -7,6 +7,7 @@ import {
   decodePaymentRequired,
   decodeSettlementHeader,
   extractRejectionReason,
+  needsConfirmation,
   parseAmount,
   selectRequirements,
   utf8ToBase64,
@@ -228,6 +229,38 @@ describe("selectRequirements", () => {
         CAIP2_TESTNET,
       ),
     ).toThrow(InvalidRequirementsError);
+  });
+});
+
+describe("needsConfirmation (#228)", () => {
+  it("is false when confirmationThreshold is unset, regardless of amount", () => {
+    expect(needsConfirmation(999_999_999n, { maxAmount: 10_000_000_000n })).toBe(false);
+  });
+
+  it("is false when the amount is below the threshold", () => {
+    expect(
+      needsConfirmation(4_999_999n, { maxAmount: 10_000_000n, confirmationThreshold: 5_000_000n }),
+    ).toBe(false);
+  });
+
+  it("is true when the amount equals the threshold", () => {
+    expect(
+      needsConfirmation(5_000_000n, { maxAmount: 10_000_000n, confirmationThreshold: 5_000_000n }),
+    ).toBe(true);
+  });
+
+  it("is true when the amount exceeds the threshold", () => {
+    expect(
+      needsConfirmation(5_000_001n, { maxAmount: 10_000_000n, confirmationThreshold: 5_000_000n }),
+    ).toBe(true);
+  });
+
+  it("is true for a zero threshold even at a zero amount (0 >= 0)", () => {
+    // Edge case worth pinning down explicitly: a threshold of exactly 0 means
+    // "confirm everything", including a zero-amount payment.
+    expect(
+      needsConfirmation(0n, { maxAmount: 10_000_000n, confirmationThreshold: 0n }),
+    ).toBe(true);
   });
 });
 

--- a/src/x402-guards.ts
+++ b/src/x402-guards.ts
@@ -15,6 +15,7 @@
 
 import type { Network } from "./types";
 import {
+  ConfirmationRequiredError,
   DisallowedAssetError,
   InvalidRequirementsError,
   MaxAmountExceededError,
@@ -27,13 +28,19 @@ import {
 // The errors these guards throw, re-exported so a consumer importing
 // "vellar-sdk/x402-guards" can catch them without also importing the wallet.
 export {
+  ConfirmationRequiredError,
   DisallowedAssetError,
   InvalidRequirementsError,
   MaxAmountExceededError,
   NoUsablePaymentOptionError,
   PaymentRejectedError,
 } from "./x402-types";
-export type { PaymentRequired, PaymentRequirements, X402PayOptions } from "./x402-types";
+export type {
+  PaymentRequired,
+  PaymentRequirements,
+  PendingConfirmation,
+  X402PayOptions,
+} from "./x402-types";
 
 // ── base64 (browser-safe: no Buffer, no @types/node) ─────────────────────────
 
@@ -148,6 +155,19 @@ export function selectRequirements(
     throw new MaxAmountExceededError(required, opts.maxAmount, usable.asset);
   }
   return usable;
+}
+
+// ── explicit confirmation for high-value payments ───────────────────────────
+
+/**
+ * Pure predicate: does this payment amount require explicit confirmation
+ * under `opts`? True when `opts.confirmationThreshold` is set and `amount`
+ * meets or exceeds it. Kept separate from the (necessarily async, IO-bound)
+ * act of actually calling `confirm()` — that lives in ./x402-client, which
+ * owns the signing flow's control order.
+ */
+export function needsConfirmation(amount: bigint, opts: X402PayOptions): boolean {
+  return opts.confirmationThreshold !== undefined && amount >= opts.confirmationThreshold;
 }
 
 // ── 402 decode ───────────────────────────────────────────────────────────────

--- a/src/x402-types.ts
+++ b/src/x402-types.ts
@@ -59,6 +59,21 @@ export interface SmartAccountX402Signer {
   ): Promise<string>;
 }
 
+/**
+ * A pending payment awaiting explicit confirmation — passed to
+ * {@link X402PayOptions.confirm}. Carries what's needed to render a
+ * meaningful confirmation prompt (amount, asset, destination) without the
+ * caller having to re-derive it from `PaymentRequirements`.
+ */
+export interface PendingConfirmation {
+  /** Amount, in the asset's base units. */
+  amount: bigint;
+  /** SAC (asset contract) id the payment is denominated in. */
+  asset: string;
+  /** The requirements this confirmation is for. */
+  requirements: PaymentRequirements;
+}
+
 /** Options for building/signing a single payment (shared by fetch + createPayment). */
 export interface X402PayOptions {
   /**
@@ -71,6 +86,28 @@ export interface X402PayOptions {
   /** If set, only pay for these asset (SAC) ids; a 402 asking for anything else
    * is rejected without signing. Default: accept whatever asset the server asks. */
   allowedAssets?: string[];
+  /**
+   * When set, any payment whose amount is >= this threshold (base units, same
+   * asset the payment is denominated in) additionally requires `confirm` to
+   * resolve `true` before the client will sign. This is a SEPARATE gate from
+   * `maxAmount`: `maxAmount` is a hard ceiling the client will never exceed
+   * regardless of confirmation; `confirmationThreshold` narrows the band of
+   * amounts BELOW that ceiling that still require an explicit go-ahead (e.g.
+   * "auto-pay under $1, but ask above that").
+   *
+   * Setting a threshold without also setting `confirm` is a configuration
+   * error — every threshold-crossing payment would otherwise have nothing to
+   * resolve it and fails closed with {@link ConfirmationRequiredError}.
+   */
+  confirmationThreshold?: bigint;
+  /**
+   * Resolve `true` to proceed with a payment that crossed
+   * `confirmationThreshold`, or `false` to refuse it. The client blocks
+   * signing until this promise settles — no auth entry is built or signed
+   * while confirmation is pending. Rejecting/throwing propagates to the
+   * caller of `fetch`/`createPayment` same as any other error.
+   */
+  confirm?: (pending: PendingConfirmation) => Promise<boolean>;
 }
 
 export interface X402FetchInit extends X402PayOptions {
@@ -179,6 +216,31 @@ export class MaxAmountExceededError extends Error {
       `x402 payment of ${required} (${asset}) exceeds maxAmount ${maxAmount}; refusing to sign.`,
     );
     this.name = "MaxAmountExceededError";
+  }
+}
+
+/**
+ * A payment crossed `confirmationThreshold` but either no `confirm` callback
+ * was configured (a configuration error — fails closed rather than silently
+ * skipping the confirmation the caller asked for) or `confirm` resolved
+ * `false`. No payment was signed either way.
+ */
+export class ConfirmationRequiredError extends Error {
+  constructor(
+    readonly required: bigint,
+    readonly threshold: bigint,
+    readonly asset: string,
+    readonly reason: "no-confirm-callback" | "declined",
+  ) {
+    super(
+      reason === "no-confirm-callback"
+        ? `x402 payment of ${required} (${asset}) crosses confirmationThreshold ${threshold}, ` +
+            "but no `confirm` callback was configured; refusing to sign. " +
+            "Pass a `confirm` function alongside `confirmationThreshold` to allow this payment."
+        : `x402 payment of ${required} (${asset}) crosses confirmationThreshold ${threshold} ` +
+            "and was declined via `confirm`; refusing to sign.",
+    );
+    this.name = "ConfirmationRequiredError";
   }
 }
 

--- a/website/content/docs/x402.md
+++ b/website/content/docs/x402.md
@@ -165,6 +165,46 @@ Use the **token-scoped** spending-limit policy for an agent budget so only one
 specific token's transfers count against it — then "give your agent $10/day of
 USDC" means exactly that: USDC only, capped, on-chain.
 
+## Confirming high-value payments
+
+`maxAmount` and the on-chain spending-limit policy are both **static**
+ceilings, decided ahead of time. `confirmationThreshold` adds a third,
+**per-payment** gate: any payment whose amount meets or exceeds it blocks on
+an explicit `confirm` callback before the SDK will sign anything.
+
+```ts
+const { response, paid } = await vellar.x402.fetch(
+  "https://api.example.com/paid",
+  {
+    maxAmount: 10_000_000n,
+    confirmationThreshold: 5_000_000n, // require confirmation at/above 5 (base units)
+    async confirm({ amount, asset, requirements }) {
+      // e.g. prompt a human, or apply extra agent-side policy logic.
+      return await promptUser(`Approve payment of ${amount} ${asset}?`);
+    },
+  },
+);
+```
+
+- Amounts **below** the threshold sign immediately — `confirm` is never
+  called, so existing callers that don't set `confirmationThreshold` see no
+  behavior change.
+- Amounts **at or above** the threshold block until `confirm` resolves. No
+  auth entry is built or signed while confirmation is pending.
+- `confirm` resolving `false`, or being omitted entirely while
+  `confirmationThreshold` is set, throws `ConfirmationRequiredError` —
+  nothing is signed either way. Setting a threshold with no `confirm`
+  callback is treated as a configuration error (fails closed) rather than
+  silently skipping the confirmation you asked for.
+- This applies to both `wallet.x402.fetch(...)` and the lower-level
+  `wallet.x402.createPayment(requirements, opts)`.
+
+This is a client-side UX gate, not a security boundary — same caveat as
+`maxAmount`: it's only as trustworthy as the client process. For agent
+flows, prefer the on-chain spending-limit policy for anything that must hold
+even if client code is bypassed; use `confirmationThreshold` to add a
+human-in-the-loop check on top, e.g. "auto-pay under $1, ask above that."
+
 ## Facilitators and the fee ceiling
 
 The exact scheme requires **sponsored fees** — the facilitator rebuilds the
@@ -194,6 +234,7 @@ The client throws typed errors:
 | Error | When |
 | ----- | ---- |
 | `MaxAmountExceededError` | The server asked for more than your `maxAmount`. Nothing signed. |
+| `ConfirmationRequiredError` | The payment met `confirmationThreshold` and either `confirm` was not set, or it resolved `false`. Nothing signed. |
 | `DisallowedAssetError` | No offered asset was in `allowedAssets`. Nothing signed. |
 | `NoUsablePaymentOptionError` | No option matched the scheme/network, or none sponsored fees. |
 | `InvalidRequirementsError` | A requirement was malformed (e.g. a non-integer amount). |


### PR DESCRIPTION
## Summary

Four issues across the x402/policy/payments layers.

### #228 — Explicit confirmation flag for high-value x402 signer actions
Added `confirmationThreshold` + `confirm` to `X402PayOptions`. A payment whose amount meets or exceeds the threshold blocks on `confirm()` resolving before the SDK signs anything; setting a threshold with no `confirm` callback is a fail-closed configuration error (`ConfirmationRequiredError`), not a silent skip. This is a separate gate from `maxAmount` — narrows the band of amounts *below* the hard ceiling that still require an explicit go-ahead. Wired into both `createX402Client.createPayment` (direct path) and `.fetch` (402-retry path). Documented in a new "Confirming high-value payments" section of `website/content/docs/x402.md`.

### #232 — Cache invalidation on policy-client template update
`policy-client.ts`'s `listTemplates()` had no caching at all — added an in-memory cache (with in-flight de-duplication for concurrent callers), invalidated by `generate()` (a mutation that could change template state) and by a new explicit `refreshTemplates()`. Invalidation is observable via an injectable `onCacheInvalidated` callback (matching the SDK's existing `fetch`/`webAuthn` seams rather than a hardcoded `console.debug`). Forwarded through `policy-facade.ts`.

### #240 — Exactly-once submission guard in payments.ts
Added an idempotency guard to `payments-client.ts`'s `PreparedPayment.confirm()`, keyed on a caller-supplied `paymentId` (passed to `preparePayment`, and threaded up through `client.ts`'s `pay({ paymentId })`). Two `confirm()`/`pay()` calls for the same id share one in-flight submission (or return the cached result) instead of resubmitting. A **failed** submission does not permanently block retries under the same id — only a successful one is cached. Documented in the root `README.md` with the guarantee's scope and limits (in-memory, single-instance, not a substitute for backend-side idempotency).

### #242 — Ordering issue in queued policy-facade batch operations
`policy-facade.ts` had no batching/queueing logic at all — added a per-wallet FIFO operation queue so concurrent `deploy()` calls for the *same* wallet complete strictly in call order (operations for different wallets run unaffected/concurrently), plus a new `deployBatch(policyIds)` that runs its items in the given order through the same queue. Includes an `onOutOfOrderOperation` defense-in-depth signal (should never fire under normal operation — a bug/bypass detector, not an expected event) and a `BatchDeployError` reporting what succeeded before a batch item failed.

## Test plan
- [x] `npx vitest run` — 550/550 passing (23 new tests across `x402-client`, `x402-guards`, `policy-client`, `policy-facade`, `payments` (client.ts's `createPaymentClient`), and `client.ts`)
- [x] `npx tsc --noEmit` — clean
- [x] `node scripts/check-doc-snippets.mjs` — clean

Closes #228
Closes #232
Closes #240
Closes #242