### PR TITLE
Add canary npm dist-tag rollout process for pre-1.0 releases

### DIFF
--- a/.github/workflows/promote-canary.yml
+++ b/.github/workflows/promote-canary.yml
@@ -1,0 +1,46 @@
+name: Promote canary to latest
+
+# Manual-only: promoting a canary is a maintainer decision made after real
+# consumer validation (see docs/release-process.md's checklist), never an
+# automatic follow-on to publishing it. This workflow does not build or
+# publish a new tarball — it moves the npm `latest` dist-tag to point at a
+# version ALREADY published under `next`/canary, so what consumers get on
+# `latest` is byte-for-byte the same artifact that was validated as a canary.
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Exact package version already published to npm (e.g. 0.7.0-canary.0, or 0.7.0 once renamed) — must already exist on the registry"
+        required: true
+        type: string
+
+jobs:
+  promote:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          registry-url: https://registry.npmjs.org
+
+      # Fail loudly if someone fat-fingers a version that was never published,
+      # rather than having `npm dist-tag add` produce a confusing registry
+      # error, or worse, silently doing nothing.
+      - name: Verify the version exists on the registry
+        run: |
+          if ! npm view "vellar-sdk@${{ inputs.version }}" version >/dev/null 2>&1; then
+            echo "vellar-sdk@${{ inputs.version }} is not published — nothing to promote"
+            exit 1
+          fi
+
+      - name: Promote to latest
+        run: npm dist-tag add "vellar-sdk@${{ inputs.version }}" latest
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Confirm the promotion
+        run: npm dist-tag ls vellar-sdk

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,6 +4,14 @@ name: Publish
 # that guard a pull request. Security audit V-8: a compromised publish executes
 # in every consumer's browser and inside an MCP server holding a signing key, so
 # the artifact must be attributable to a specific commit and workflow.
+#
+# Canary rollout (#283): while this package is pre-1.0, a tag carrying a
+# semver PRERELEASE suffix (e.g. v0.7.0-canary.0) publishes to the npm `next`
+# dist-tag instead of `latest`. `npm install vellar-sdk` for ordinary
+# consumers is completely unaffected — `next` is only ever installed by
+# someone who explicitly asks for it (`npm install vellar-sdk@next`) or who
+# is promoted onto it deliberately. See docs/release-process.md for the full
+# canary -> latest promotion process and its consumer-validation checklist.
 on:
   push:
     tags: ["v*"]
@@ -40,6 +48,13 @@ jobs:
             exit 1
           fi
 
