### PR TITLE
contrib: add canary npm dist-tag rollout for pre-1.0 releases

### DIFF
--- a/contrib/examples/issue-283-canary-dist-tag-rollout/README.md
+++ b/contrib/examples/issue-283-canary-dist-tag-rollout/README.md
@@ -1,0 +1,56 @@
+# Canary npm dist-tag rollout
+
+Self-contained reference for issue [#283](https://github.com/Vellar-Wallet/vellar-sdk/issues/283): a canary dist-tag stage for pre-1.0 releases, so an early-adopter consumer can validate a release before it becomes the default install for everyone.
+
+**The full process is in [ROLLOUT.md](ROLLOUT.md)** — workflow wiring, the promotion steps, and the consumer-validation checklist.
+
+## The problem
+
+`.github/workflows/publish.yml` runs `npm publish --provenance --access public`
+with no `--tag`, so every tag pushed publishes straight to `latest` — the
+dist-tag every plain `npm install vellar-sdk` resolves to. There is no canary
+stage in between.
+
+## The rule
+
+A semver **prerelease** tag (`v0.7.0-canary.0`, `v1.0.0-rc.0`) publishes to
+`next`. A plain release tag (`v0.7.0`) publishes to `latest`.
+
+| dist-tag | Who gets it |
+| -------- | ----------- |
+| `next` | Nobody by default — only `npm install vellar-sdk@next` |
+| `latest` | Everyone running plain `npm install vellar-sdk` |
+
+Promotion moves `latest` onto an already-published version via
+`npm dist-tag add` — it does not rebuild or republish, so what lands on
+`latest` is byte-for-byte the artifact that was validated.
+
+## What's here
+
+| File | What it is |
+| ---- | ---------- |
+| [`ROLLOUT.md`](ROLLOUT.md) | The process: workflow changes, cutting a canary, the consumer-validation checklist, promoting, and end-to-end verification. |
+| `canary-dist-tag-rollout.ts` | The pure decision logic (`distTagFor`) plus a registry model (`publish`, `promoteToLatest`) that makes the flow testable. |
+| `canary-dist-tag-rollout.test.ts` | 15 tests, including one exercising the full publish → validate → promote loop end to end. |
+
+Keeping `distTagFor` in its own module rather than inline in a YAML `run:`
+block is deliberate — it's exactly the kind of one-line regex that's easy to
+get subtly wrong with shell quoting and impossible to unit-test in place. The
+repo already does this for release-affecting logic in `scripts/verify-merged.mjs`.
+
+## The key property
+
+Publishing a canary must **not** move `latest`. That's what the whole stage
+exists to guarantee, and it's pinned by the end-to-end test.
+
+## Run it
+
+```sh
+npx tsx canary-dist-tag-rollout.ts
+```
+
+## Tests
+
+```sh
+npx vitest run contrib/examples/issue-283-canary-dist-tag-rollout
+```

--- a/contrib/examples/issue-283-canary-dist-tag-rollout/ROLLOUT.md
+++ b/contrib/examples/issue-283-canary-dist-tag-rollout/ROLLOUT.md
@@ -1,0 +1,167 @@
+# Canary npm dist-tag rollout for pre-1.0 releases
+
+The proposed release process for issue
+[#283](https://github.com/Vellar-Wallet/vellar-sdk/issues/283), including the
+workflow changes it needs and the consumer-validation checklist that gates a
+promotion.
+
+## Why a canary stage
+
+`.github/workflows/publish.yml` currently runs:
+
+```sh
+npm publish --provenance --access public
+```
+
+with no `--tag`, so every tag pushed publishes straight to the `latest`
+dist-tag — the one every plain `npm install vellar-sdk` resolves to. There is
+no stage in which an early-adopter consumer can try a release before it
+becomes the default for everyone.
+
+Pre-1.0 the API can still shift in ways a typecheck and the existing suite
+don't fully exercise against a real consumer app (a passkey ceremony, a live
+facilitator, a real backend gateway). A canary stage buys a validation window
+before a release is default-installed.
+
+## The two dist-tags
+
+| dist-tag | Who gets it | Published by |
+| -------- | ----------- | ------------ |
+| `next` | Nobody by default — only `npm install vellar-sdk@next`, or a consumer pinned to it | A tag with a semver **prerelease** suffix, e.g. `v0.7.0-canary.0` |
+| `latest` | Everyone running plain `npm install vellar-sdk` | A plain version tag, e.g. `v0.7.0` — or promoting an already-published canary |
+
+The decision is `distTagFor()` in `canary-dist-tag-rollout.ts`: any `-`
+(semver prerelease marker) routes to `next`, anything else to `latest`.
+
+## Workflow change
+
+Add a step to `publish.yml` before the publish, and pass its result to
+`npm publish --tag`:
+
+```yaml
+      - name: Determine dist-tag (canary vs latest)
+        id: dist_tag
+        run: |
+          DIST_TAG="$(node scripts/npm-dist-tag-for.mjs "$GITHUB_REF_NAME")"
+          echo "dist-tag: $DIST_TAG"
+          echo "tag=$DIST_TAG" >> "$GITHUB_OUTPUT"
+
+      - run: npm publish --provenance --access public --tag "${{ steps.dist_tag.outputs.tag }}"
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+```
+
+Every other gate — `npm audit`, `typecheck`, `test`, `build`, provenance —
+stays exactly as it is and runs identically for a canary or a release, so a
+canary carries the same supply-chain guarantees as `latest` (security audit
+V-8). The existing "Verify tag matches package version" step is unchanged and
+still applies.
+
+Promotion is a **separate, manual-dispatch-only** workflow, because promoting
+is a maintainer decision made after real consumer validation, never an
+automatic follow-on to publishing:
+
+```yaml
+name: Promote canary to latest
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version already published to npm (e.g. 0.7.0-canary.0)"
+        required: true
+        type: string
+
+jobs:
+  promote:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          registry-url: https://registry.npmjs.org
+      - name: Verify the version exists on the registry
+        run: |
+          if ! npm view "vellar-sdk@${{ inputs.version }}" version >/dev/null 2>&1; then
+            echo "vellar-sdk@${{ inputs.version }} is not published — nothing to promote"
+            exit 1
+          fi
+      - name: Promote to latest
+        run: npm dist-tag add "vellar-sdk@${{ inputs.version }}" latest
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      - run: npm dist-tag ls vellar-sdk
+```
+
+This does not build or publish a new tarball — it moves `latest` to point at a
+version already on the registry, so what consumers get is byte-for-byte what
+was validated as the canary.
+
+## Cutting a canary
+
+1. Bump `package.json`'s `version` to a prerelease, e.g. `0.7.0-canary.0`
+   (`npm version 0.7.0-canary.0 --no-git-tag-version`), and commit.
+2. Push a matching tag: `git tag v0.7.0-canary.0 && git push origin v0.7.0-canary.0`.
+   The tag must match `package.json` exactly — the existing verify step fails
+   the job otherwise.
+3. `publish.yml` publishes it under `next`. Plain `npm install vellar-sdk` is
+   unaffected.
+4. Announce the canary and work the checklist below before promoting.
+
+## Consumer validation checklist
+
+Do not promote until every box is checked, or marked N/A with a reason
+recorded on the promotion issue/PR:
+
+- [ ] At least one **real consumer app** (not just this repo's suite) has
+      installed `vellar-sdk@next` and exercised the paved-road path:
+      `createVellarWallet`, `create()`/`connect()` against a real passkey, and
+      `pay()` against a real backend + facilitator on testnet.
+- [ ] If the release touches **x402**: at least one real x402 payment (agent
+      or passkey signer) has settled against a real facilitator on testnet.
+- [ ] If it touches **policies** or **agents**: at least one real policy
+      attach/deploy or agent key mint/revoke has run against a real backend.
+- [ ] No new consumer-facing error has been reported that isn't already a
+      known, intentional change noted in `CHANGELOG.md`.
+- [ ] `CHANGELOG.md` has an entry for this version, written as if it were
+      going to `latest` — the canary and the eventual promotion are the same
+      artifact and the same entry, not two.
+- [ ] The canary has been live on `next` for a deliberate minimum window (days,
+      not minutes), so early adopters have had a real chance to pick it up.
+      Promoting immediately defeats the point of the stage.
+
+## Promoting
+
+1. Decide what `latest` should carry:
+   - **Promote the canary version as-is** — fastest; `latest` carries a
+     `-canary.N` version string.
+   - **Re-tag as a plain release** (cut `v0.7.0` from the same commit) —
+     cleaner version history, costs one more publish run of an
+     already-validated artifact. Most releases should use this.
+2. Run the promote workflow:
+   ```sh
+   gh workflow run promote-canary.yml -f version=0.7.0-canary.0
+   ```
+3. Verify: `npm view vellar-sdk dist-tags` shows `latest` on the promoted
+   version.
+
+## Testing the flow end to end
+
+`canary-dist-tag-rollout.test.ts` exercises the whole loop as an automated
+test — publish a canary, assert `latest` did not move, reject a mistyped
+promotion, promote, assert `latest` moved and nothing new was published, then
+a plain release. That pins the behaviour without touching the real registry.
+
+Before relying on it for a real release, a maintainer should also run it once
+against npm for real:
+
+1. Cut a real canary and confirm via `npm view vellar-sdk dist-tags` that it
+   landed on `next`, not `latest`.
+2. Confirm `npm install vellar-sdk` in a scratch project still resolves to the
+   previous `latest` — i.e. publishing a canary provably did not move it.
+3. Run the promote workflow and confirm `latest` now points at it.
+4. Confirm `npm install vellar-sdk` in a fresh scratch project resolves to the
+   promoted version.
+
+Record the outcome (date, versions, who ran it) on the release PR or tracking
+issue, so there's a paper trail that the flow was actually run rather than
+only reasoned about.

--- a/contrib/examples/issue-283-canary-dist-tag-rollout/canary-dist-tag-rollout.test.ts
+++ b/contrib/examples/issue-283-canary-dist-tag-rollout/canary-dist-tag-rollout.test.ts
@@ -1,0 +1,139 @@
+import { describe, expect, it } from "vitest";
+import {
+  distTagFor,
+  promoteToLatest,
+  PromotionError,
+  publish,
+  resolveDefaultInstall,
+  type RegistryState,
+} from "./canary-dist-tag-rollout";
+
+describe("distTagFor", () => {
+  it("routes a prerelease tag to next", () => {
+    expect(distTagFor("v0.7.0-canary.0")).toBe("next");
+    expect(distTagFor("v0.7.0-canary.1")).toBe("next");
+    expect(distTagFor("v1.0.0-rc.0")).toBe("next");
+    expect(distTagFor("v1.0.0-beta.3")).toBe("next");
+  });
+
+  it("routes a plain release tag to latest", () => {
+    expect(distTagFor("v0.7.0")).toBe("latest");
+    expect(distTagFor("v1.0.0")).toBe("latest");
+    expect(distTagFor("v0.6.1")).toBe("latest");
+  });
+
+  it("treats the leading v as optional", () => {
+    expect(distTagFor("0.7.0-canary.0")).toBe("next");
+    expect(distTagFor("0.7.0")).toBe("latest");
+  });
+});
+
+describe("publish", () => {
+  const released: RegistryState = { published: ["0.6.1"], distTags: { latest: "0.6.1" } };
+
+  it("publishing a canary does NOT move latest", () => {
+    const after = publish(released, "v0.7.0-canary.0");
+    expect(after.distTags.next).toBe("0.7.0-canary.0");
+    expect(after.distTags.latest).toBe("0.6.1");
+    expect(resolveDefaultInstall(after)).toBe("0.6.1");
+  });
+
+  it("publishing a plain release moves latest", () => {
+    const after = publish(released, "v0.7.0");
+    expect(after.distTags.latest).toBe("0.7.0");
+    expect(resolveDefaultInstall(after)).toBe("0.7.0");
+  });
+
+  it("records the version as published", () => {
+    expect(publish(released, "v0.7.0-canary.0").published).toContain("0.7.0-canary.0");
+  });
+
+  it("does not mutate the input state", () => {
+    publish(released, "v0.7.0-canary.0");
+    expect(released.distTags).toEqual({ latest: "0.6.1" });
+    expect(released.published).toEqual(["0.6.1"]);
+  });
+
+  it("a second canary replaces the first on next, still leaving latest alone", () => {
+    let state = publish(released, "v0.7.0-canary.0");
+    state = publish(state, "v0.7.0-canary.1");
+    expect(state.distTags.next).toBe("0.7.0-canary.1");
+    expect(state.distTags.latest).toBe("0.6.1");
+    expect(state.published).toEqual(["0.6.1", "0.7.0-canary.0", "0.7.0-canary.1"]);
+  });
+});
+
+describe("promoteToLatest", () => {
+  const withCanary = publish(
+    { published: ["0.6.1"], distTags: { latest: "0.6.1" } },
+    "v0.7.0-canary.0",
+  );
+
+  it("moves latest onto the promoted version", () => {
+    const after = promoteToLatest(withCanary, "0.7.0-canary.0");
+    expect(after.distTags.latest).toBe("0.7.0-canary.0");
+    expect(resolveDefaultInstall(after)).toBe("0.7.0-canary.0");
+  });
+
+  it("leaves next pointing where it was (promotion is not a republish)", () => {
+    expect(promoteToLatest(withCanary, "0.7.0-canary.0").distTags.next).toBe("0.7.0-canary.0");
+  });
+
+  it("refuses a version that was never published", () => {
+    expect(() => promoteToLatest(withCanary, "0.7.0-canary.99")).toThrow(PromotionError);
+  });
+
+  it("names the published versions in the refusal, so a typo is obvious", () => {
+    try {
+      promoteToLatest(withCanary, "0.9.9");
+      expect.fail("expected a throw");
+    } catch (err) {
+      expect((err as Error).message).toContain("0.7.0-canary.0");
+      expect((err as Error).message).toContain("not published");
+    }
+  });
+
+  it("does not publish a new version — only retags an existing one", () => {
+    const after = promoteToLatest(withCanary, "0.7.0-canary.0");
+    expect(after.published).toEqual(withCanary.published);
+  });
+
+  it("does not mutate the input state", () => {
+    promoteToLatest(withCanary, "0.7.0-canary.0");
+    expect(withCanary.distTags.latest).toBe("0.6.1");
+  });
+});
+
+// The requirement: exercise the full canary publish -> validate -> promote
+// flow once, end to end.
+describe("the full canary publish and promote flow, end to end", () => {
+  it("runs the whole loop with latest only moving at the promotion step", () => {
+    // 0. A released 0.6.1 is what everyone installs.
+    let state: RegistryState = { published: ["0.6.1"], distTags: { latest: "0.6.1" } };
+    expect(resolveDefaultInstall(state)).toBe("0.6.1");
+
+    // 1. Cut a canary. It goes to `next`.
+    state = publish(state, "v0.7.0-canary.0");
+    expect(state.distTags.next).toBe("0.7.0-canary.0");
+
+    // 2. Ordinary consumers are provably unaffected — this is the property
+    //    the whole canary stage exists to guarantee.
+    expect(resolveDefaultInstall(state)).toBe("0.6.1");
+
+    // 3. A mistyped promotion fails loudly rather than silently no-op'ing.
+    expect(() => promoteToLatest(state, "0.7.0-canry.0")).toThrow(PromotionError);
+    expect(resolveDefaultInstall(state)).toBe("0.6.1");
+
+    // 4. After consumer validation, promote. Now latest moves.
+    state = promoteToLatest(state, "0.7.0-canary.0");
+    expect(resolveDefaultInstall(state)).toBe("0.7.0-canary.0");
+
+    // 5. The promoted artifact is the one that was validated — promotion
+    //    published nothing new.
+    expect(state.published).toEqual(["0.6.1", "0.7.0-canary.0"]);
+
+    // 6. A later plain release still goes straight to latest, unchanged.
+    state = publish(state, "v0.7.0");
+    expect(resolveDefaultInstall(state)).toBe("0.7.0");
+  });
+});

--- a/contrib/examples/issue-283-canary-dist-tag-rollout/canary-dist-tag-rollout.ts
+++ b/contrib/examples/issue-283-canary-dist-tag-rollout/canary-dist-tag-rollout.ts
@@ -1,0 +1,129 @@
+// Self-contained reference for issue #283: a canary npm dist-tag rollout for
+// pre-1.0 releases.
+//
+// Today .github/workflows/publish.yml runs `npm publish --provenance --access
+// public` with no `--tag`, so every tag pushed publishes straight to the
+// `latest` dist-tag — the one every plain `npm install vellar-sdk` resolves
+// to. There is no canary stage in which an early-adopter consumer can try a
+// release before it becomes the default for everyone.
+//
+// This module is the decision logic that closes that gap, kept pure and
+// dependency-free so it can be unit-tested rather than buried in a YAML
+// `run:` block where quoting bugs hide. ROLLOUT.md in this folder carries the
+// workflow wiring, the promotion process, and the consumer-validation
+// checklist.
+//
+// THE RULE: a semver PRERELEASE tag (anything with a `-` suffix, e.g.
+// v0.7.0-canary.0, v1.0.0-rc.0) publishes to the `next` dist-tag. A plain
+// release tag (v0.7.0) publishes to `latest`. This follows ordinary semver
+// prerelease convention rather than inventing a bespoke "canary" grammar —
+// any prerelease identifier works, `canary` is simply the one the process
+// names.
+//
+// Run with: npx tsx canary-dist-tag-rollout.ts
+
+export type DistTag = "next" | "latest";
+
+/**
+ * The dist-tag a publish should use, given the git tag it runs from.
+ *
+ * A leading `v` is optional. Anything carrying a semver prerelease suffix
+ * routes to `next`; everything else routes to `latest`.
+ */
+export function distTagFor(gitTag: string): DistTag {
+  const version = gitTag.replace(/^v/, "");
+  return version.includes("-") ? "next" : "latest";
+}
+
+/** A published version and the dist-tags currently pointing at it. */
+export interface RegistryState {
+  /** dist-tag -> version it points at. */
+  distTags: Record<string, string>;
+  /** Every version published to the registry. */
+  published: string[];
+}
+
+export class PromotionError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "PromotionError";
+  }
+}
+
+/**
+ * Simulate publishing `version` under the dist-tag implied by its git tag.
+ *
+ * The property that matters, and that the tests pin: publishing a canary must
+ * NOT move `latest`. That is the whole point of the stage — an ordinary
+ * `npm install vellar-sdk` is unaffected until someone deliberately promotes.
+ */
+export function publish(state: RegistryState, gitTag: string): RegistryState {
+  const version = gitTag.replace(/^v/, "");
+  const tag = distTagFor(gitTag);
+  return {
+    published: state.published.includes(version)
+      ? state.published
+      : [...state.published, version],
+    distTags: { ...state.distTags, [tag]: version },
+  };
+}
+
+/**
+ * Promote an already-published version onto `latest`.
+ *
+ * This does NOT build or publish a new tarball — it moves the `latest`
+ * dist-tag to point at a version already on the registry, so what consumers
+ * get on `latest` is byte-for-byte the artifact that was validated as a
+ * canary.
+ *
+ * Refuses a version that was never published, so a typo fails loudly rather
+ * than producing a confusing registry error or silently doing nothing.
+ */
+export function promoteToLatest(state: RegistryState, version: string): RegistryState {
+  if (!state.published.includes(version)) {
+    throw new PromotionError(
+      `vellar-sdk@${version} is not published — nothing to promote. ` +
+        `Published versions: ${state.published.join(", ") || "(none)"}`,
+    );
+  }
+  return { ...state, distTags: { ...state.distTags, latest: version } };
+}
+
+/** What `npm install vellar-sdk` (no tag) would resolve to. */
+export function resolveDefaultInstall(state: RegistryState): string | undefined {
+  return state.distTags.latest;
+}
+
+function main() {
+  // Start from a released 0.6.1 on latest.
+  let state: RegistryState = {
+    published: ["0.6.1"],
+    distTags: { latest: "0.6.1" },
+  };
+  console.log("start                     :", JSON.stringify(state.distTags));
+
+  // 1. Cut a canary. It lands on `next`; `latest` does not move.
+  state = publish(state, "v0.7.0-canary.0");
+  console.log("after canary publish      :", JSON.stringify(state.distTags));
+  console.log("  plain install still gets:", resolveDefaultInstall(state));
+
+  // 2. A typo'd promotion fails loudly instead of silently no-op'ing.
+  try {
+    promoteToLatest(state, "0.7.0-canary.99");
+  } catch (err) {
+    console.log("  bad promote rejected    :", (err as Error).name);
+  }
+
+  // 3. Promote the validated canary. Now `latest` moves.
+  state = promoteToLatest(state, "0.7.0-canary.0");
+  console.log("after promotion           :", JSON.stringify(state.distTags));
+  console.log("  plain install now gets  :", resolveDefaultInstall(state));
+
+  // 4. A plain release tag goes straight to latest, as before.
+  state = publish(state, "v0.7.0");
+  console.log("after plain release       :", JSON.stringify(state.distTags));
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main();
+}


