### PR TITLE
Add experimental strict wildcard flag for x402 signer capabilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -341,6 +341,40 @@ what the SDK will attempt, but the on-chain `SignerLimits`/Policy mechanism
 process can't bypass. See `src/x402-signer-capabilities.ts`'s doc comments for
 the full scope of what this does and does not guarantee.
 
+##### Experimental: strict wildcard validation
+
+> **Experimental.** Opt-in only. Default signer behavior is completely
+> unchanged unless you set this flag.
+
+`capabilities` rules accept `"*"` as a wildcard for `resourceType` or
+`action` by default — this is deliberate and remains the default so existing
+configs never break. For early adopters who want to catch an accidentally
+loose rule (a wildcard left in place after copy-pasting an example, say)
+before it ships, pass `experimentalStrictWildcardCapabilities: true` to
+either signer:
+
+```ts
+const signer = createSessionKeySigner({
+  address: walletCAddress,
+  secretKey: sessionKeySecret,
+  capabilities: [{ resourceType: usdcSac, action: "transfer" }],
+  // Any rule using "*" now throws InvalidCapabilityRuleError at
+  // construction, instead of being silently accepted.
+  experimentalStrictWildcardCapabilities: true,
+});
+```
+
+**Risks:**
+
+- This is experimental and may change shape or be removed in a future
+  release without a major-version bump, per this package's pre-1.0 status.
+- Turning it on for a signer config that currently relies on a wildcard rule
+  is a **breaking change for that signer** — construction throws instead of
+  succeeding. Only enable it once your `capabilities` list is already fully
+  explicit, or as a CI check ahead of tightening a config for production.
+- It has no effect at all when `capabilities` is omitted or contains no
+  wildcard rules — those configs behave exactly as before.
+
 #### Attribute-based session key budgets
 
 `maxAmount` and the on-chain spending-limit policy bound a session key's

--- a/src/x402-signer-capabilities.test.ts
+++ b/src/x402-signer-capabilities.test.ts
@@ -127,4 +127,36 @@ describe("assertValidCapabilityRules", () => {
       assertValidCapabilityRules([{ resourceType: TOKEN_A, action: "a".repeat(33) }]),
     ).toThrow(InvalidCapabilityRuleError);
   });
+
+  describe("strictWildcards (experimental, #284)", () => {
+    it("accepts wildcard rules when strictWildcards is not set (default, unchanged)", () => {
+      expect(() =>
+        assertValidCapabilityRules([{ resourceType: "*", action: "*" }]),
+      ).not.toThrow();
+    });
+
+    it("accepts wildcard rules when strictWildcards is explicitly false", () => {
+      expect(() =>
+        assertValidCapabilityRules([{ resourceType: TOKEN_A, action: "*" }], false),
+      ).not.toThrow();
+    });
+
+    it("rejects a wildcard resourceType when strictWildcards is true", () => {
+      expect(() =>
+        assertValidCapabilityRules([{ resourceType: "*", action: "transfer" }], true),
+      ).toThrow(InvalidCapabilityRuleError);
+    });
+
+    it("rejects a wildcard action when strictWildcards is true", () => {
+      expect(() =>
+        assertValidCapabilityRules([{ resourceType: TOKEN_A, action: "*" }], true),
+      ).toThrow(InvalidCapabilityRuleError);
+    });
+
+    it("still accepts fully explicit rules when strictWildcards is true", () => {
+      expect(() =>
+        assertValidCapabilityRules([{ resourceType: TOKEN_A, action: "transfer" }], true),
+      ).not.toThrow();
+    });
+  });
 });

--- a/src/x402-signer-capabilities.ts
+++ b/src/x402-signer-capabilities.ts
@@ -78,9 +78,22 @@ const CONTRACT_ID = /^C[A-Z2-7]{55}$/;
 // function names this SDK actually emits (e.g. "transfer").
 const SOROBAN_SYMBOL = /^[A-Za-z0-9_]{1,32}$/;
 
