### PR TITLE
Add PII redaction helper for consumer-supplied logging hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -387,8 +387,10 @@ The facade is the paved road. For custom flows the package also exports the
 underlying pieces: `createPasskeyKitConnector`, `createPaymentClient`,
 `createSessionStore`, `createX402Client` (x402 without the wallet handle) and its
 signers (`createSessionKeySigner`, `createPasskeyX402Signer`), the
-`WalletConnector` interface, balances helpers (`vellar-sdk/balances`), and
-RPC-backed readers (`vellar-sdk/rpc`, imported separately so
+`WalletConnector` interface, balances helpers (`vellar-sdk/balances`), a
+`redactSensitiveFields` helper for logging hooks (see
+[Redacting sensitive fields in logging hooks](#security-redacting-sensitive-fields-in-logging-hooks)),
+and RPC-backed readers (`vellar-sdk/rpc`, imported separately so
 `@stellar/stellar-sdk` stays out of bundles that don't read balances).
 
 #### Session key rotation on re-authentication
@@ -426,6 +428,50 @@ failure is reported to `onDebugLog` (default: a no-op — bring your own logger)
 rather than thrown, and mint always runs before revoke so a revoke failure
 never leaves the wallet with no valid session key. Omit `sessionKeyRotation`
 for the pre-existing behaviour (no rotation).
+
+#### Security: redacting sensitive fields in logging hooks
+
+`onDebugLog` (above) and any other place this SDK hands a structured object to
+a hook you supplied is designed to be piped straight into your own
+logger/telemetry pipeline — this SDK never logs anything on its own. Those
+objects can carry fields that identify a specific user or wallet: an ed25519
+session-key public key, the smart-account contract id, a WebAuthn credential
+id (`WalletSession.keyId`), or a server-side session id. None of these are
+secrets this SDK holds (it never has a wallet private key to log), but they
+are stable, wallet-linkable identifiers that a downstream log aggregator,
+support export, or analytics sink generally should not retain in plaintext.
+
+`redactSensitiveFields` replaces every field matching a known-sensitive name
+(`secretKey`, `secret`, `privateKey`, `publicKey`, `previousPublicKey`,
+`newPublicKey`, `accountId`, `contractId`, `keyId`, `sessionId`,
+`serverSessionId`, `signature` — see `SENSITIVE_LOG_FIELDS`) with `"[redacted]"`,
+walking nested objects and arrays, before you hand the result to your logger:
+
+```ts
+import { createPasskeyKitConnector, redactSensitiveFields } from "vellar-sdk";
+
+const connector = createPasskeyKitConnector({
+  kit,
+  backend,
+  network: "testnet",
+  appName: "Vellar",
+  onDebugLog: (event, details) => myLogger.debug(event, redactSensitiveFields(details)),
+});
+```
+
+This is an **opt-in helper**, not a change to what the SDK passes to your
+hook by default — wiring it is your call, so tests and pipelines that already
+inspect real values are unaffected unless you choose to wrap the hook. Pass
+`extraFields` to also redact fields specific to your own `details` payloads
+(e.g. an email address your app adds before re-logging):
+
+```ts
+redactSensitiveFields(details, { extraFields: ["email", "phoneNumber"] });
+```
+
+`redactSensitiveFields` is a pure function over plain data: it does not
+serialize, and non-plain values (`Error`, `Date`, class instances, XDR/`ScVal`
+objects) pass through untouched rather than being flattened into `{}`.
 ## API stability
 
 Exports fall into two groups:

--- a/src/index.ts
+++ b/src/index.ts
@@ -29,6 +29,7 @@ export * from "./x402-facade";
 export * from "./x402-request-auth";
 export * from "./session";
 export * from "./tx-status";
+export * from "./log-redaction";
 
 /** Stable v1 API — breaking changes only in major semver releases. */
 export * from "./v1-exports";

--- a/src/log-redaction.test.ts
+++ b/src/log-redaction.test.ts
@@ -1,0 +1,157 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  REDACTED,
+  redactSensitiveFields,
+  SENSITIVE_LOG_FIELDS,
+} from "./log-redaction";
+import { createPasskeyKitConnector, type PasskeyKitLike, type WalletBackend } from "./passkeykit-connector";
+
+describe("redactSensitiveFields", () => {
+  it("redacts every known sensitive field at the top level", () => {
+    const input: Record<string, unknown> = {};
+    for (const field of SENSITIVE_LOG_FIELDS) input[field] = `value-of-${field}`;
+    input.event = "user-connected";
+
+    const out = redactSensitiveFields(input);
+    for (const field of SENSITIVE_LOG_FIELDS) expect(out[field]).toBe(REDACTED);
+    expect(out.event).toBe("user-connected");
+  });
+
+  it("matches field names case-insensitively", () => {
+    const out = redactSensitiveFields({ SecretKey: "S123", ACCOUNTID: "CABC" });
+    expect(out.SecretKey).toBe(REDACTED);
+    expect(out.ACCOUNTID).toBe(REDACTED);
+  });
+
+  it("redacts sensitive fields nested inside objects and arrays", () => {
+    const out = redactSensitiveFields({
+      event: "session-key-rotated",
+      details: {
+        previousPublicKey: "GFIRST",
+        newPublicKey: "GSECOND",
+        history: [{ publicKey: "GOLD1" }, { publicKey: "GOLD2" }],
+      },
+    });
+    const details = out.details as Record<string, unknown>;
+    expect(details.previousPublicKey).toBe(REDACTED);
+    expect(details.newPublicKey).toBe(REDACTED);
+    const history = details.history as Array<Record<string, unknown>>;
+    expect(history[0]!.publicKey).toBe(REDACTED);
+    expect(history[1]!.publicKey).toBe(REDACTED);
+  });
+
+  it("leaves non-sensitive fields untouched", () => {
+    const out = redactSensitiveFields({ event: "wallet-created", network: "testnet", count: 3 });
+    expect(out).toEqual({ event: "wallet-created", network: "testnet", count: 3 });
+  });
+
+  it("does not mutate the input", () => {
+    const input = { secretKey: "S123", event: "x" };
+    const out = redactSensitiveFields(input);
+    expect(input.secretKey).toBe("S123");
+    expect(out).not.toBe(input);
+  });
+
+  it("passes through null and undefined", () => {
+    expect(redactSensitiveFields(null)).toBeNull();
+    expect(redactSensitiveFields(undefined)).toBeUndefined();
+  });
+
+  it("passes through primitives unchanged", () => {
+    expect(redactSensitiveFields("hello")).toBe("hello");
+    expect(redactSensitiveFields(42)).toBe(42);
+    expect(redactSensitiveFields(true)).toBe(true);
+  });
+
+  it("passes through non-plain objects (Error, Date) without flattening them", () => {
+    const err = new Error("boom");
+    const date = new Date("2026-01-01T00:00:00.000Z");
+    expect(redactSensitiveFields({ err, date })).toEqual({ err, date });
+  });
+
+  it("supports extraFields for consumer-specific sensitive keys", () => {
+    const out = redactSensitiveFields(
+      { email: "user@example.com", event: "x" },
+      { extraFields: ["email"] },
+    );
+    expect(out.email).toBe(REDACTED);
+    expect(out.event).toBe("x");
+  });
+
+  it("does not redact fields not in the sensitive set even if similarly named", () => {
+    const out = redactSensitiveFields({ eventKeyId: "not-a-real-keyId-field", keyId: "abc" });
+    // Only an exact (case-insensitive) field-name match is redacted.
+    expect(out.eventKeyId).toBe("not-a-real-keyId-field");
+    expect(out.keyId).toBe(REDACTED);
+  });
+
+  it("redacts circular references safely instead of throwing or looping forever", () => {
+    const obj: Record<string, unknown> = { secretKey: "S123" };
+    obj.self = obj;
+    const out = redactSensitiveFields(obj);
+    expect(out.secretKey).toBe(REDACTED);
+    expect(out.self).toBe("[circular]");
+  });
+
+  it("stops descending past maxDepth, leaving deeper values as-is", () => {
+    const deep = { a: { b: { c: { secretKey: "S123" } } } };
+    const out = redactSensitiveFields(deep, { maxDepth: 1 });
+    // depth 1 only redacts/walks the top level's direct children; a's value
+    // (an object) is returned unwalked once depth is exhausted.
+    expect(out.a).toEqual({ b: { c: { secretKey: "S123" } } });
+  });
+});
+
+describe("PII redaction guidance wired to onDebugLog (#291)", () => {
+  // connectWallet guards on a browser WebAuthn context; simulate it for these
+  // Node-run unit tests (same pattern as passkeykit-connector.test.ts).
+  beforeEach(() => {
+    vi.stubGlobal("window", {});
+    vi.stubGlobal("navigator", { credentials: {} });
+  });
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  function fakeKit(): PasskeyKitLike {
+    return {
+      createWallet: vi.fn(),
+      connectWallet: vi.fn().mockResolvedValue({ keyIdBase64: "key1", contractId: "CABC" }),
+      sign: vi.fn(),
+      wallet: undefined,
+    };
+  }
+  function fakeBackend(): WalletBackend {
+    return {
+      submitWalletCreation: vi.fn(),
+      lookupContractId: vi.fn().mockResolvedValue({ contractId: "CABC", sessionId: "sess-1" }),
+    };
+  }
+
+  it("a consumer wrapping onDebugLog with redactSensitiveFields never sees raw public keys", async () => {
+    const sink: Array<{ event: string; details: unknown }> = [];
+    const connector = createPasskeyKitConnector({
+      kit: fakeKit(),
+      backend: fakeBackend(),
+      network: "testnet",
+      appName: "Test App",
+      sessionKeyRotation: {
+        mint: vi.fn().mockResolvedValue({ publicKey: "GVERYSENSITIVEPUBLICKEY00000000000000000000000000000000" }),
+        revoke: vi.fn().mockResolvedValue(undefined),
+      },
+      onDebugLog: (event, details) => {
+        sink.push({ event, details: redactSensitiveFields(details) });
+      },
+    });
+
+    await connector.connectWallet("testnet");
+
+    const rotated = sink.find((s) => s.event === "session-key-rotated");
+    expect(rotated).toBeDefined();
+    const details = rotated!.details as Record<string, unknown>;
+    expect(details.newPublicKey).toBe(REDACTED);
+    // Confirm the raw value genuinely never reached the sink at all, not just
+    // that the redacted copy looks right.
+    expect(JSON.stringify(sink)).not.toContain("GVERYSENSITIVEPUBLICKEY");
+  });
+});

--- a/src/log-redaction.ts
+++ b/src/log-redaction.ts
@@ -1,0 +1,144 @@
+// PII / sensitive-field redaction for consumer-supplied logging hooks (#291).
+//
+// This SDK never logs anything itself (no logging library dependency), but it
+// does hand structured `details` objects to consumer-supplied hooks —
+// `onDebugLog` on `createPasskeyKitConnector` today — that a host typically
+// pipes straight into their own logger/telemetry pipeline. Those details can
+// carry fields that identify a specific user or wallet: an ed25519 session-key
+// public key, a smart-account contract id, a server-side session id, or a
+// WebAuthn credential id. None of these are "secrets" in the sense of a
+// private key (this SDK never has one to log), but they are stable,
+// wallet-linkable identifiers — exactly the shape of field a downstream log
+// aggregator, support ticket export, or analytics sink should not retain in
+// plaintext.
+//
+// This module does NOT change what any SDK code passes to a hook — that
+// would be a silent, surprising behavior change for consumers who already
+// rely on seeing real values (e.g. in tests, or their own already-redacting
+// pipeline). Instead it's an opt-in helper: wrap your `onDebugLog` (or any
+// other hook fed SDK-internal objects) with `redactSensitiveFields` yourself.
+//
+//   const vellar = createVellarWallet({
+//     ...,
+//     onDebugLog: (event, details) => myLogger.debug(event, redactSensitiveFields(details)),
+//   });
+
+/**
+ * Field names (case-insensitive, exact match) treated as sensitive by
+ * {@link redactSensitiveFields}. Covers every field this SDK's own hooks and
+ * public types are known to carry that identifies a specific user, wallet, or
+ * credential:
+ *
+ *  - `secretKey`, `secret`, `privateKey` — key material. This SDK never holds
+ *    a wallet private key, but a consumer's own logging hook can receive
+ *    these if the object passed through also carries a signer config (e.g.
+ *    a caller logging `{ event, config }` rather than just the hook's
+ *    `details` parameter).
+ *  - `publicKey`, `previousPublicKey`, `newPublicKey` — ed25519 session-key
+ *    public keys, as passed to `onDebugLog` by session-key rotation
+ *    (`src/passkeykit-connector.ts`). Not secret, but a stable identifier
+ *    tying a log line to one wallet's agent key.
+ *  - `accountId`, `contractId` — the smart-account C-address. Directly
+ *    identifies the wallet.
+ *  - `keyId` — the WebAuthn credential id (`WalletSession.keyId`). Identifies
+ *    the specific passkey/device.
+ *  - `sessionId`, `serverSessionId` — server-side session record ids
+ *    (`WalletSession.serverSessionId`, `WalletBackend` responses). Lets a
+ *    log line be joined back to a specific user's backend session.
+ *  - `signature` — auth-entry / WebAuthn assertion signature bytes. Not
+ *    reversible to a secret, but unnecessary in a log line and large.
+ */
+export const SENSITIVE_LOG_FIELDS: readonly string[] = [
+  "secretKey",
+  "secret",
+  "privateKey",
+  "publicKey",
+  "previousPublicKey",
+  "newPublicKey",
+  "accountId",
+  "contractId",
+  "keyId",
+  "sessionId",
+  "serverSessionId",
+  "signature",
+];
+
+const SENSITIVE_FIELD_SET = new Set(SENSITIVE_LOG_FIELDS.map((f) => f.toLowerCase()));
+
+/** The string substituted for a redacted field's value. */
+export const REDACTED = "[redacted]";
+
+export interface RedactOptions {
+  /**
+   * Additional field names to treat as sensitive, on top of
+   * {@link SENSITIVE_LOG_FIELDS}. Use this for consumer-specific fields (e.g.
+   * an email or phone number your own `details` payloads add before they
+   * reach the shared hook).
+   */
+  extraFields?: readonly string[];
+  /** Maximum object nesting depth to walk before leaving remaining values
+   * untouched. Defaults to 6 — deep enough for any shape this SDK's hooks
+   * produce, shallow enough to bound the work on an adversarial/circular
+   * consumer-supplied object. */
+  maxDepth?: number;
+}
+
+/**
+ * Return a deep copy of `value` with every sensitive field (by name, see
+ * {@link SENSITIVE_LOG_FIELDS}) replaced with {@link REDACTED}. Field-name
+ * matching is case-insensitive so `SecretKey`, `secretkey`, and `secret_key`
+ * (naive snake_case) are all caught.
+ *
+ * Safe to call on whatever a consumer is about to pass to their logger:
+ * arrays are walked, non-plain values (functions, `Error`, `Date`, class
+ * instances, XDR/`ScVal`-shaped objects) are passed through as-is rather than
+ * spread into `{}` and losing their meaning — this is a redaction filter, not
+ * a serializer. `undefined`/`null` pass through unchanged.
+ *
+ * Does not mutate `value`.
+ */
+export function redactSensitiveFields<T>(value: T, options: RedactOptions = {}): T {
+  const sensitive =
+    options.extraFields && options.extraFields.length > 0
+      ? new Set([...SENSITIVE_FIELD_SET, ...options.extraFields.map((f) => f.toLowerCase())])
+      : SENSITIVE_FIELD_SET;
+  const maxDepth = options.maxDepth ?? 6;
+  return redact(value, sensitive, maxDepth, new Set()) as T;
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  if (typeof value !== "object" || value === null) return false;
+  const proto = Object.getPrototypeOf(value);
+  return proto === Object.prototype || proto === null;
+}
+
+function redact(
+  value: unknown,
+  sensitive: ReadonlySet<string>,
+  depthRemaining: number,
+  seen: Set<unknown>,
+): unknown {
+  if (value === null || typeof value !== "object") return value;
+  if (depthRemaining <= 0) return value;
+  if (seen.has(value)) return "[circular]";
+
+  if (Array.isArray(value)) {
+    seen.add(value);
+    return value.map((item) => redact(item, sensitive, depthRemaining - 1, seen));
+  }
+
+  // Only walk into plain objects — an Error, Date, Map, ScVal/XDR class
+  // instance, etc. is passed through untouched rather than flattened.
+  if (!isPlainObject(value)) return value;
+
+  seen.add(value);
+  const out: Record<string, unknown> = {};
+  for (const [key, val] of Object.entries(value)) {
+    if (sensitive.has(key.toLowerCase())) {
+      out[key] = REDACTED;
+    } else {
+      out[key] = redact(val, sensitive, depthRemaining - 1, seen);
+    }
+  }
+  return out;
+}


### PR DESCRIPTION
## Summary

Consumer-supplied logging hooks (`onDebugLog` on `createPasskeyKitConnector` today, and any future hook of the same shape) are designed to be piped straight into a host's own logger/telemetry pipeline. The structured `details` objects they receive can carry fields that identify a specific user or wallet: an ed25519 session-key public key, the smart-account contract id, the WebAuthn credential id (`WalletSession.keyId`), or a server-side session id. None of these are secrets this SDK itself holds (it never has a wallet private key to log), but they are stable, wallet-linkable identifiers that a downstream log aggregator, support-ticket export, or analytics sink generally should not retain in plaintext.

## Changes

- **`src/log-redaction.ts`** (new): exports `SENSITIVE_LOG_FIELDS` (the identified sensitive field names — `secretKey`, `secret`, `privateKey`, `publicKey`, `previousPublicKey`, `newPublicKey`, `accountId`, `contractId`, `keyId`, `sessionId`, `serverSessionId`, `signature`) and `redactSensitiveFields(value, options?)`, a pure function that walks an object/array, case-insensitively matches field names against the sensitive set (plus any `options.extraFields`), and replaces matches with a redacted marker. Non-plain values (`Error`, `Date`, class/XDR instances) pass through untouched rather than being flattened; circular references and a configurable max depth are both handled safely.
- **`src/index.ts`**: exports the new module from the package root.
- **`README.md`**: new "Security: redacting sensitive fields in logging hooks" subsection (under Advanced, next to the existing session-key-rotation / `onDebugLog` docs) showing usage, the field list, and the `extraFields` escape hatch; the Advanced section intro links to it.
- **`src/log-redaction.test.ts`** (new): unit tests for the pure redaction logic (top-level and nested fields, case-insensitivity, arrays, non-plain values, mutation-safety, circular refs, depth limit, `extraFields`), plus an integration test that wires `redactSensitiveFields` into a real `onDebugLog` hook on `createPasskeyKitConnector` and asserts a raw session-key public key never reaches the sink (checked by string search over the full captured payload, not just structural equality).

This is deliberately an **opt-in helper**, not a change to what the SDK passes to `onDebugLog` by default — existing consumers and the existing `passkeykit-connector.test.ts` assertions on raw values are unaffected unless a consumer chooses to wrap their hook.

## Requirements checklist

- [x] Identify SDK-internal fields that should be flagged as sensitive
- [x] Helper that redacts known sensitive fields before passing to logging hooks
- [x] Tests verifying redacted fields never reach the logging hook
- [x] Redaction guidance documented in the README security section

## Test plan

- `npx vitest run src/log-redaction.test.ts` — 13 tests, all pass
- `npx vitest run src/passkeykit-connector.test.ts` — unaffected, all 30 pass (default `onDebugLog` behavior unchanged)
- Full `npx vitest run` — no new failures versus a clean `dev` checkout (16 pre-existing, environment-only failures in `contrib/examples/` unrelated to this change); 13 new tests pass
- `npm run typecheck` — no new errors versus a clean `dev` checkout

closes #291