### PR TITLE
contrib: reference implementations for #228, #232, #242

### DIFF
--- a/contrib/examples/issue-228-x402-confirmation-threshold/README.md
+++ b/contrib/examples/issue-228-x402-confirmation-threshold/README.md
@@ -1,0 +1,52 @@
+# x402 Confirmation Threshold
+
+Self-contained reference for issue [#228](https://github.com/Vellar-Wallet/vellar-sdk/issues/228): an explicit confirmation step for high-value x402 payments, above and beyond the standing `maxAmount` budget check.
+
+## Run tests
+
+```bash
+npx vitest run contrib/examples/issue-228-x402-confirmation-threshold
+```
+
+## Why
+
+`X402PayOptions.maxAmount` is a client-side hard ceiling, and the durable budget is the on-chain spending-limit policy — but neither is a per-payment "ask before this one" gate. A caller who wants to auto-pay small amounts but require an explicit go-ahead above some threshold (e.g. an agent that should ask a human before spending more than $1) has no seam for that today.
+
+## Usage
+
+```ts
+import { withConfirmationThreshold } from "./confirmation-threshold";
+import { CAIP2_BY_NETWORK } from "vellar-sdk/x402-guards";
+
+const guardedClient = withConfirmationThreshold(wallet.x402, {
+  confirmationThreshold: 5_000_000n, // 0.5 XLM, in stroops
+  ourCaip2: CAIP2_BY_NETWORK[network], // "stellar:testnet" | "stellar:pubnet"
+  async confirm({ amount, asset }) {
+    return await promptUser(`Approve payment of ${amount} ${asset}?`);
+  },
+});
+
+// Below the threshold — signs immediately, confirm() never called.
+await guardedClient.fetch("https://api.example.com/cheap", { maxAmount: 10_000_000n });
+
+// At/above the threshold — blocks on confirm() before signing.
+await guardedClient.fetch("https://api.example.com/expensive", { maxAmount: 10_000_000n });
+```
+
+## Semantics
+
+| Case | Result |
+|------|--------|
+| Amount below threshold | Delegates immediately; `confirm` is never called |
+| Amount at/above threshold, `confirm` resolves `true` | Delegates once `confirm` settles |
+| Amount at/above threshold, `confirm` resolves `false` | `PaymentNotConfirmedError` — nothing signed |
+| `createPayment` | Amount read straight off `requirements.amount` |
+| `fetch` | See "Limits" below |
+
+## Limits
+
+`X402Client.fetch(url, init)` decodes the 402 and retries with the signed payment inside one call — nothing about the amount is observable from outside until it's already about to sign. This wrapper's `fetch` does its own preliminary request to see the 402 and decode which option would be picked (via the SDK's public `x402-guards` exports — `decodePaymentRequired` / `selectRequirements` / `parseAmount`, not internals), then either delegates immediately or after `confirm` resolves.
+
+That means a payment gated through `fetch` costs **two** round-trips to the 402 challenge instead of one: the wrapper's own probe, then the wrapped client's real fetch → 402 → sign → retry flow. This is the real cost of adding a confirmation gate from *outside* `createX402Client` rather than inside it — building it inside `src/x402-client.ts` (where the 402 is already decoded once) would avoid the extra round-trip, at the cost of `src/`-level changes I could not make. If that overhead matters for your case, gate at the `createPayment` call site instead (where the amount is already known with no extra request), or ask a maintainer to fold this into `createX402Client` directly.
+
+This is a client-side UX gate, not a security boundary — same caveat as `maxAmount` itself: it's only as trustworthy as the code calling it.

--- a/contrib/examples/issue-228-x402-confirmation-threshold/confirmation-threshold.test.ts
+++ b/contrib/examples/issue-228-x402-confirmation-threshold/confirmation-threshold.test.ts
@@ -1,0 +1,188 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  PaymentNotConfirmedError,
+  withConfirmationThreshold,
+} from "./confirmation-threshold";
+import type { PaymentRequirements, X402Client } from "../../../src/x402-types";
+
+const CAIP2_TESTNET = "stellar:testnet";
+const TOKEN = "CBIN4HTPJM2QLJ32DTRO6OCLIMM7TR7D74JDIPVQYLNYGL7SBWOXH5ND";
+const PAYTO = "GAN5MFH3GGAWH2UTO5DDOMDRQK6E32CE2GPAMPQT6KEHEPNHVBKJEF6A";
+
+function requirements(over: Partial<PaymentRequirements> = {}): PaymentRequirements {
+  return {
+    scheme: "exact",
+    network: CAIP2_TESTNET,
+    asset: TOKEN,
+    amount: "1000000",
+    payTo: PAYTO,
+    maxTimeoutSeconds: 120,
+    extra: { areFeesSponsored: true },
+    ...over,
+  };
+}
+
+function b64(o: unknown): string {
+  const bytes = new TextEncoder().encode(JSON.stringify(o));
+  let bin = "";
+  for (const byte of bytes) bin += String.fromCharCode(byte);
+  return btoa(bin);
+}
+
+function response402(accepts: PaymentRequirements[]): Response {
+  return new Response("{}", {
+    status: 402,
+    headers: { "PAYMENT-REQUIRED": b64({ x402Version: 2, error: "Payment required", accepts }) },
+  });
+}
+
+/** A wrapped X402Client whose createPayment/fetch throw if called — so a
+ * test observing that error proves confirmation was never granted. */
+const stubClient: X402Client = {
+  async fetch() {
+    throw new Error("wrapped client should not have been called");
+  },
+  async createPayment() {
+    throw new Error("wrapped client should not have been called");
+  },
+};
+
+describe("withConfirmationThreshold — createPayment", () => {
+  it("signs immediately (never calls confirm) when the amount is below the threshold", async () => {
+    const confirm = vi.fn(async () => true);
+    const delegate = vi.fn(async () => ({
+      header: "signed",
+      requirements: requirements(),
+      amount: 1_000_000n,
+    }));
+    const client = withConfirmationThreshold(
+      { ...stubClient, createPayment: delegate },
+      { confirmationThreshold: 5_000_000n, confirm, ourCaip2: CAIP2_TESTNET },
+    );
+
+    const result = await client.createPayment(requirements(), { maxAmount: 10_000_000n });
+
+    expect(result.amount).toBe(1_000_000n);
+    expect(confirm).not.toHaveBeenCalled();
+    expect(delegate).toHaveBeenCalledTimes(1);
+  });
+
+  it("blocks on confirm when the amount meets the threshold, then delegates once approved", async () => {
+    const confirm = vi.fn(async () => true);
+    const delegate = vi.fn(async () => ({
+      header: "signed",
+      requirements: requirements({ amount: "5000000" }),
+      amount: 5_000_000n,
+    }));
+    const client = withConfirmationThreshold(
+      { ...stubClient, createPayment: delegate },
+      { confirmationThreshold: 5_000_000n, confirm, ourCaip2: CAIP2_TESTNET },
+    );
+
+    const result = await client.createPayment(requirements({ amount: "5000000" }), {
+      maxAmount: 10_000_000n,
+    });
+
+    expect(result.amount).toBe(5_000_000n);
+    expect(confirm).toHaveBeenCalledTimes(1);
+    expect(confirm).toHaveBeenCalledWith(
+      expect.objectContaining({ amount: 5_000_000n, asset: TOKEN }),
+    );
+  });
+
+  it("throws PaymentNotConfirmedError and never delegates when confirm resolves false", async () => {
+    const confirm = vi.fn(async () => false);
+    const client = withConfirmationThreshold(stubClient, {
+      confirmationThreshold: 5_000_000n,
+      confirm,
+      ourCaip2: CAIP2_TESTNET,
+    });
+
+    await expect(
+      client.createPayment(requirements({ amount: "9000000" }), { maxAmount: 10_000_000n }),
+    ).rejects.toBeInstanceOf(PaymentNotConfirmedError);
+  });
+
+  it("treats an amount exactly equal to the threshold as requiring confirmation", async () => {
+    const confirm = vi.fn(async () => true);
+    const delegate = vi.fn(async () => ({
+      header: "signed",
+      requirements: requirements({ amount: "5000000" }),
+      amount: 5_000_000n,
+    }));
+    const client = withConfirmationThreshold(
+      { ...stubClient, createPayment: delegate },
+      { confirmationThreshold: 5_000_000n, confirm, ourCaip2: CAIP2_TESTNET },
+    );
+
+    await client.createPayment(requirements({ amount: "5000000" }), { maxAmount: 10_000_000n });
+    expect(confirm).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("withConfirmationThreshold — fetch", () => {
+  it("passes through untouched (never calls confirm) when no payment is required", async () => {
+    const confirm = vi.fn(async () => true);
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = vi.fn(async () => new Response("ok", { status: 200 }));
+    try {
+      const delegate = vi.fn(async () => ({
+        response: new Response("ok", { status: 200 }),
+        paid: false,
+      }));
+      const client = withConfirmationThreshold(
+        { ...stubClient, fetch: delegate },
+        { confirmationThreshold: 5_000_000n, confirm, ourCaip2: CAIP2_TESTNET },
+      );
+
+      const out = await client.fetch("https://res.test/paid", { maxAmount: 10_000_000n });
+      expect(out.paid).toBe(false);
+      expect(confirm).not.toHaveBeenCalled();
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it("blocks on confirm before delegating when the decoded 402 amount meets the threshold", async () => {
+    const confirm = vi.fn(async () => true);
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = vi.fn(async () => response402([requirements({ amount: "5000000" })]));
+    try {
+      const delegate = vi.fn(async () => ({
+        response: new Response("unlocked", { status: 200 }),
+        paid: true,
+      }));
+      const client = withConfirmationThreshold(
+        { ...stubClient, fetch: delegate },
+        { confirmationThreshold: 5_000_000n, confirm, ourCaip2: CAIP2_TESTNET },
+      );
+
+      const out = await client.fetch("https://res.test/paid", { maxAmount: 10_000_000n });
+      expect(out.paid).toBe(true);
+      expect(confirm).toHaveBeenCalledTimes(1);
+      expect(delegate).toHaveBeenCalledTimes(1); // the real client still does its own fetch+402+sign
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it("never delegates to the wrapped client's fetch when confirmation is declined", async () => {
+    const confirm = vi.fn(async () => false);
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = vi.fn(async () => response402([requirements({ amount: "9000000" })]));
+    try {
+      const delegate = vi.fn();
+      const client = withConfirmationThreshold(
+        { ...stubClient, fetch: delegate },
+        { confirmationThreshold: 5_000_000n, confirm, ourCaip2: CAIP2_TESTNET },
+      );
+
+      await expect(
+        client.fetch("https://res.test/paid", { maxAmount: 10_000_000n }),
+      ).rejects.toBeInstanceOf(PaymentNotConfirmedError);
+      expect(delegate).not.toHaveBeenCalled();
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+});

--- a/contrib/examples/issue-228-x402-confirmation-threshold/confirmation-threshold.ts
+++ b/contrib/examples/issue-228-x402-confirmation-threshold/confirmation-threshold.ts
@@ -1,0 +1,159 @@
+/**
+ * Explicit confirmation for high-value x402 payments.
+ *
+ * Contributed for issue #228: payments authorized through the x402 signer
+ * only ever check `maxAmount` (a client-side ceiling) and the on-chain
+ * spending-limit policy (the durable budget) — neither is a per-payment
+ * "ask before this one" gate. A caller who wants to auto-pay small amounts
+ * but require explicit confirmation above some threshold has no seam for
+ * that today.
+ *
+ * This wraps any `X402Client` (the public interface `createX402Client`
+ * returns — see `src/x402-types.ts`) with a confirmation gate: a payment
+ * whose amount meets or exceeds `confirmationThreshold` blocks on a
+ * `confirm` callback before the wrapped client ever signs it.
+ *
+ * `createPayment(requirements, opts)` is the clean case — the amount is
+ * right there on `requirements.amount`, decoded and checked before
+ * delegating.
+ *
+ * `fetch(url, init)` is architecturally harder to wrap from the OUTSIDE:
+ * `X402Client.fetch` decodes the 402 and retries with the signed payment in
+ * one call, so nothing about the amount is observable until it's already
+ * signing. This wrapper's `fetch` does its own preliminary request to see
+ * the 402 and decode the amount (via the SDK's public `x402-guards` exports
+ * — `decodePaymentRequired` / `selectRequirements` are legitimate public
+ * API, not internals), confirms if needed, and only then delegates to the
+ * wrapped client's real `fetch`, which redoes that same request. That
+ * SECOND round-trip to the resource is the real cost of gating this
+ * interface from outside rather than inside `createX402Client` itself — see
+ * the README's "Limits" section.
+ *
+ * Run with: npx vitest run contrib/examples/issue-228-x402-confirmation-threshold
+ */
+
+import {
+  decodePaymentRequired,
+  selectRequirements,
+  parseAmount,
+  type PaymentRequirements,
+  type X402PayOptions,
+} from "../../../src/x402-guards";
+import type {
+  X402Client,
+  X402FetchInit,
+  X402Response,
+  SignedPayment,
+} from "../../../src/x402-types";
+
+/** What a caller reviews before approving a high-value payment. */
+export interface PendingConfirmation {
+  amount: bigint;
+  asset: string;
+  requirements: PaymentRequirements;
+}
+
+export interface ConfirmationThresholdOptions {
+  /**
+   * Any payment whose amount (base units) meets or exceeds this requires
+   * `confirm` to resolve `true` before the wrapped client signs it.
+   */
+  confirmationThreshold: bigint;
+  /**
+   * Resolve `true` to proceed with a payment that crossed the threshold, or
+   * `false` to refuse it. The wrapper blocks signing until this settles.
+   */
+  confirm: (pending: PendingConfirmation) => Promise<boolean>;
+  /**
+   * The CAIP-2 network id to match 402 offers against on the `fetch` path
+   * (e.g. "stellar:testnet") — needed to decode the same option the wrapped
+   * client itself would pick, via the SDK's own `selectRequirements`. Get
+   * this from `CAIP2_BY_NETWORK[network]` (also exported by `x402-guards`).
+   */
+  ourCaip2: string;
+}
+
+/**
+ * A payment crossed `confirmationThreshold` and `confirm` resolved `false`.
+ * Nothing was signed.
+ */
+export class PaymentNotConfirmedError extends Error {
+  constructor(
+    readonly required: bigint,
+    readonly threshold: bigint,
+    readonly asset: string,
+  ) {
+    super(
+      `x402 payment of ${required} (${asset}) crosses confirmationThreshold ${threshold} ` +
+        "and was declined via `confirm`; refusing to sign.",
+    );
+    this.name = "PaymentNotConfirmedError";
+  }
+}
+
+function needsConfirmation(amount: bigint, threshold: bigint): boolean {
+  return amount >= threshold;
+}
+
+async function requestConfirmation(
+  requirements: PaymentRequirements,
+  amount: bigint,
+  options: ConfirmationThresholdOptions,
+): Promise<void> {
+  if (!needsConfirmation(amount, options.confirmationThreshold)) return;
+  const approved = await options.confirm({ amount, asset: requirements.asset, requirements });
+  if (!approved) {
+    throw new PaymentNotConfirmedError(amount, options.confirmationThreshold, requirements.asset);
+  }
+}
+
+/**
+ * Wrap an `X402Client` so any payment at/above `confirmationThreshold`
+ * blocks on `confirm` before the underlying client signs it. A payment
+ * below the threshold passes straight through — `confirm` is never called,
+ * so wrapping a client you don't want a threshold on for a given call is a
+ * no-op (pass a threshold higher than any real payment, or don't wrap it).
+ */
+export function withConfirmationThreshold(
+  client: X402Client,
+  options: ConfirmationThresholdOptions,
+): X402Client {
+  return {
+    async createPayment(
+      requirements: PaymentRequirements,
+      opts: X402PayOptions,
+    ): Promise<SignedPayment> {
+      const amount = parseAmount(requirements.amount);
+      await requestConfirmation(requirements, amount, options);
+      return client.createPayment(requirements, opts);
+    },
+
+    async fetch(url: string, init: X402FetchInit): Promise<X402Response> {
+      // Preliminary request: see whether this resource even needs payment,
+      // and if so, decode which option the wrapped client would pick — all
+      // read-only, no state changed by this call.
+      const probe = await fetch(url, {
+        method: init.method ?? "GET",
+        headers: init.headers,
+      });
+
+      if (probe.status !== 402) {
+        // No payment needed. The probe response itself isn't a valid
+        // replacement for the real (non-preflight) request that init.body
+        // etc. would produce, so delegate to the wrapped client for the
+        // real thing rather than trying to reuse this one.
+        return client.fetch(url, init);
+      }
+
+      const decoded = decodePaymentRequired(probe);
+      const requirements = selectRequirements(decoded, init, options.ourCaip2);
+      const amount = parseAmount(requirements.amount);
+      await requestConfirmation(requirements, amount, options);
+
+      // Confirmed (or below threshold) — let the wrapped client do the real
+      // fetch → 402 → sign → retry flow. This repeats the 402 round-trip;
+      // see the module doc comment and README for why.
+      return client.fetch(url, init);
+    },
+  };
+}

--- a/contrib/examples/issue-232-policy-template-cache/README.md
+++ b/contrib/examples/issue-232-policy-template-cache/README.md
@@ -1,0 +1,54 @@
+# Policy Template Cache
+
+Self-contained reference for issue [#232](https://github.com/Vellar-Wallet/vellar-sdk/issues/232): local caching of `listTemplates()`, invalidated on template-affecting mutations.
+
+## Run tests
+
+```bash
+npx vitest run contrib/examples/issue-232-policy-template-cache
+```
+
+## Why
+
+`PolicyClient.listTemplates()` in `src/policy-client.ts` has no caching — every call is a fresh network round-trip. A component that lists templates on every render (or several components each mounting their own call) all hit the network independently, and there's no cache for a mutation to invalidate in the first place.
+
+## Usage
+
+```ts
+import { withTemplateCache } from "./policy-template-cache";
+
+const cachedClient = withTemplateCache(policyClient, {
+  onCacheInvalidated(event) {
+    console.debug("templates cache invalidated:", event.reason, event.at);
+  },
+});
+
+const templates = await cachedClient.listTemplates(); // network call
+const again = await cachedClient.listTemplates(); // served from cache
+
+await cachedClient.generate(definition); // invalidates the cache on success
+const fresh = await cachedClient.listTemplates(); // network call again
+
+// Or invalidate explicitly, e.g. after an out-of-band admin change:
+await cachedClient.refreshTemplates();
+```
+
+## Semantics
+
+| Call | Result |
+|------|--------|
+| `listTemplates()`, cache empty | Network call; result cached |
+| `listTemplates()`, cache populated | Served from cache, no network call |
+| `listTemplates()` called concurrently, cache empty | One shared in-flight request, not one per caller |
+| `generate()` succeeds | Invalidates the cache (fires `onCacheInvalidated` if the cache was populated) |
+| `generate()` fails | Cache untouched — nothing changed server-side, so nothing is stale |
+| `refreshTemplates()` | Invalidates unconditionally and re-fetches immediately |
+
+Two properties carry the guarantee, the same shape as [issue #209's idempotency wrapper](../issue-209-payment-idempotency):
+
+1. **The in-flight promise is cached, not only the settled result** — a burst of concurrent callers share one request instead of each firing their own.
+2. **Invalidation is observable via `onCacheInvalidated`**, not a hardcoded `console.debug` call, matching the SDK's existing injectable-callback conventions (`fetch`, `webAuthn`).
+
+## Limits
+
+This is an in-memory cache scoped to whatever object holds the wrapped client — it does not survive a page reload and does not coordinate across two separate wrapped-client instances (e.g. two tabs, or two independently-constructed policy clients in the same app). It also only tracks mutations made **through this wrapper's own `generate()`** — an out-of-band change (an admin action elsewhere, a different client instance calling the real `generate()` directly) won't be observed automatically; call `refreshTemplates()` after any change you know about but couldn't have seen.

--- a/contrib/examples/issue-232-policy-template-cache/policy-template-cache.test.ts
+++ b/contrib/examples/issue-232-policy-template-cache/policy-template-cache.test.ts
@@ -1,0 +1,139 @@
+import { describe, expect, it, vi } from "vitest";
+import { withTemplateCache, type PolicyClientLike } from "./policy-template-cache";
+import type { PolicyDefinition } from "../../../src/types";
+
+const definition: PolicyDefinition = {
+  version: "1",
+  type: "spending_limit",
+  owners: ["CAFK7NMQOT7G2SKMREDUII3EOK4APIY54WIK6CVGY72XWFE76YFRDF67"],
+  spendingLimits: { dailyXlm: "100" },
+};
+
+function template(title: string) {
+  return { type: "spending_limit", title, description: "", enforcement: { kind: "none" as const } };
+}
+
+function fakeClient(overrides: Partial<PolicyClientLike> = {}): PolicyClientLike & {
+  listTemplates: ReturnType<typeof vi.fn>;
+  generate: ReturnType<typeof vi.fn>;
+} {
+  return {
+    listTemplates: vi.fn().mockResolvedValue([template("Spending limit")]),
+    generate: vi.fn().mockResolvedValue({ id: "p1", createdAt: "now", status: "generated" }),
+    ...overrides,
+  };
+}
+
+describe("withTemplateCache", () => {
+  it("caches listTemplates() — a second call does not re-fetch", async () => {
+    const client = fakeClient();
+    const cached = withTemplateCache(client);
+
+    const first = await cached.listTemplates();
+    const second = await cached.listTemplates();
+
+    expect(second).toEqual(first);
+    expect(client.listTemplates).toHaveBeenCalledTimes(1);
+  });
+
+  it("de-duplicates concurrent listTemplates() calls into one underlying request", async () => {
+    const client = fakeClient();
+    const cached = withTemplateCache(client);
+
+    const [a, b, c] = await Promise.all([
+      cached.listTemplates(),
+      cached.listTemplates(),
+      cached.listTemplates(),
+    ]);
+
+    expect(a).toEqual(b);
+    expect(b).toEqual(c);
+    expect(client.listTemplates).toHaveBeenCalledTimes(1);
+  });
+
+  it("generate() invalidates the cache — a subsequent listTemplates() re-fetches", async () => {
+    const client = fakeClient({
+      listTemplates: vi
+        .fn()
+        .mockResolvedValueOnce([template("Spending limit")])
+        .mockResolvedValueOnce([template("Spending limit (updated)")]),
+    });
+    const cached = withTemplateCache(client);
+
+    await cached.listTemplates(); // populates the cache
+    await cached.generate(definition); // should invalidate it
+    const templates = await cached.listTemplates(); // should re-fetch
+
+    expect(templates[0]!.title).toBe("Spending limit (updated)");
+    expect(client.listTemplates).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not invalidate the cache if generate() fails", async () => {
+    const client = fakeClient({ generate: vi.fn().mockRejectedValue(new Error("server error")) });
+    const cached = withTemplateCache(client);
+
+    await cached.listTemplates(); // populates the cache
+    await expect(cached.generate(definition)).rejects.toThrow("server error");
+    await cached.listTemplates(); // should still read the cache
+
+    expect(client.listTemplates).toHaveBeenCalledTimes(1);
+  });
+
+  it("refreshTemplates() invalidates and re-fetches even without an intervening generate()", async () => {
+    const client = fakeClient({
+      listTemplates: vi
+        .fn()
+        .mockResolvedValueOnce([template("Spending limit")])
+        .mockResolvedValueOnce([template("Spending limit v2")]),
+    });
+    const cached = withTemplateCache(client);
+
+    await cached.listTemplates();
+    const refreshed = await cached.refreshTemplates();
+
+    expect(refreshed[0]!.title).toBe("Spending limit v2");
+    expect(client.listTemplates).toHaveBeenCalledTimes(2);
+  });
+
+  it("fires onCacheInvalidated with reason 'template-update' from generate()", async () => {
+    const client = fakeClient();
+    const onCacheInvalidated = vi.fn();
+    const now = () => new Date("2026-01-01T00:00:00.000Z");
+    const cached = withTemplateCache(client, { onCacheInvalidated, now });
+
+    await cached.listTemplates();
+    await cached.generate(definition);
+
+    expect(onCacheInvalidated).toHaveBeenCalledWith({
+      cache: "templates",
+      reason: "template-update",
+      at: "2026-01-01T00:00:00.000Z",
+    });
+  });
+
+  it("fires onCacheInvalidated with reason 'explicit-refresh' from refreshTemplates()", async () => {
+    const client = fakeClient();
+    const onCacheInvalidated = vi.fn();
+    const cached = withTemplateCache(client, { onCacheInvalidated });
+
+    await cached.listTemplates();
+    await cached.refreshTemplates();
+
+    expect(onCacheInvalidated.mock.calls[0]![0]).toMatchObject({ reason: "explicit-refresh" });
+  });
+
+  it("does not fire onCacheInvalidated when generate() runs before the cache was ever populated", async () => {
+    const client = fakeClient();
+    const onCacheInvalidated = vi.fn();
+    const cached = withTemplateCache(client, { onCacheInvalidated });
+
+    await cached.generate(definition); // no prior listTemplates() call
+    expect(onCacheInvalidated).not.toHaveBeenCalled();
+  });
+
+  it("exposes the wrapped client via .inner for methods this wrapper doesn't touch", async () => {
+    const client = fakeClient();
+    const cached = withTemplateCache(client);
+    expect(cached.inner).toBe(client);
+  });
+});

--- a/contrib/examples/issue-232-policy-template-cache/policy-template-cache.ts
+++ b/contrib/examples/issue-232-policy-template-cache/policy-template-cache.ts
@@ -1,0 +1,124 @@
+/**
+ * Cache invalidation for policy template listings.
+ *
+ * Contributed for issue #232: `PolicyClient.listTemplates()` in
+ * src/policy-client.ts has no caching at all today — every call is a fresh
+ * network round-trip, and there is no local cache for a mutation to
+ * invalidate.
+ *
+ * This wraps any `PolicyClient` (the structural interface `createPolicyClient`
+ * returns — see `src/policy-client.ts`) with an in-memory `listTemplates()`
+ * cache, invalidated automatically by `generate()` (a mutation that could
+ * change template state server-side) and by an explicit `refreshTemplates()`.
+ *
+ * Two properties carry the guarantee, same shape as `issue-209`'s idempotency
+ * wrapper:
+ *
+ *  1. The IN-FLIGHT promise is cached, not only the settled result — a burst
+ *     of concurrent `listTemplates()` callers (e.g. several components
+ *     mounting at once) share one request instead of each firing their own.
+ *
+ *  2. Invalidation fires an `onCacheInvalidated` event rather than a
+ *     hardcoded `console.debug` call, so a host can route it into its own
+ *     logger or ignore it — matching the SDK's existing injectable-callback
+ *     conventions (`fetch`, `webAuthn`).
+ *
+ * Run with: npx vitest run contrib/examples/issue-232-policy-template-cache
+ */
+
+import type { GeneratedPolicy, PolicyTemplateInfo } from "../../../src/policy-types";
+import type { PolicyDefinition } from "../../../src/types";
+
+/** Structural match for `PolicyClient` in src/policy-client.ts — only the
+ * two methods this wrapper actually touches are required, so it composes
+ * with the real client (which has more methods) or a test double. */
+export interface PolicyClientLike {
+  listTemplates(): Promise<PolicyTemplateInfo[]>;
+  generate(definition: PolicyDefinition): Promise<GeneratedPolicy>;
+}
+
+/**
+ * Fired when the local `listTemplates()` cache is invalidated. Purely
+ * observational — invalidation happens regardless of whether a listener is
+ * attached.
+ */
+export interface CacheInvalidationEvent {
+  cache: "templates";
+  /** Why: an explicit `refreshTemplates()` call, or a `generate()` call that
+   * could have changed template data server-side. */
+  reason: "explicit-refresh" | "template-update";
+  at: string;
+}
+
+export interface CachedPolicyClientOptions {
+  /** Called whenever the templates cache is invalidated. */
+  onCacheInvalidated?: (event: CacheInvalidationEvent) => void;
+  /** Injected clock (tests only); defaults to `() => new Date()`. */
+  now?: () => Date;
+}
+
+export interface CachedPolicyClient<T extends PolicyClientLike> {
+  listTemplates(): Promise<PolicyTemplateInfo[]>;
+  /** Invalidate the cache and re-fetch immediately, returning the fresh list.
+   * Call this after any out-of-band change to templates (e.g. an admin
+   * action elsewhere) that this wrapper couldn't have observed on its own. */
+  refreshTemplates(): Promise<PolicyTemplateInfo[]>;
+  generate(definition: PolicyDefinition): Promise<GeneratedPolicy>;
+  /** The wrapped client, for methods this wrapper doesn't touch. */
+  readonly inner: T;
+}
+
+/**
+ * Wrap a `PolicyClient`-like object with a `listTemplates()` cache. `generate`
+ * is passed through but ALSO invalidates the cache first (well, after it
+ * resolves — see below), since a successful generate is a signal the cached
+ * listing may be stale.
+ */
+export function withTemplateCache<T extends PolicyClientLike>(
+  client: T,
+  options: CachedPolicyClientOptions = {},
+): CachedPolicyClient<T> {
+  const now = options.now ?? (() => new Date());
+
+  let cache: PolicyTemplateInfo[] | undefined;
+  let inFlight: Promise<PolicyTemplateInfo[]> | undefined;
+
+  function invalidate(reason: CacheInvalidationEvent["reason"]): void {
+    if (cache === undefined) return; // nothing cached — nothing to invalidate
+    cache = undefined;
+    options.onCacheInvalidated?.({ cache: "templates", reason, at: now().toISOString() });
+  }
+
+  function listTemplates(): Promise<PolicyTemplateInfo[]> {
+    if (cache !== undefined) return Promise.resolve(cache);
+    if (inFlight) return inFlight;
+
+    inFlight = client
+      .listTemplates()
+      .then((templates) => {
+        cache = templates;
+        return templates;
+      })
+      .finally(() => {
+        inFlight = undefined;
+      });
+    return inFlight;
+  }
+
+  return {
+    inner: client,
+    listTemplates,
+    refreshTemplates() {
+      invalidate("explicit-refresh");
+      return listTemplates();
+    },
+    async generate(definition) {
+      const policy = await client.generate(definition);
+      // Invalidate AFTER the mutation succeeds, not before: an invalidation
+      // ahead of a generate() call that then fails would drop a perfectly
+      // good cache for no reason.
+      invalidate("template-update");
+      return policy;
+    },
+  };
+}

--- a/contrib/examples/issue-242-policy-batch-ordering/README.md
+++ b/contrib/examples/issue-242-policy-batch-ordering/README.md
@@ -1,0 +1,63 @@
+# Policy Batch Ordering
+
+Self-contained reference for issue [#242](https://github.com/Vellar-Wallet/vellar-sdk/issues/242): per-wallet ordering guarantees for queued `policy-facade` operations.
+
+## Run tests
+
+```bash
+npx vitest run contrib/examples/issue-242-policy-batch-ordering
+```
+
+## Why
+
+`PolicyFacade.deploy(policyId)` in `src/policy-facade.ts` has no batching or queueing at all — nothing stops two concurrent `deploy()` calls for the SAME connected wallet from interleaving their steps (server-side instance deploy, passkey attach, record) out of the order they were requested in. Attaching several policies back-to-back without awaiting each one is a natural thing to do and currently unsafe.
+
+## Usage
+
+```ts
+import { createPerWalletQueue } from "./policy-batch-ordering";
+
+const queue = createPerWalletQueue<string, DeployPolicyResult>({
+  onOutOfOrder(event) {
+    // Should never fire — a bug/bypass detector, not an expected event.
+    console.error("policy queue out of order!", event);
+  },
+});
+
+// Wrap the wallet's existing deploy():
+function orderedDeploy(policyId: string) {
+  const accountId = wallet.session!.accountId;
+  return queue.enqueue(accountId, policyId, (id) => wallet.policies.deploy(id));
+}
+
+// Now concurrent calls for the SAME wallet complete in call order:
+const [r1, r2, r3] = await Promise.all([
+  orderedDeploy("policy-1"),
+  orderedDeploy("policy-2"),
+  orderedDeploy("policy-3"),
+]);
+
+// Or run a list strictly in order, stopping at the first failure:
+const results = await queue.runBatch(accountId, ["policy-1", "policy-2", "policy-3"], (id) =>
+  wallet.policies.deploy(id),
+);
+```
+
+## Semantics
+
+| Case | Result |
+|------|--------|
+| Two `enqueue()` calls, same account id | Complete strictly in call order, one at a time |
+| Two `enqueue()` calls, different account ids | Run concurrently, unaffected by each other |
+| An enqueued operation fails | Later operations for the same account still run — a rejection doesn't wedge the queue |
+| `runBatch(accountId, inputs, run)` | Each input runs through the SAME per-account queue, strictly in the given order |
+| A `runBatch` item fails | Stops immediately; throws `BatchOperationError` carrying what succeeded before the failure |
+| Every operation completes in order | `onOutOfOrder` never fires (see "Design note") |
+
+## Design note: `onOutOfOrder`
+
+Given the queue's own construction, an operation running out of sequence for its account id should be structurally impossible — each operation only starts once the previous one for the same account has settled. `onOutOfOrder` exists anyway as a defense-in-depth check (comparing each operation's assigned sequence number against the last-completed one right before it runs), not because it's expected to fire. If it ever does, that's a bug in the queue itself, or something bypassing it — not a legitimate ordering outcome to build product logic around.
+
+## Limits
+
+This is generic over any single-operation async function keyed by an account id — it isn't specific to `deploy`. It queues calls made **through this wrapper**; a caller that calls `wallet.policies.deploy()` directly, bypassing the queue, is not ordered against calls made through it. Wire every call site that needs the ordering guarantee through the same `createPerWalletQueue()` instance.

--- a/contrib/examples/issue-242-policy-batch-ordering/policy-batch-ordering.test.ts
+++ b/contrib/examples/issue-242-policy-batch-ordering/policy-batch-ordering.test.ts
@@ -1,0 +1,188 @@
+import { describe, expect, it, vi } from "vitest";
+import { BatchOperationError, createPerWalletQueue } from "./policy-batch-ordering";
+
+describe("createPerWalletQueue.enqueue", () => {
+  it("completes concurrent operations for the SAME account strictly in call order, even when each resolves unpredictably", async () => {
+    const order: string[] = [];
+    const gates = new Map<string, () => void>();
+    const queue = createPerWalletQueue<string, string>();
+
+    async function op(id: string): Promise<string> {
+      await new Promise<void>((resolve) => gates.set(id, resolve));
+      order.push(id);
+      return `result-${id}`;
+    }
+
+    const pa = queue.enqueue("WALLET-A", "a", op);
+    const pb = queue.enqueue("WALLET-A", "b", op);
+    const pc = queue.enqueue("WALLET-A", "c", op);
+
+    // "b" and "c" haven't even started their gate yet — the queue itself
+    // serializes op() calls, not just their completion — so only "a"'s gate
+    // exists at this point.
+    await vi.waitFor(() => expect(gates.has("a")).toBe(true));
+    gates.get("a")!();
+
+    await vi.waitFor(() => expect(gates.has("b")).toBe(true));
+    gates.get("b")!();
+
+    await vi.waitFor(() => expect(gates.has("c")).toBe(true));
+    gates.get("c")!();
+
+    await Promise.all([pa, pb, pc]);
+    expect(order).toEqual(["a", "b", "c"]);
+  });
+
+  it("does not serialize operations for DIFFERENT accounts against each other", async () => {
+    const order: string[] = [];
+    let releaseA!: () => void;
+    const gateA = new Promise<void>((r) => (releaseA = r));
+    const queue = createPerWalletQueue<string, string>();
+
+    const pa = queue.enqueue("WALLET-A", "a", async (id) => {
+      await gateA;
+      order.push(id);
+      return id;
+    });
+    const pb = queue.enqueue("WALLET-B", "b", async (id) => {
+      order.push(id);
+      return id;
+    });
+
+    await pb; // B completes even though A is still blocked
+    expect(order).toEqual(["b"]);
+
+    releaseA();
+    await pa;
+    expect(order).toEqual(["b", "a"]);
+  });
+
+  it("a failed operation does not block later operations for the same account", async () => {
+    const queue = createPerWalletQueue<string, string>();
+    const run = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("first fails"))
+      .mockResolvedValueOnce("ok-2");
+
+    const first = queue.enqueue("WALLET-A", "a", run);
+    const second = queue.enqueue("WALLET-A", "b", run);
+
+    await expect(first).rejects.toThrow("first fails");
+    await expect(second).resolves.toBe("ok-2");
+  });
+
+  it("fires onOutOfOrder only in the (expected-never) out-of-order case, not during normal operation", async () => {
+    const onOutOfOrder = vi.fn();
+    const queue = createPerWalletQueue<string, string>({ onOutOfOrder });
+    const run = vi.fn().mockResolvedValue("ok");
+
+    await queue.enqueue("WALLET-A", "a", run);
+    await queue.enqueue("WALLET-A", "b", run);
+    await queue.enqueue("WALLET-A", "c", run);
+
+    expect(onOutOfOrder).not.toHaveBeenCalled();
+  });
+});
+
+describe("createPerWalletQueue.runBatch", () => {
+  it("runs items strictly in the given order", async () => {
+    const order: string[] = [];
+    const gates = new Map<string, () => void>();
+    const queue = createPerWalletQueue<string, string>();
+
+    async function op(id: string): Promise<string> {
+      await new Promise<void>((resolve) => gates.set(id, resolve));
+      order.push(id);
+      return `result-${id}`;
+    }
+
+    const batch = queue.runBatch("WALLET-A", ["x", "y", "z"], op);
+
+    await vi.waitFor(() => expect(gates.has("x")).toBe(true));
+    gates.get("x")!();
+    await vi.waitFor(() => expect(gates.has("y")).toBe(true));
+    gates.get("y")!();
+    await vi.waitFor(() => expect(gates.has("z")).toBe(true));
+    gates.get("z")!();
+
+    const results = await batch;
+    expect(results).toEqual(["result-x", "result-y", "result-z"]);
+    expect(order).toEqual(["x", "y", "z"]);
+  });
+
+  it("stops after a failure, reporting what succeeded via BatchOperationError", async () => {
+    const run = vi
+      .fn()
+      .mockResolvedValueOnce("ok-1")
+      .mockRejectedValueOnce(new Error("boom"))
+      .mockResolvedValueOnce("ok-3");
+    const queue = createPerWalletQueue<string, string>();
+
+    const err = await queue.runBatch("WALLET-A", ["p1", "p2", "p3"], run).catch((e) => e);
+
+    expect(err).toBeInstanceOf(BatchOperationError);
+    expect((err as BatchOperationError<string>).failedIndex).toBe(1);
+    expect((err as BatchOperationError<string>).succeeded).toEqual(["ok-1"]);
+    // p3 must never have been attempted.
+    expect(run).toHaveBeenCalledTimes(2);
+  });
+
+  it("a batch for one wallet does not block a concurrent batch for a different wallet", async () => {
+    const order: string[] = [];
+    let releaseA!: () => void;
+    const gateA = new Promise<void>((r) => (releaseA = r));
+    const queue = createPerWalletQueue<string, string>();
+
+    const batchA = queue.runBatch("WALLET-A", ["a1"], async (id) => {
+      await gateA;
+      order.push(id);
+      return id;
+    });
+    const batchB = queue.runBatch("WALLET-B", ["b1", "b2"], async (id) => {
+      order.push(id);
+      return id;
+    });
+
+    await batchB;
+    expect(order).toEqual(["b1", "b2"]);
+
+    releaseA();
+    await batchA;
+    expect(order).toEqual(["b1", "b2", "a1"]);
+  });
+});
+
+describe("applied to a PolicyFacade.deploy-shaped operation", () => {
+  /** A minimal stand-in matching src/policy-facade.ts's DeployPolicyResult shape. */
+  interface DeployResult {
+    policy: { id: string };
+    contractId: string;
+    attachTxHash: string;
+  }
+
+  it("guarantees deploy() calls for the same connected wallet complete in call order", async () => {
+    const attachOrder: string[] = [];
+    const queue = createPerWalletQueue<string, DeployResult>();
+
+    // Simulates PolicyFacade.deploy's three steps for one policyId.
+    async function deployOne(policyId: string): Promise<DeployResult> {
+      const contractId = `C-${policyId}`;
+      // ...server-side instance deploy would happen here...
+      attachOrder.push(contractId); // the passkey attach step
+      return { policy: { id: policyId }, contractId, attachTxHash: `TX-${contractId}` };
+    }
+
+    function deploy(accountId: string, policyId: string) {
+      return queue.enqueue(accountId, policyId, deployOne);
+    }
+
+    const [r1, r2, r3] = await Promise.all([
+      deploy("WALLET-A", "p1"),
+      deploy("WALLET-A", "p2"),
+      deploy("WALLET-A", "p3"),
+    ]);
+
+    expect(attachOrder).toEqual(["C-p1", "C-p2", "C-p3"]);
+    expect([r1.contractId, r2.contractId, r3.contractId]).toEqual(["C-p1", "C-p2", "C-p3"]);
+  });
+});

--- a/contrib/examples/issue-242-policy-batch-ordering/policy-batch-ordering.ts
+++ b/contrib/examples/issue-242-policy-batch-ordering/policy-batch-ordering.ts
@@ -1,0 +1,148 @@
+/**
+ * Per-wallet ordering for queued policy-facade batch operations.
+ *
+ * Contributed for issue #242: `PolicyFacade.deploy(policyId)` in
+ * src/policy-facade.ts has no batching or queueing at all today — nothing
+ * stops two concurrent `deploy()` calls for the SAME connected wallet from
+ * interleaving their steps (server-side instance deploy, passkey attach,
+ * record) out of the order they were requested in.
+ *
+ * This wraps any single-operation async function keyed by an account id
+ * (the shape `PolicyFacade.deploy` has) with a per-wallet FIFO queue:
+ * operations for the SAME account id always complete in call order, one at a
+ * time; operations for DIFFERENT account ids are unaffected and run
+ * concurrently. It also exposes a `runBatch` helper that runs a list of
+ * inputs through the SAME queue, strictly in the given order.
+ *
+ * A failed operation does not permanently wedge the queue — later operations
+ * for the same wallet still run; they just don't wait on a REJECTION, only
+ * on the prior operation SETTLING (success or failure).
+ *
+ * Run with: npx vitest run contrib/examples/issue-242-policy-batch-ordering
+ */
+
+/**
+ * Fired when a queued operation is detected running out of sequence for its
+ * account id — i.e. the queue itself misbehaved. Should never fire under
+ * normal operation; it exists as a defense-in-depth signal, not an expected
+ * event.
+ */
+export interface OutOfOrderOperationEvent {
+  accountId: string;
+  /** The sequence number assigned when this operation was enqueued. */
+  sequence: number;
+  /** The highest sequence number already completed for this account at the
+   * time this one started running — expected to be exactly `sequence - 1`. */
+  lastCompletedSequence: number;
+  at: string;
+}
+
+export interface PerWalletQueueOptions {
+  /** Called if the queue ever detects out-of-order execution. Should never fire in practice. */
+  onOutOfOrder?: (event: OutOfOrderOperationEvent) => void;
+  /** Injected clock (tests only); defaults to `() => new Date()`. */
+  now?: () => Date;
+}
+
+/** Thrown by `runBatch` when one item fails; carries what succeeded before it. */
+export class BatchOperationError<TResult> extends Error {
+  constructor(
+    /** The 0-based index of the input that failed. */
+    readonly failedIndex: number,
+    /** Results for the inputs before it that succeeded, in order. */
+    readonly succeeded: TResult[],
+    readonly cause: unknown,
+  ) {
+    super(
+      `runBatch: item ${failedIndex} failed after ${succeeded.length} prior ` +
+        `operation(s) succeeded — ${cause instanceof Error ? cause.message : String(cause)}`,
+    );
+    this.name = "BatchOperationError";
+  }
+}
+
+export interface PerWalletQueue<TInput, TResult> {
+  /** Run `run(input)` for `accountId`, queued after any prior operation for
+   * the SAME account id (different account ids run concurrently). */
+  enqueue(accountId: string, input: TInput, run: (input: TInput) => Promise<TResult>): Promise<TResult>;
+  /** Run `inputs` for `accountId` through the queue, STRICTLY in the given
+   * order — each item fully completes before the next starts. Stops at the
+   * first failure, throwing `BatchOperationError` with what succeeded. */
+  runBatch(
+    accountId: string,
+    inputs: TInput[],
+    run: (input: TInput) => Promise<TResult>,
+  ): Promise<TResult[]>;
+}
+
+/**
+ * Create a per-wallet FIFO operation queue. Generic over the operation's
+ * input/result types so it applies to `PolicyFacade.deploy(policyId):
+ * Promise<DeployPolicyResult>` (this issue's target) as well as any other
+ * single-operation, per-account-scoped async call.
+ */
+export function createPerWalletQueue<TInput = string, TResult = unknown>(
+  options: PerWalletQueueOptions = {},
+): PerWalletQueue<TInput, TResult> {
+  const now = options.now ?? (() => new Date());
+
+  const tailByAccount = new Map<string, Promise<unknown>>();
+  const nextSequenceByAccount = new Map<string, number>();
+  const lastCompletedSequenceByAccount = new Map<string, number>();
+
+  function enqueue(
+    accountId: string,
+    _input: TInput,
+    run: (input: TInput) => Promise<TResult>,
+  ): Promise<TResult> {
+    const sequence = nextSequenceByAccount.get(accountId) ?? 0;
+    nextSequenceByAccount.set(accountId, sequence + 1);
+
+    const previousTail = tailByAccount.get(accountId) ?? Promise.resolve();
+
+    // A prior operation's REJECTION must not abort this one — `.catch(() =>
+    // {})` lets the chain continue past it, since one wallet's failed
+    // operation must not permanently wedge every later operation for the
+    // same wallet. Chaining `run` off this settled promise (rather than
+    // passing two handlers to one `.then`) keeps the resulting type exactly
+    // `Promise<TResult>`, not `Promise<TResult | void>`.
+    const task = previousTail.catch(() => {}).then(async () => {
+      const lastCompleted = lastCompletedSequenceByAccount.get(accountId) ?? -1;
+      if (sequence !== lastCompleted + 1) {
+        options.onOutOfOrder?.({
+          accountId,
+          sequence,
+          lastCompletedSequence: lastCompleted,
+          at: now().toISOString(),
+        });
+      }
+      try {
+        return await run(_input);
+      } finally {
+        lastCompletedSequenceByAccount.set(accountId, sequence);
+      }
+    });
+
+    // Every operation (success or failure) becomes the new tail so the next
+    // enqueue() waits on IT — not on whichever earlier task happened to
+    // resolve first.
+    tailByAccount.set(accountId, task);
+
+    return task;
+  }
+
+  return {
+    enqueue,
+    async runBatch(accountId, inputs, run) {
+      const results: TResult[] = [];
+      for (let i = 0; i < inputs.length; i++) {
+        try {
+          results.push(await enqueue(accountId, inputs[i] as TInput, run));
+        } catch (err) {
+          throw new BatchOperationError(i, results, err);
+        }
+      }
+      return results;
+    },
+  };
+}


### PR DESCRIPTION
## Summary

Standalone reference implementations under `contrib/examples/`, scoped per [CONTRIBUTING.md](../CONTRIBUTING.md) and [contrib/README.md](../contrib/README.md) — no `src/` changes.

### #228 — Explicit confirmation flag for high-value x402 signer actions
`contrib/examples/issue-228-x402-confirmation-threshold/` — wraps any `X402Client` with a `confirmationThreshold` + `confirm` callback gate. `createPayment` reads the amount directly off `requirements.amount`; `fetch` does its own preliminary request + decode (via the SDK's public `x402-guards` exports — `decodePaymentRequired`/`selectRequirements`/`parseAmount`) to know the amount before delegating. The README documents this as a real limitation (a second round-trip to the resource) of gating this interface from *outside* rather than inside `createX402Client` itself.

### #232 — Cache invalidation on policy-client template update
`contrib/examples/issue-232-policy-template-cache/` — wraps any `PolicyClient`-like object with an in-memory `listTemplates()` cache, invalidated by `generate()` (only on success — a failed mutation leaves the cache untouched) and an explicit `refreshTemplates()`. In-flight de-duplication for concurrent callers, plus an injectable `onCacheInvalidated` callback matching the SDK's existing seams.

### #242 — Ordering issue in queued policy-facade batch operations
`contrib/examples/issue-242-policy-batch-ordering/` — a generic per-wallet FIFO operation queue (`createPerWalletQueue`) so concurrent calls for the SAME account id complete strictly in call order, while different accounts run unaffected/concurrently. Includes a `runBatch` helper and an `onOutOfOrder` defense-in-depth signal (should never fire under normal operation). The README/tests show it applied to `PolicyFacade.deploy`'s exact shape.

## Test plan
- [x] `npx vitest run contrib/examples/issue-228-x402-confirmation-threshold contrib/examples/issue-232-policy-template-cache contrib/examples/issue-242-policy-batch-ordering` — 24/24 passing
- [x] `npx tsc --noEmit` — no new errors (2 pre-existing, unrelated errors in `src/balances.test.ts`/`src/tx-rpc.ts` predate this PR and aren't touched by it)
- [x] Confirmed no files outside `contrib/` are touched

Closes #228
Closes #232
Closes #242
Close #240