-      - run: npm publish --provenance --access public
+      - name: Determine dist-tag (canary vs latest)
+        id: dist_tag
+        run: |
+          DIST_TAG="$(node scripts/npm-dist-tag-for.mjs "$GITHUB_REF_NAME")"
+          echo "dist-tag: $DIST_TAG"
+          echo "tag=$DIST_TAG" >> "$GITHUB_OUTPUT"
+
+      - run: npm publish --provenance --access public --tag "${{ steps.dist_tag.outputs.tag }}"
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -1,0 +1,130 @@
+# Release process: canary rollout for pre-1.0 releases
+
+Maintainer-only. This is the process for cutting a release of `vellar-sdk`
+while the package is pre-1.0 — see `CONTRIBUTING.md` rule 3 for why this
+lives outside `contrib/` and is not something contributors run.
+
+## Why a canary stage exists
+
+Before this process, every tag pushed to this repo published straight to the
+npm `latest` dist-tag — the tag every plain `npm install vellar-sdk` resolves
+to. There was no way for an early-adopter consumer to try a release before it
+became the default for everyone. Pre-1.0, the API can still shift in ways a
+typecheck and the existing test suite don't fully exercise against a real
+consumer app (a passkey ceremony, a live facilitator, a real backend
+gateway) — a canary stage buys a validation window before a release is
+default-installed.
+
+## The two dist-tags
+
+| dist-tag | Who gets it | Published by |
+| -------- | ------------ | ------------ |
+| `next`   | Nobody by default — only `npm install vellar-sdk@next`, or a consumer pinned to it | Pushing a tag with a semver **prerelease** suffix, e.g. `v0.7.0-canary.0` |
+| `latest` | Everyone running plain `npm install vellar-sdk` | Pushing a plain version tag, e.g. `v0.7.0` — OR promoting an already-published canary (below) |
+
+The decision is made by `scripts/npm-dist-tag-for.mjs` (unit-tested in
+`scripts/npm-dist-tag-for.test.mjs`) and wired into `.github/workflows/publish.yml`
+as the `Determine dist-tag (canary vs latest)` step. It reads the pushed git
+tag: any `-` (semver prerelease marker) routes to `next`, anything else
+routes to `latest`. Nothing else about the publish job changes — the same
+`npm audit`, `typecheck`, `test`, `build`, and provenance-signed
+`npm publish` steps run either way, so a canary gets exactly the same
+supply-chain guarantees as a `latest` release (security audit V-8).
+
+## Step by step: cutting a canary
+
+1. Bump `package.json`'s `version` to a prerelease, e.g. `0.7.0-canary.0`.
+   Use `npm version 0.7.0-canary.0 --no-git-tag-version` or edit by hand,
+   then commit.
+2. Push a matching tag: `git tag v0.7.0-canary.0 && git push origin v0.7.0-canary.0`.
+   The tag MUST match `package.json`'s version exactly (`publish.yml`'s
+   existing "Verify tag matches package version" step fails the job
+   otherwise — unchanged by this process).
+3. `publish.yml` runs, and — because the tag carries a prerelease suffix —
+   publishes to npm under the `next` dist-tag. `npm install vellar-sdk`
+   for ordinary consumers is completely unaffected; only
+   `npm install vellar-sdk@next` (or `@0.7.0-canary.0` exactly) picks it up.
+4. Announce the canary (Telegram, a GitHub Discussion/issue, whatever this
+   project's current channel is) asking early adopters to validate it, and
+   work through the checklist below before promoting.
+
+## Consumer validation checklist (before promoting)
+
+Do not promote a canary to `latest` until every box below is checked, or the
+box is marked N/A with a reason recorded in the promotion PR/issue:
+
+- [ ] At least one real consumer app (not just this repo's own test suite)
+      has installed `vellar-sdk@next` and exercised the paved-road path:
+      `createVellarWallet` construction, `create()`/`connect()` against a
+      real passkey, and `pay()` against a real backend + facilitator on
+      testnet.
+- [ ] If this release touches `x402`: at least one real x402 payment (agent
+      or passkey signer) has settled against a real facilitator on testnet.
+- [ ] If this release touches `policies` or `agents`: at least one real
+      policy attach/deploy or agent key mint/revoke has been exercised
+      against a real backend.
+- [ ] No new consumer-facing error has been reported that isn't already a
+      known, intentional behavior change called out in `CHANGELOG.md`.
+- [ ] `CHANGELOG.md` has an entry for this version (written as if it were
+      going to `latest` — the canary and the eventual `latest` promotion are
+      the same artifact and the same changelog entry, not two).
+- [ ] The canary has been live on `next` for a deliberate minimum window
+      (a few days, not minutes) so early adopters have had a real chance to
+      pick it up — promoting immediately after publishing defeats the point
+      of the stage.
+
+## Step by step: promoting canary to latest
+
+Once the checklist above is satisfied:
+
+1. Decide the version consumers on `latest` should actually see. Two valid
+   options:
+   - **Promote the canary version as-is** (e.g. `0.7.0-canary.0` becomes
+     `latest`) — fastest, but an unusual-looking version number for
+     `latest` to carry.
+   - **Re-tag as a plain release** (e.g. cut `v0.7.0` from the same commit
+     the canary was built from, bump `package.json`, and let `publish.yml`
+     publish it fresh to `latest` under the normal path) — cleaner version
+     history, costs one more publish run of an already-validated artifact.
+
+   Most releases should use the second option; the promotion workflow
+   below exists for the first, and for recovering a mid-validation "we
+   actually just want what's on `next` right now" promotion.
+
+2. Run the **Promote canary to latest** workflow
+   (`.github/workflows/promote-canary.yml`) from the Actions tab, or:
+
+   ```sh
+   gh workflow run promote-canary.yml -f version=0.7.0-canary.0
+   ```
+
+   This does not build or publish a new tarball — it points the `latest`
+   dist-tag at a version already on the registry, so what consumers get is
+   byte-for-byte what was validated as the canary. It first checks the
+   version is actually published (fails loudly instead of silently
+   no-op'ing on a typo), runs `npm dist-tag add`, then confirms with
+   `npm dist-tag ls`.
+
+3. Verify: `npm view vellar-sdk dist-tags` should show `latest` pointing at
+   the promoted version.
+
+## Testing this process end to end
+
+Because this touches real npm publishes, it is not something CI exercises
+automatically against the real registry on every PR. Before relying on it
+for a real release, a maintainer runs the full loop once, deliberately:
+
+1. Cut a real canary (`v0.0.0-canary-test.0` off a throwaway commit, or the
+   next real prerelease when one is due) and confirm on npmjs.com / `npm
+   view vellar-sdk dist-tags` that it landed under `next`, not `latest`.
+2. Confirm `npm install vellar-sdk` (no tag) in a scratch project still
+   resolves to the previous `latest` version — i.e. publishing a canary
+   provably did not move `latest`.
+3. Run `promote-canary.yml` against that version and confirm `latest` now
+   points at it (`npm view vellar-sdk dist-tags`).
+4. Confirm `npm install vellar-sdk` in a fresh scratch project now resolves
+   to the promoted version.
+
+Record the outcome (date, versions used, who ran it) in the release PR or
+tracking issue for the release that exercised it, so there's a paper trail
+that the flow was actually run end to end rather than only reasoned about.

--- a/scripts/npm-dist-tag-for.mjs
+++ b/scripts/npm-dist-tag-for.mjs
@@ -1,0 +1,69 @@
+#!/usr/bin/env node
+// Decide the npm dist-tag a publish should use, from the git tag it runs from.
+//
+// WHY THIS IS ITS OWN SCRIPT (not inlined in publish.yml): the decision —
+// "does this look like a canary?" — is exactly the kind of one-line regex
+// that's easy to get subtly wrong inside a YAML `run:` block (quoting,
+// escaping, and no way to unit-test it in isolation). Pulling it out means
+// the logic that decides where a release goes can be tested the same way any
+// other release-affecting logic in this repo is (see verify-merged.mjs).
+//
+// Rule: a semver PRERELEASE tag (anything with a `-` suffix, e.g.
+// `v0.7.0-canary.0`, `v0.7.0-canary.1`, `v0.7.0-rc.0`) publishes to the
+// `next` dist-tag. A plain release tag (`v0.7.0`) publishes to `latest`.
+// This mirrors ordinary semver prerelease convention (see semver.org) rather
+// than inventing a bespoke "canary" grammar — any prerelease identifier
+// works, `canary` is simply the one this project's process names.
+//
+// Usage:
+//   node scripts/npm-dist-tag-for.mjs v0.7.0-canary.0   ->  next
+//   node scripts/npm-dist-tag-for.mjs v0.7.0            ->  latest
+//   node scripts/npm-dist-tag-for.mjs --selftest        ->  runs the cases below
+
+/**
+ * @param {string} tag a `v`-prefixed git tag, e.g. "v0.7.0-canary.0"
+ * @returns {"next" | "latest"}
+ */
+export function distTagFor(tag) {
+  const version = tag.replace(/^v/, "");
+  const isPrerelease = /-/.test(version);
+  return isPrerelease ? "next" : "latest";
+}
+
+const CASES = [
+  ["v0.7.0-canary.0", "next"],
+  ["v0.7.0-canary.1", "next"],
+  ["v1.0.0-rc.0", "next"],
+  ["v0.7.0", "latest"],
+  ["v1.0.0", "latest"],
+  ["v0.6.1", "latest"],
+];
+
+function selftest() {
+  let failed = 0;
+  for (const [tag, expected] of CASES) {
+    const got = distTagFor(tag);
+    const ok = got === expected;
+    if (!ok) failed++;
+    console.log(`  ${ok ? "ok" : "FAIL"}  ${tag} -> ${got}${ok ? "" : ` (expected ${expected})`}`);
+  }
+  console.log(`\n  ${CASES.length} case(s), ${failed} failed.`);
+  process.exit(failed ? 1 : 0);
+}
+
+// Only run the CLI when this file is executed directly (`node
+// scripts/npm-dist-tag-for.mjs ...`), not when imported by the test file.
+// Compared via pathToFileURL (not a raw `file://` template) so this also
+// works on Windows, where argv[1] uses backslashes.
+import { pathToFileURL } from "node:url";
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  const arg = process.argv[2];
+  if (arg === "--selftest") {
+    selftest();
+  } else if (!arg) {
+    console.error("usage: node scripts/npm-dist-tag-for.mjs <git-tag>   |   --selftest");
+    process.exit(2);
+  } else {
+    console.log(distTagFor(arg));
+  }
+}

--- a/scripts/npm-dist-tag-for.test.mjs
+++ b/scripts/npm-dist-tag-for.test.mjs
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+import { distTagFor } from "./npm-dist-tag-for.mjs";
+
+describe("distTagFor", () => {
+  it("publishes a prerelease tag to next", () => {
+    expect(distTagFor("v0.7.0-canary.0")).toBe("next");
+    expect(distTagFor("v0.7.0-canary.1")).toBe("next");
+    expect(distTagFor("v1.0.0-rc.0")).toBe("next");
+    expect(distTagFor("v1.0.0-beta.3")).toBe("next");
+  });
+
+  it("publishes a plain release tag to latest", () => {
+    expect(distTagFor("v0.7.0")).toBe("latest");
+    expect(distTagFor("v1.0.0")).toBe("latest");
+    expect(distTagFor("v0.6.1")).toBe("latest");
+  });
+
+  it("strips the leading v before checking for a prerelease suffix", () => {
+    expect(distTagFor("0.7.0-canary.0")).toBe("next");
+    expect(distTagFor("0.7.0")).toBe("latest");
+  });
+});


### PR DESCRIPTION
## Summary

Pre-1.0 releases of `vellar-sdk` previously published straight to the npm `latest` dist-tag with no canary stage — every plain `npm install vellar-sdk` got whatever the most recent tag produced, with no window for early-adopter validation before a release became the default install for everyone.

## Changes

- **`scripts/npm-dist-tag-for.mjs`** (new): a small, unit-tested helper that decides the publish dist-tag from the pushed git tag — a semver **prerelease** suffix (`v0.7.0-canary.0`, `v1.0.0-rc.0`) routes to `next`; a plain version tag (`v0.7.0`) routes to `latest`. Pulled out of the workflow YAML into its own testable script, the same way `scripts/verify-merged.mjs` already pulls release-affecting logic out of inline shell in this repo.
- **`scripts/npm-dist-tag-for.test.mjs`** (new): vitest coverage for the above (prerelease -> next, plain -> latest, leading-`v` stripping).
- **`.github/workflows/publish.yml`**: adds a `Determine dist-tag (canary vs latest)` step that runs the script against `$GITHUB_REF_NAME` and passes the result to `npm publish --tag`. Every other gate (audit, typecheck, test, build, provenance) is completely unchanged and runs identically whether the tag is a canary or a release — a canary carries the exact same supply-chain guarantees as `latest` (security audit V-8).
- **`.github/workflows/promote-canary.yml`** (new): a manual-dispatch-only workflow that promotes an already-published version onto `latest` via `npm dist-tag add`, after first verifying that version actually exists on the registry (fails loudly on a typo rather than silently no-op'ing). It does not rebuild or republish — the artifact promoted to `latest` is byte-for-byte what was validated as the canary.
- **`docs/release-process.md`** (new): the full canary rollout process for maintainers — the two dist-tags and who gets each, step-by-step canary cutting instructions, a **consumer validation checklist** required before promoting (a real app exercising the paved-road path and x402/policies/agents where relevant, no unexplained new errors, a changelog entry, a deliberate minimum canary window), the promotion steps, and instructions for running the full publish-then-promote loop end to end once before relying on it for a real release.

## Requirements checklist

- [x] `next`/canary dist-tag publishing step added to the release workflow
- [x] Promotion process from canary to `latest` documented (`docs/release-process.md`)
- [x] Checklist step for consumer validation before promotion (same doc)
- [x] Documented instructions for testing the full canary publish and promote flow end to end (real npm publishes can't safely run unattended in CI against the real registry, so this is a maintainer-run, deliberate one-time verification step, documented in the doc's final section)

## Test plan

- `node scripts/npm-dist-tag-for.mjs --selftest` — all cases pass
- `npx vitest run scripts/npm-dist-tag-for.test.mjs` — 3 tests, all pass
- YAML validity of both workflow files confirmed with a YAML parser
- Full `npx vitest run` and `npm run typecheck` — no new failures/errors versus a clean `dev` checkout

closes #283