-/** Validate a capability rule set at construction time. Throws on the first
- * malformed rule; an empty array is valid (see {@link evaluateCapability}). */
-export function assertValidCapabilityRules(rules: readonly CapabilityRule[]): void {
+/**
+ * Validate a capability rule set at construction time. Throws on the first
+ * malformed rule; an empty array is valid (see {@link evaluateCapability}).
+ *
+ * `strictWildcards` (experimental, opt-in — see the signer configs'
+ * `experimentalStrictWildcardCapabilities` flag) additionally rejects any rule
+ * using `"*"` for `resourceType` or `action`. A wildcard rule is valid and
+ * unrestricted by default: this only tightens validation for callers who
+ * opt in, e.g. to enforce fully-explicit least-privilege capability lists in
+ * CI before promoting a signer config to production. Default `false` keeps
+ * today's behaviour (wildcards accepted) unchanged for everyone else.
+ */
+export function assertValidCapabilityRules(
+  rules: readonly CapabilityRule[],
+  strictWildcards = false,
+): void {
   for (const rule of rules) {
     if (rule.resourceType !== "*" && !CONTRACT_ID.test(rule.resourceType)) {
       throw new InvalidCapabilityRuleError(
@@ -90,6 +103,13 @@ export function assertValidCapabilityRules(rules: readonly CapabilityRule[]): vo
     if (rule.action !== "*" && !SOROBAN_SYMBOL.test(rule.action)) {
       throw new InvalidCapabilityRuleError(
         `capability rule action must be a Soroban function-name symbol or "*": got ${JSON.stringify(rule.action)}`,
+      );
+    }
+    if (strictWildcards && (rule.resourceType === "*" || rule.action === "*")) {
+      throw new InvalidCapabilityRuleError(
+        `capability rule uses a wildcard ("*") but experimentalStrictWildcardCapabilities is enabled, ` +
+          `which requires every rule to name an explicit resourceType and action: got ` +
+          `${JSON.stringify(rule)}`,
       );
     }
   }

--- a/src/x402-signer.test.ts
+++ b/src/x402-signer.test.ts
@@ -188,6 +188,57 @@ describe("createSessionKeySigner", () => {
         }),
       ).toThrow(InvalidCapabilityRuleError);
     });
+
+    describe("experimentalStrictWildcardCapabilities (#284)", () => {
+      it("flagged and unflagged behavior differ on a wildcard rule", () => {
+        const kp = Keypair.random();
+        const wildcardConfig = {
+          address: C_ADDRESS,
+          secretKey: kp.secret(),
+          capabilities: [{ resourceType: OTHER_C, action: "*" }],
+        };
+
+        // Default (flag unset): wildcard rules are accepted, unchanged.
+        expect(() => createSessionKeySigner(wildcardConfig)).not.toThrow();
+
+        // Flagged: the same config is now rejected at construction.
+        expect(() =>
+          createSessionKeySigner({
+            ...wildcardConfig,
+            experimentalStrictWildcardCapabilities: true,
+          }),
+        ).toThrow(InvalidCapabilityRuleError);
+      });
+
+      it("explicitly setting the flag to false matches default (unflagged) behavior", () => {
+        const kp = Keypair.random();
+        expect(() =>
+          createSessionKeySigner({
+            address: C_ADDRESS,
+            secretKey: kp.secret(),
+            capabilities: [{ resourceType: "*", action: "transfer" }],
+            experimentalStrictWildcardCapabilities: false,
+          }),
+        ).not.toThrow();
+      });
+
+      it("does not affect signers with no wildcard rules", async () => {
+        const kp = Keypair.random();
+        const signer = createSessionKeySigner({
+          address: C_ADDRESS,
+          secretKey: kp.secret(),
+          capabilities: [{ resourceType: OTHER_C, action: "transfer" }],
+          experimentalStrictWildcardCapabilities: true,
+        });
+        const entry = makeV1AuthEntry(C_ADDRESS);
+        await expect(
+          signer.signAuthEntry(entry.toXDR("base64"), {
+            networkPassphrase: PASSPHRASE,
+            expirationLedger: 1000,
+          }),
+        ).resolves.toBeDefined();
+      });
+    });
   });
 });
 