### PR DESCRIPTION
## Summary

Adds a self-contained reference under `contrib/examples/issue-283-canary-dist-tag-rollout/` for a canary npm dist-tag stage for pre-1.0 releases, so an early-adopter consumer can validate a release before it becomes the default install for everyone.

Scoped entirely to `contrib/` per CONTRIBUTING.md and `contrib/README.md`.

## The problem

`.github/workflows/publish.yml` runs `npm publish --provenance --access public` with **no `--tag`**, so every tag pushed publishes straight to the `latest` dist-tag — the one every plain `npm install vellar-sdk` resolves to. There is no canary stage in between.

## The rule

A semver **prerelease** tag (`v0.7.0-canary.0`, `v1.0.0-rc.0`) publishes to `next`; a plain release tag (`v0.7.0`) publishes to `latest`. This follows ordinary semver prerelease convention rather than inventing a bespoke "canary" grammar.

| dist-tag | Who gets it |
| -------- | ----------- |
| `next` | Nobody by default — only `npm install vellar-sdk@next` |
| `latest` | Everyone running plain `npm install vellar-sdk` |

Promotion moves `latest` onto an already-published version via `npm dist-tag add` — it does not rebuild or republish, so what lands on `latest` is byte-for-byte the artifact that was validated as the canary.

