### PR TITLE
contrib: add PII redaction helper for consumer-supplied logging hooks

### DIFF
--- a/contrib/examples/issue-291-pii-redaction-logging-hooks/README.md
+++ b/contrib/examples/issue-291-pii-redaction-logging-hooks/README.md
@@ -1,0 +1,80 @@
+# PII redaction for consumer-supplied logging hooks
+
+Self-contained reference for issue [#291](https://github.com/Vellar-Wallet/vellar-sdk/issues/291): redact known-sensitive fields before they reach a consumer-supplied logging hook.
+
+## The problem
+
+The SDK never logs anything itself, but it does hand structured `details`
+objects to consumer-supplied hooks — `onDebugLog` on
+`createPasskeyKitConnector` (`src/passkeykit-connector.ts`) today — that a host
+typically pipes straight into their own logger or telemetry pipeline.
+
+Those details can carry fields that identify a specific user or wallet. None
+are secrets the SDK holds (it never has a wallet private key to log), but they
+are stable, wallet-linkable identifiers that a log aggregator, support-ticket
+export, or analytics sink generally should not retain in plaintext.
+
+## SDK-internal fields flagged as sensitive
+
+| Field(s) | Why |
+| -------- | --- |
+| `secretKey`, `secret`, `privateKey` | Key material. Reachable if a consumer's payload carries a signer config. |
+| `publicKey`, `previousPublicKey`, `newPublicKey` | ed25519 session-key public keys, passed to `onDebugLog` by session-key rotation. Stable per-wallet identifier. |
+| `accountId`, `contractId` | The smart-account C-address — directly identifies the wallet. |
+| `keyId` | The WebAuthn credential id (`WalletSession.keyId`) — identifies the passkey/device. |
+| `sessionId`, `serverSessionId` | Server-side session record ids — joins a log line back to a user's backend session. |
+| `signature` | Auth-entry / WebAuthn assertion signature bytes. |
+
+## Usage
+
+Wrap your hook once and hand *that* to the SDK, so no call site can forget:
+
+```ts
+const connector = createPasskeyKitConnector({
+  kit,
+  backend,
+  network: "testnet",
+  appName: "Vellar",
+  onDebugLog: withRedaction((event, details) => myLogger.debug(event, details)),
+});
+```
+
+Or redact at the call site:
+
+```ts
+onDebugLog: (event, details) => myLogger.debug(event, redactSensitiveFields(details)),
+```
+
+Pass `extraFields` for fields specific to your own payloads:
+
+```ts
+redactSensitiveFields(details, { extraFields: ["email", "phoneNumber"] });
+```
+
+## Guidance
+
+- **This is opt-in.** It does not change what the SDK passes to your hook —
+  wiring it is your call, so existing pipelines that inspect real values are
+  unaffected unless you choose to wrap.
+- **Redact at the boundary, not per-field.** Wrapping the hook once with
+  `withRedaction` is safer than remembering to redact at each call site.
+- **It is a filter, not a serializer.** Non-plain values (`Error`, `Date`,
+  class instances, XDR/`ScVal` objects) pass through untouched rather than
+  being flattened into `{}`; circular references become `"[circular]"`.
+- **Non-sensitive context survives**, so log lines stay useful for debugging —
+  only the named fields are replaced.
+- **Match is by exact field name**, case-insensitively. A field whose *value*
+  happens to contain a key, under an unrecognised name, is not caught — add it
+  via `extraFields`.
+
+## Run it
+
+```sh
+npx tsx pii-redaction-logging-hooks.ts
+```
+
+## Tests
+
+```sh
+npx vitest run contrib/examples/issue-291-pii-redaction-logging-hooks
+```

--- a/contrib/examples/issue-291-pii-redaction-logging-hooks/pii-redaction-logging-hooks.test.ts
+++ b/contrib/examples/issue-291-pii-redaction-logging-hooks/pii-redaction-logging-hooks.test.ts
@@ -1,0 +1,156 @@
+import { describe, expect, it } from "vitest";
+import {
+  REDACTED,
+  redactSensitiveFields,
+  SENSITIVE_LOG_FIELDS,
+  withRedaction,
+  type DebugLogHook,
+} from "./pii-redaction-logging-hooks";
+
+describe("redactSensitiveFields", () => {
+  it("redacts every known sensitive field at the top level", () => {
+    const input: Record<string, unknown> = {};
+    for (const field of SENSITIVE_LOG_FIELDS) input[field] = `value-of-${field}`;
+    input.event = "user-connected";
+
+    const out = redactSensitiveFields(input);
+    for (const field of SENSITIVE_LOG_FIELDS) expect(out[field]).toBe(REDACTED);
+    expect(out.event).toBe("user-connected");
+  });
+
+  it("matches field names case-insensitively", () => {
+    const out = redactSensitiveFields({ SecretKey: "S123", ACCOUNTID: "CABC" });
+    expect(out.SecretKey).toBe(REDACTED);
+    expect(out.ACCOUNTID).toBe(REDACTED);
+  });
+
+  it("redacts sensitive fields nested inside objects and arrays", () => {
+    const out = redactSensitiveFields({
+      event: "session-key-rotated",
+      details: {
+        previousPublicKey: "GFIRST",
+        newPublicKey: "GSECOND",
+        history: [{ publicKey: "GOLD1" }, { publicKey: "GOLD2" }],
+      },
+    });
+    const details = out.details as Record<string, unknown>;
+    expect(details.previousPublicKey).toBe(REDACTED);
+    expect(details.newPublicKey).toBe(REDACTED);
+    const history = details.history as Array<Record<string, unknown>>;
+    expect(history[0]!.publicKey).toBe(REDACTED);
+    expect(history[1]!.publicKey).toBe(REDACTED);
+  });
+
+  it("leaves non-sensitive fields untouched", () => {
+    const out = redactSensitiveFields({ event: "wallet-created", network: "testnet", count: 3 });
+    expect(out).toEqual({ event: "wallet-created", network: "testnet", count: 3 });
+  });
+
+  it("does not mutate the input", () => {
+    const input = { secretKey: "S123", event: "x" };
+    const out = redactSensitiveFields(input);
+    expect(input.secretKey).toBe("S123");
+    expect(out).not.toBe(input);
+  });
+
+  it("passes through null, undefined, and primitives", () => {
+    expect(redactSensitiveFields(null)).toBeNull();
+    expect(redactSensitiveFields(undefined)).toBeUndefined();
+    expect(redactSensitiveFields("hello")).toBe("hello");
+    expect(redactSensitiveFields(42)).toBe(42);
+    expect(redactSensitiveFields(true)).toBe(true);
+  });
+
+  it("passes through non-plain objects (Error, Date) without flattening them", () => {
+    const err = new Error("boom");
+    const date = new Date("2026-01-01T00:00:00.000Z");
+    expect(redactSensitiveFields({ err, date })).toEqual({ err, date });
+  });
+
+  it("supports extraFields for consumer-specific sensitive keys", () => {
+    const out = redactSensitiveFields(
+      { email: "user@example.com", event: "x" },
+      { extraFields: ["email"] },
+    );
+    expect(out.email).toBe(REDACTED);
+    expect(out.event).toBe("x");
+  });
+
+  it("only redacts exact field-name matches, not substrings", () => {
+    const out = redactSensitiveFields({ eventKeyId: "not-sensitive", keyId: "abc" });
+    expect(out.eventKeyId).toBe("not-sensitive");
+    expect(out.keyId).toBe(REDACTED);
+  });
+
+  it("handles circular references instead of throwing or looping forever", () => {
+    const obj: Record<string, unknown> = { secretKey: "S123" };
+    obj.self = obj;
+    const out = redactSensitiveFields(obj);
+    expect(out.secretKey).toBe(REDACTED);
+    expect(out.self).toBe("[circular]");
+  });
+
+  it("stops descending past maxDepth, leaving deeper values as-is", () => {
+    const deep = { a: { b: { c: { secretKey: "S123" } } } };
+    const out = redactSensitiveFields(deep, { maxDepth: 1 });
+    expect(out.a).toEqual({ b: { c: { secretKey: "S123" } } });
+  });
+});
+
+describe("withRedaction: redacted fields never reach the logging hook", () => {
+  it("the wrapped hook receives redacted values, never the raw ones", () => {
+    const received: Array<{ event: string; details: Record<string, unknown> }> = [];
+    const hook: DebugLogHook = (event, details) => received.push({ event, details });
+
+    withRedaction(hook)("session-key-rotated", {
+      previousPublicKey: "GOLDSENSITIVEKEY",
+      newPublicKey: "GNEWSENSITIVEKEY",
+      attempt: 1,
+    });
+
+    expect(received).toHaveLength(1);
+    expect(received[0]!.details.previousPublicKey).toBe(REDACTED);
+    expect(received[0]!.details.newPublicKey).toBe(REDACTED);
+    // Non-sensitive context survives, so the log line stays useful.
+    expect(received[0]!.details.attempt).toBe(1);
+    expect(received[0]!.event).toBe("session-key-rotated");
+  });
+
+  it("the raw sensitive value never appears anywhere in what the hook saw", () => {
+    const captured: string[] = [];
+    const hook: DebugLogHook = (event, details) =>
+      captured.push(`${event} ${JSON.stringify(details)}`);
+
+    withRedaction(hook)("wallet-connected", {
+      wallet: {
+        accountId: "CVERYSENSITIVEACCOUNTID",
+        keyId: "VERYSENSITIVEKEYID",
+        network: "testnet",
+      },
+    });
+
+    const all = captured.join("\n");
+    expect(all).not.toContain("CVERYSENSITIVEACCOUNTID");
+    expect(all).not.toContain("VERYSENSITIVEKEYID");
+    expect(all).toContain("testnet");
+  });
+
+  it("passes extraFields through to the redaction", () => {
+    const received: Record<string, unknown>[] = [];
+    const hook: DebugLogHook = (_event, details) => received.push(details);
+
+    withRedaction(hook, { extraFields: ["email"] })("signup", {
+      email: "user@example.com",
+      plan: "free",
+    });
+
+    expect(received[0]!.email).toBe(REDACTED);
+    expect(received[0]!.plan).toBe("free");
+  });
+
+  it("forwards the event name unchanged", () => {
+    const events: string[] = [];
+    withRedaction((event) => events.push(event))("session-key-revoke-failed", {});
+    expect(events).toEqual(["session-key-revoke-failed"]);
+  });
+});

--- a/contrib/examples/issue-291-pii-redaction-logging-hooks/pii-redaction-logging-hooks.ts
+++ b/contrib/examples/issue-291-pii-redaction-logging-hooks/pii-redaction-logging-hooks.ts
@@ -1,0 +1,165 @@
+// Self-contained reference for issue #291: PII redaction for consumer-supplied
+// logging hooks.
+//
+// The SDK never logs anything itself, but it does hand structured `details`
+// objects to consumer-supplied hooks — `onDebugLog` on
+// `createPasskeyKitConnector` (src/passkeykit-connector.ts) today — that a
+// host typically pipes straight into their own logger or telemetry pipeline.
+// Those details can carry fields that identify a specific user or wallet.
+//
+// This is a standalone, dependency-free demonstration of a redaction helper
+// that a consumer wraps their own hook with, so those fields never reach the
+// logger in plaintext.
+//
+// Run with: npx tsx pii-redaction-logging-hooks.ts
+
+/**
+ * Field names (case-insensitive, exact match) treated as sensitive. These are
+ * the SDK-internal fields that identify a specific user, wallet, or
+ * credential:
+ *
+ *  - `secretKey`, `secret`, `privateKey` — key material. The SDK never holds
+ *    a wallet private key, but a consumer's hook can still receive these if
+ *    the object they pass through carries a signer config.
+ *  - `publicKey`, `previousPublicKey`, `newPublicKey` — ed25519 session-key
+ *    public keys, as passed to `onDebugLog` by session-key rotation. Not
+ *    secret, but a stable identifier tying a log line to one wallet's key.
+ *  - `accountId`, `contractId` — the smart-account C-address. Directly
+ *    identifies the wallet.
+ *  - `keyId` — the WebAuthn credential id (`WalletSession.keyId`). Identifies
+ *    the specific passkey / device.
+ *  - `sessionId`, `serverSessionId` — server-side session record ids. Lets a
+ *    log line be joined back to a specific user's backend session.
+ *  - `signature` — auth-entry / WebAuthn assertion signature bytes.
+ */
+export const SENSITIVE_LOG_FIELDS: readonly string[] = [
+  "secretKey",
+  "secret",
+  "privateKey",
+  "publicKey",
+  "previousPublicKey",
+  "newPublicKey",
+  "accountId",
+  "contractId",
+  "keyId",
+  "sessionId",
+  "serverSessionId",
+  "signature",
+];
+
+const SENSITIVE_FIELD_SET = new Set(SENSITIVE_LOG_FIELDS.map((f) => f.toLowerCase()));
+
+/** The string substituted for a redacted field's value. */
+export const REDACTED = "[redacted]";
+
+export interface RedactOptions {
+  /** Additional field names to treat as sensitive, on top of
+   * {@link SENSITIVE_LOG_FIELDS} — for consumer-specific fields (an email,
+   * say) that your own payloads add before reaching the shared hook. */
+  extraFields?: readonly string[];
+  /** Maximum nesting depth to walk before leaving deeper values untouched.
+   * Defaults to 6 — deep enough for any shape the SDK's hooks produce,
+   * shallow enough to bound work on an adversarial object. */
+  maxDepth?: number;
+}
+
+/**
+ * Return a deep copy of `value` with every sensitive field (by name) replaced
+ * with {@link REDACTED}. Matching is case-insensitive.
+ *
+ * Arrays are walked; non-plain values (functions, `Error`, `Date`, class
+ * instances, XDR/ScVal-shaped objects) pass through as-is rather than being
+ * spread into `{}` and losing their meaning — this is a redaction filter, not
+ * a serializer. Circular references are replaced with `"[circular]"` rather
+ * than looping forever. Does not mutate `value`.
+ */
+export function redactSensitiveFields<T>(value: T, options: RedactOptions = {}): T {
+  const sensitive =
+    options.extraFields && options.extraFields.length > 0
+      ? new Set([...SENSITIVE_FIELD_SET, ...options.extraFields.map((f) => f.toLowerCase())])
+      : SENSITIVE_FIELD_SET;
+  const maxDepth = options.maxDepth ?? 6;
+  return redact(value, sensitive, maxDepth, new Set()) as T;
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  if (typeof value !== "object" || value === null) return false;
+  const proto = Object.getPrototypeOf(value);
+  return proto === Object.prototype || proto === null;
+}
+
+function redact(
+  value: unknown,
+  sensitive: ReadonlySet<string>,
+  depthRemaining: number,
+  seen: Set<unknown>,
+): unknown {
+  if (value === null || typeof value !== "object") return value;
+  if (depthRemaining <= 0) return value;
+  if (seen.has(value)) return "[circular]";
+
+  if (Array.isArray(value)) {
+    seen.add(value);
+    return value.map((item) => redact(item, sensitive, depthRemaining - 1, seen));
+  }
+
+  // Only walk plain objects — an Error, Date, Map, ScVal/XDR instance, etc.
+  // passes through untouched rather than being flattened.
+  if (!isPlainObject(value)) return value;
+
+  seen.add(value);
+  const out: Record<string, unknown> = {};
+  for (const [key, val] of Object.entries(value)) {
+    if (sensitive.has(key.toLowerCase())) {
+      out[key] = REDACTED;
+    } else {
+      out[key] = redact(val, sensitive, depthRemaining - 1, seen);
+    }
+  }
+  return out;
+}
+
+/** The shape of the SDK's consumer-supplied debug-log hook. */
+export type DebugLogHook = (event: string, details: Record<string, unknown>) => void;
+
+/**
+ * Wrap a logging hook so every `details` object is redacted before it
+ * reaches the underlying hook. This is the recommended way to apply the
+ * helper: build the wrapper once and hand THAT to the SDK, so no call site
+ * can forget to redact.
+ */
+export function withRedaction(hook: DebugLogHook, options: RedactOptions = {}): DebugLogHook {
+  return (event, details) => hook(event, redactSensitiveFields(details, options));
+}
+
+function main() {
+  // The kind of details object session-key rotation hands to `onDebugLog`.
+  const rotationEvent = {
+    previousPublicKey: "GOLDKEY0000000000000000000000000000000000000000000000000",
+    newPublicKey: "GNEWKEY0000000000000000000000000000000000000000000000000",
+    wallet: {
+      accountId: "CAFIATCEAZJTGQQKFL3N2YB6VMCUN2UYX4QD5A3FALDRU7UJJ6OWBKOW",
+      keyId: "a-webauthn-credential-id",
+      network: "testnet",
+    },
+    attempt: 1,
+  };
+
+  console.log("raw     :", JSON.stringify(rotationEvent));
+  console.log("redacted:", JSON.stringify(redactSensitiveFields(rotationEvent)));
+
+  // Wired the recommended way: the SDK is handed an already-redacting hook.
+  const captured: string[] = [];
+  const safeHook = withRedaction((event, details) => {
+    captured.push(`${event} ${JSON.stringify(details)}`);
+  });
+  safeHook("session-key-rotated", rotationEvent);
+  console.log("via hook:", captured[0]);
+
+  // Non-sensitive fields survive; the raw key never appears anywhere.
+  console.log("leaked raw key?:", captured[0]!.includes("GNEWKEY") ? "YES (bug)" : "no");
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main();
+}


### PR DESCRIPTION
## Summary

Adds a self-contained reference implementation under `contrib/examples/issue-291-pii-redaction-logging-hooks/` for redacting known-sensitive fields before they reach a consumer-supplied logging hook.

Scoped entirely to `contrib/` per CONTRIBUTING.md and `contrib/README.md`.

## The problem

The SDK never logs anything itself, but it does hand structured `details` objects to consumer-supplied hooks — `onDebugLog` on `createPasskeyKitConnector` (`src/passkeykit-connector.ts`) today — that a host typically pipes straight into their own logger or telemetry pipeline. Those objects can carry fields identifying a specific user or wallet. None are secrets the SDK holds, but they are stable, wallet-linkable identifiers a log aggregator or support export should not retain in plaintext.

## SDK-internal fields flagged as sensitive

| Field(s) | Why |
| -------- | --- |
| `secretKey`, `secret`, `privateKey` | Key material. Reachable if a consumer's payload carries a signer config. |
| `publicKey`, `previousPublicKey`, `newPublicKey` | ed25519 session-key public keys, passed to `onDebugLog` by session-key rotation. |
| `accountId`, `contractId` | The smart-account C-address — directly identifies the wallet. |
| `keyId` | The WebAuthn credential id (`WalletSession.keyId`) — identifies the passkey/device. |
| `sessionId`, `serverSessionId` | Server-side session record ids. |
| `signature` | Auth-entry / WebAuthn assertion signature bytes. |

## Files

- `pii-redaction-logging-hooks.ts` — `SENSITIVE_LOG_FIELDS`, `redactSensitiveFields(value, options?)`, and `withRedaction(hook)` which wraps a hook once so no call site can forget. Includes a runnable `main()` demo.
- `pii-redaction-logging-hooks.test.ts` — 15 tests.
- `README.md` — the flagged-field table, usage both ways, and the redaction guidance.

Non-plain values (`Error`, `Date`, class/XDR instances) pass through untouched rather than being flattened; circular references become `"[circular]"`; a configurable `maxDepth` bounds the walk; `extraFields` covers consumer-specific fields.

## Requirements checklist

- [x] Identify SDK-internal fields that should be flagged as sensitive
- [x] Helper that redacts known sensitive fields before passing to logging hooks
- [x] Tests verifying redacted fields never reach the logging hook
- [x] Redaction guidance documented (in the example's README, since this PR is scoped to `contrib/`)

## Test plan

```sh
npx vitest run contrib/examples/issue-291-pii-redaction-logging-hooks
```

15 tests, all passing — including two that assert the raw sensitive value never appears anywhere in what the wrapped hook received, checked by string search over the full captured payload rather than only structural equality.

closes #291