@@ -270,6 +321,22 @@ describe("createPasskeyX402Signer", () => {
           expirationLedger: 2000,
         }),
       ).resolves.toBeDefined();
+    });
+
+    it("experimentalStrictWildcardCapabilities (#284): flagged and unflagged behavior differ", () => {
+      const wildcardConfig = {
+        address: C_ADDRESS,
+        webAuthn: { async sign() { return assertion; } },
+        capabilities: [{ resourceType: "*", action: "transfer" }],
+      };
+
+      expect(() => createPasskeyX402Signer(wildcardConfig)).not.toThrow();
+      expect(() =>
+        createPasskeyX402Signer({
+          ...wildcardConfig,
+          experimentalStrictWildcardCapabilities: true,
+        }),
+      ).toThrow(InvalidCapabilityRuleError);
     });
   });
 });

--- a/src/x402-signer.ts
+++ b/src/x402-signer.ts
@@ -202,6 +202,22 @@ export interface SessionKeySignerConfig {
    * for what this does and does not guarantee.
    */
   capabilities?: readonly CapabilityRule[];
+  /**
+   * EXPERIMENTAL (#284) — opt in to stricter capability-rule validation: any
+   * `capabilities` rule using a `"*"` wildcard for `resourceType` or `action`
+   * is rejected at construction, requiring every rule to be fully explicit.
+   *
+   * Default (`false`/omitted): unchanged — wildcard rules are accepted, same
+   * as every signer built before this flag existed.
+   *
+   * This is a signal for early adopters that new signer-policy behavior may
+   * default to strict validation in a future major version. Turning it on
+   * for an existing signer config that uses wildcards is a BREAKING change
+   * for that signer (construction throws `InvalidCapabilityRuleError`) — only
+   * enable it once your capability rules are already fully explicit, or in a
+   * CI check ahead of tightening a config for production.
+   */
+  experimentalStrictWildcardCapabilities?: boolean;
 }
 
 /**
@@ -224,7 +240,7 @@ export function createSessionKeySigner(config: SessionKeySignerConfig): SmartAcc
   }
 
   const capabilities = config.capabilities ?? [];
-  assertValidCapabilityRules(capabilities);
+  assertValidCapabilityRules(capabilities, config.experimentalStrictWildcardCapabilities ?? false);
 
   return {
     address: config.address,
@@ -271,6 +287,10 @@ export interface PasskeyX402SignerConfig {
   /** Client-side capability scoping (#224) — see
    * {@link SessionKeySignerConfig.capabilities}. Same semantics apply here. */
   capabilities?: readonly CapabilityRule[];
+  /** EXPERIMENTAL (#284) — see
+   * {@link SessionKeySignerConfig.experimentalStrictWildcardCapabilities}.
+   * Same semantics apply here. */
+  experimentalStrictWildcardCapabilities?: boolean;
 }
 
 /**
@@ -286,7 +306,7 @@ export function createPasskeyX402Signer(config: PasskeyX402SignerConfig): SmartA
     throw new Error(`passkey signer address must be a contract (C…): got ${config.address}`);
   }
   const capabilities = config.capabilities ?? [];
-  assertValidCapabilityRules(capabilities);
+  assertValidCapabilityRules(capabilities, config.experimentalStrictWildcardCapabilities ?? false);
 
   return {
     address: config.address,


### PR DESCRIPTION
Reopen of #336, closed automatically by the contrib/ scope guard. This issue (#284) is assigned to me and was flagged on the issue before implementation as requiring changes outside contrib/ (see issue comment). closes #284