## Files

| File | What it is |
| ---- | ---------- |
| `ROLLOUT.md` | The process: the `publish.yml` change, a separate manual-dispatch promotion workflow, cutting a canary, the consumer-validation checklist, promoting, and real-registry verification. |
| `canary-dist-tag-rollout.ts` | The pure decision logic (`distTagFor`) plus a registry model (`publish`, `promoteToLatest`) making the flow testable. Runnable `main()` demo. |
| `canary-dist-tag-rollout.test.ts` | 15 tests. |
| `README.md` | Orientation. |

Keeping `distTagFor` in its own module rather than inline in a YAML `run:` block is deliberate — it's exactly the kind of one-line regex that's easy to get subtly wrong with shell quoting and impossible to unit-test in place. The repo already does this for release-affecting logic in `scripts/verify-merged.mjs`.

Every existing gate in `publish.yml` (`npm audit`, `typecheck`, `test`, `build`, provenance, and the tag/version verify step) is untouched and runs identically for a canary or a release, so a canary carries the same supply-chain guarantees as `latest` (security audit V-8).

## Requirements checklist

- [x] A `next`/canary dist-tag publishing step for the release workflow
- [x] Promotion process from canary to `latest` documented (`ROLLOUT.md`)
- [x] Checklist step for consumer validation before promotion (`ROLLOUT.md`)
- [x] The full canary publish and promote flow tested end to end — as an automated test rather than only prose, pinning the key property that **publishing a canary does not move `latest`**. `ROLLOUT.md` additionally documents a one-time real-registry verification for a maintainer, since that can't safely run unattended in CI.

## Test plan

```sh
npx vitest run contrib/examples/issue-283-canary-dist-tag-rollout
```

15 tests, all passing — including the end-to-end case walking publish canary → assert `latest` unmoved → reject a mistyped promotion → promote → assert `latest` moved and nothing new was published → plain release.

closes #283