### PR TITLE
contrib: add readiness check helper for mcp-x402-payer

### DIFF
--- a/contrib/examples/issue-278-x402-payer-readiness-check/README.md
+++ b/contrib/examples/issue-278-x402-payer-readiness-check/README.md
@@ -1,0 +1,93 @@
+# mcp-x402-payer readiness check
+
+A standalone `checkReadiness` helper that tells a consumer whether
+`@vellar/mcp-x402-payer`'s environment is correctly configured, without
+booting the server and without ever reading or logging the payer secret
+itself.
+
+Contributed for [issue #278](https://github.com/Vellar-Wallet/vellar-sdk/issues/278).
+
+## Why
+
+`packages/mcp-x402-payer`'s `loadConfig` only validates its environment
+implicitly: it throws at startup if something is missing or malformed. That
+is fine for the server process, but a consumer who wants to check
+configuration ahead of time — a health check, a setup wizard, a CI smoke
+test — has no way to ask "is this ready?" without starting the server and
+catching whatever it throws.
+
+`checkReadiness` re-derives the same validation rules as
+[`packages/mcp-x402-payer/src/config.ts`](../../../packages/mcp-x402-payer/src/config.ts)
+as a pure, side-effect-free function, and returns a typed result instead of
+throwing.
+
+## Usage
+
+```ts
+import { checkReadiness } from "./readiness-check";
+
+const result = checkReadiness(process.env);
+
+if (!result.ready) {
+  for (const issue of result.issues) {
+    console.error(`${issue.variable}: ${issue.message}`);
+  }
+  process.exit(1);
+}
+
+console.log("mcp-x402-payer is ready to start.");
+```
+
+`checkReadiness` accepts an optional environment record (defaults to
+`process.env`), which makes it easy to test against synthetic environments
+without touching real process state.
+
+### Result shape
+
+```ts
+interface ReadinessIssue {
+  variable: string; // the environment variable this issue is about
+  message: string;  // human-readable, safe to print or log
+}
+
+interface ReadinessResult {
+  ready: boolean;
+  issues: ReadinessIssue[]; // empty when ready is true
+}
+```
+
+### What is checked
+
+- Exactly one of `VELLAR_X402_SECRET` / `VELLAR_X402_SECRET_FILE` is set, and
+  an inline secret matches the shape of a Stellar ed25519 secret seed (`S...`).
+  A file-sourced secret is **not** read or validated here — this check never
+  touches secret material, matching the package's own non-negotiable rule.
+- `VELLAR_X402_NETWORK`, if set, is `testnet` or `mainnet`.
+- `VELLAR_X402_ASSETS` is present and every `<assetContractId>:<ceiling>`
+  entry is well-formed, has a valid Soroban contract id, a positive integer
+  ceiling, and no duplicate assets.
+- `VELLAR_X402_WALLET`, if set, is a valid Soroban contract id.
+- `VELLAR_X402_POLICIES`, if set, only names valid contract ids and is only
+  set alongside `VELLAR_X402_WALLET`.
+- `VELLAR_X402_MAX_RESPONSE_BYTES`, if set, is a positive integer.
+
+## Run it
+
+```sh
+npx tsx readiness-check.ts
+```
+
+Prints a not-ready result for an empty environment, then a ready result for
+a fully configured one.
+
+## Tests
+
+```sh
+npx vitest run contrib/examples/issue-278-x402-payer-readiness-check
+```
+
+Covers both a fully ready configuration and each individual not-ready case
+(missing secret, both secret forms set, malformed asset entries, a zero
+ceiling, duplicate assets, an invalid wallet or policy id, policies without a
+wallet, and an invalid `VELLAR_X402_MAX_RESPONSE_BYTES`), plus a check that no
+issue message ever echoes a secret value.

--- a/contrib/examples/issue-278-x402-payer-readiness-check/readiness-check.test.ts
+++ b/contrib/examples/issue-278-x402-payer-readiness-check/readiness-check.test.ts
@@ -1,0 +1,159 @@
+import { describe, expect, it } from "vitest";
+import { checkReadiness } from "./readiness-check";
+
+const VALID_SECRET = "SBPTZAOFHOKY7ZZE7HGXXVGWCVTAMLLI4KYY2EI7DGZY6L4KTAWWZ2XY";
+const VALID_ASSET = "CBIN4HTPJM2QLJ32DTRO6OCLIMM7TR7D74JDIPVQYLNYGL7SBWOXH5ND";
+const VALID_WALLET = "CATOMTOMTOMTOMTOMTOMTOMTOMTOMTOMTOMTOMTOMTOMTOMTOMTOMTOM";
+const VALID_POLICY = "CPOLICYPOLICYPOLICYPOLICYPOLICYPOLICYPOLICYPOLICYPOLICYX";
+
+describe("checkReadiness", () => {
+  it("reports ready with no issues for a fully valid configuration", () => {
+    const result = checkReadiness({
+      VELLAR_X402_SECRET: VALID_SECRET,
+      VELLAR_X402_ASSETS: `${VALID_ASSET}:5000000`,
+      VELLAR_X402_NETWORK: "testnet",
+    });
+    expect(result).toEqual({ ready: true, issues: [] });
+  });
+
+  it("is ready when the secret is sourced from a file", () => {
+    const result = checkReadiness({
+      VELLAR_X402_SECRET_FILE: "/run/secrets/x402-payer-key",
+      VELLAR_X402_ASSETS: `${VALID_ASSET}:5000000`,
+    });
+    expect(result.ready).toBe(true);
+  });
+
+  it("is not ready on a completely empty environment", () => {
+    const result = checkReadiness({});
+    expect(result.ready).toBe(false);
+    expect(result.issues.map((i) => i.variable)).toEqual(
+      expect.arrayContaining(["VELLAR_X402_SECRET", "VELLAR_X402_ASSETS"]),
+    );
+  });
+
+  it("flags setting both secret and secret file", () => {
+    const result = checkReadiness({
+      VELLAR_X402_SECRET: VALID_SECRET,
+      VELLAR_X402_SECRET_FILE: "/run/secrets/x402-payer-key",
+      VELLAR_X402_ASSETS: `${VALID_ASSET}:5000000`,
+    });
+    expect(result.ready).toBe(false);
+    expect(result.issues).toContainEqual(
+      expect.objectContaining({ variable: "VELLAR_X402_SECRET / VELLAR_X402_SECRET_FILE" }),
+    );
+  });
+
+  it("flags a malformed secret", () => {
+    const result = checkReadiness({
+      VELLAR_X402_SECRET: "not-a-real-secret",
+      VELLAR_X402_ASSETS: `${VALID_ASSET}:5000000`,
+    });
+    expect(result.ready).toBe(false);
+    expect(result.issues).toContainEqual(expect.objectContaining({ variable: "VELLAR_X402_SECRET" }));
+  });
+
+  it("never echoes the secret value in any issue message", () => {
+    const secretLike = "SSHOULDNEVERAPPEARINOUTPUTSSHOULDNEVERAPPEARINOUTPUT123";
+    const result = checkReadiness({
+      VELLAR_X402_SECRET: secretLike,
+      VELLAR_X402_ASSETS: "not-valid",
+    });
+    const serialized = JSON.stringify(result);
+    expect(serialized.includes(secretLike)).toBe(false);
+  });
+
+  it("flags an invalid network value", () => {
+    const result = checkReadiness({
+      VELLAR_X402_SECRET: VALID_SECRET,
+      VELLAR_X402_ASSETS: `${VALID_ASSET}:5000000`,
+      VELLAR_X402_NETWORK: "devnet",
+    });
+    expect(result.ready).toBe(false);
+    expect(result.issues).toContainEqual(expect.objectContaining({ variable: "VELLAR_X402_NETWORK" }));
+  });
+
+  it("flags a missing VELLAR_X402_ASSETS", () => {
+    const result = checkReadiness({ VELLAR_X402_SECRET: VALID_SECRET });
+    expect(result.ready).toBe(false);
+    expect(result.issues).toContainEqual(expect.objectContaining({ variable: "VELLAR_X402_ASSETS" }));
+  });
+
+  it("flags a malformed VELLAR_X402_ASSETS entry", () => {
+    const result = checkReadiness({
+      VELLAR_X402_SECRET: VALID_SECRET,
+      VELLAR_X402_ASSETS: "not-an-entry",
+    });
+    expect(result.ready).toBe(false);
+    expect(result.issues).toContainEqual(expect.objectContaining({ variable: "VELLAR_X402_ASSETS" }));
+  });
+
+  it("flags a zero ceiling", () => {
+    const result = checkReadiness({
+      VELLAR_X402_SECRET: VALID_SECRET,
+      VELLAR_X402_ASSETS: `${VALID_ASSET}:0`,
+    });
+    expect(result.ready).toBe(false);
+    expect(result.issues).toContainEqual(expect.objectContaining({ variable: "VELLAR_X402_ASSETS" }));
+  });
+
+  it("flags a duplicated asset", () => {
+    const result = checkReadiness({
+      VELLAR_X402_SECRET: VALID_SECRET,
+      VELLAR_X402_ASSETS: `${VALID_ASSET}:1000,${VALID_ASSET}:2000`,
+    });
+    expect(result.ready).toBe(false);
+    expect(result.issues).toContainEqual(expect.objectContaining({ variable: "VELLAR_X402_ASSETS" }));
+  });
+
+  it("flags an invalid wallet address", () => {
+    const result = checkReadiness({
+      VELLAR_X402_SECRET: VALID_SECRET,
+      VELLAR_X402_ASSETS: `${VALID_ASSET}:5000000`,
+      VELLAR_X402_WALLET: "not-a-contract-id",
+    });
+    expect(result.ready).toBe(false);
+    expect(result.issues).toContainEqual(expect.objectContaining({ variable: "VELLAR_X402_WALLET" }));
+  });
+
+  it("is ready with a valid wallet and matching policies", () => {
+    const result = checkReadiness({
+      VELLAR_X402_SECRET: VALID_SECRET,
+      VELLAR_X402_ASSETS: `${VALID_ASSET}:5000000`,
+      VELLAR_X402_WALLET: VALID_WALLET,
+      VELLAR_X402_POLICIES: VALID_POLICY,
+    });
+    expect(result).toEqual({ ready: true, issues: [] });
+  });
+
+  it("flags policies set without a wallet", () => {
+    const result = checkReadiness({
+      VELLAR_X402_SECRET: VALID_SECRET,
+      VELLAR_X402_ASSETS: `${VALID_ASSET}:5000000`,
+      VELLAR_X402_POLICIES: VALID_POLICY,
+    });
+    expect(result.ready).toBe(false);
+    expect(result.issues).toContainEqual(expect.objectContaining({ variable: "VELLAR_X402_POLICIES" }));
+  });
+
+  it("flags an invalid policy contract id", () => {
+    const result = checkReadiness({
+      VELLAR_X402_SECRET: VALID_SECRET,
+      VELLAR_X402_ASSETS: `${VALID_ASSET}:5000000`,
+      VELLAR_X402_WALLET: VALID_WALLET,
+      VELLAR_X402_POLICIES: "not-a-contract-id",
+    });
+    expect(result.ready).toBe(false);
+    expect(result.issues).toContainEqual(expect.objectContaining({ variable: "VELLAR_X402_POLICIES" }));
+  });
+
+  it("flags a non-positive VELLAR_X402_MAX_RESPONSE_BYTES", () => {
+    const result = checkReadiness({
+      VELLAR_X402_SECRET: VALID_SECRET,
+      VELLAR_X402_ASSETS: `${VALID_ASSET}:5000000`,
+      VELLAR_X402_MAX_RESPONSE_BYTES: "0",
+    });
+    expect(result.ready).toBe(false);
+    expect(result.issues).toContainEqual(expect.objectContaining({ variable: "VELLAR_X402_MAX_RESPONSE_BYTES" }));
+  });
+});

--- a/contrib/examples/issue-278-x402-payer-readiness-check/readiness-check.ts
+++ b/contrib/examples/issue-278-x402-payer-readiness-check/readiness-check.ts
@@ -1,0 +1,207 @@
+// Example: a `checkReadiness` helper for @vellar/mcp-x402-payer consumers.
+//
+// The payer package only validates its environment implicitly, by throwing
+// from `loadConfig` at startup. That is fine for the server itself, but a
+// consumer that wants to verify configuration ahead of time — in a health
+// check, a setup wizard, or a CI smoke test — has no way to ask "is this
+// ready?" without actually booting the server and catching whatever it
+// throws. This mirrors the package's own env parsing (see
+// packages/mcp-x402-payer/src/config.ts) as a standalone, side-effect-free
+// check that never reads or logs the secret itself.
+//
+// Run with: npx tsx readiness-check.ts
+
+export interface ReadinessIssue {
+  /** The environment variable this issue is about. */
+  variable: string;
+  /** Human-readable explanation, safe to print or log. */
+  message: string;
+}
+
+export interface ReadinessResult {
+  ready: boolean;
+  /** Empty when `ready` is true. */
+  issues: ReadinessIssue[];
+}
+
+const CONTRACT_ID_RE = /^C[A-Z2-7]{55}$/;
+const SECRET_SEED_RE = /^S[A-Z2-7]{55}$/;
+
+function isValidContractId(value: string): boolean {
+  return CONTRACT_ID_RE.test(value);
+}
+
+function isValidSecretSeed(value: string): boolean {
+  return SECRET_SEED_RE.test(value);
+}
+
+/**
+ * Checks whether the environment has everything @vellar/mcp-x402-payer needs
+ * to start, without starting it and without ever reading file contents or
+ * logging secret material. `env` defaults to `process.env` but can be an
+ * arbitrary record for testing.
+ *
+ * This intentionally re-derives the package's own validation rules (see
+ * `loadConfig` in packages/mcp-x402-payer/src/config.ts) rather than
+ * importing them, since contributor examples are self-contained and must not
+ * depend on the package's internals.
+ */
+export function checkReadiness(env: Record<string, string | undefined> = process.env): ReadinessResult {
+  const issues: ReadinessIssue[] = [];
+
+  const secretFile = env.VELLAR_X402_SECRET_FILE?.trim();
+  const secretInline = env.VELLAR_X402_SECRET?.trim();
+
+  if (secretFile && secretInline) {
+    issues.push({
+      variable: "VELLAR_X402_SECRET / VELLAR_X402_SECRET_FILE",
+      message: "Set exactly one of these, not both.",
+    });
+  } else if (!secretFile && !secretInline) {
+    issues.push({
+      variable: "VELLAR_X402_SECRET",
+      message:
+        "No payer secret configured. Set VELLAR_X402_SECRET (an S... ed25519 secret) " +
+        "or VELLAR_X402_SECRET_FILE (a path to a file containing one).",
+    });
+  } else if (secretInline && !isValidSecretSeed(secretInline)) {
+    issues.push({
+      variable: "VELLAR_X402_SECRET",
+      message: "Value is not a valid Stellar ed25519 secret seed (S...).",
+    });
+  }
+  // A secret sourced from VELLAR_X402_SECRET_FILE is not validated here: doing
+  // so would mean reading the file, and this check must never touch secret
+  // material. The package itself validates the file's contents at startup.
+
+  const network = env.VELLAR_X402_NETWORK?.trim();
+  if (network !== undefined && network !== "" && network !== "testnet" && network !== "mainnet") {
+    issues.push({
+      variable: "VELLAR_X402_NETWORK",
+      message: `Must be "testnet" or "mainnet", got "${network}".`,
+    });
+  }
+
+  const assetsRaw = env.VELLAR_X402_ASSETS?.trim();
+  if (!assetsRaw) {
+    issues.push({
+      variable: "VELLAR_X402_ASSETS",
+      message:
+        "At least one <assetContractId>:<sessionCeiling> pair is required, comma-separated.",
+    });
+  } else {
+    const seen = new Set<string>();
+    let sawValidEntry = false;
+    for (const entry of assetsRaw.split(",")) {
+      const trimmed = entry.trim();
+      if (trimmed === "") continue;
+
+      const parts = trimmed.split(":");
+      if (parts.length !== 2) {
+        issues.push({
+          variable: "VELLAR_X402_ASSETS",
+          message: `Entry "${trimmed}" is malformed. Expected "<assetContractId>:<sessionCeilingBaseUnits>".`,
+        });
+        continue;
+      }
+      const [asset, ceilingRaw] = parts.map((p) => p.trim());
+
+      if (!asset || !isValidContractId(asset)) {
+        issues.push({
+          variable: "VELLAR_X402_ASSETS",
+          message: `"${asset}" is not a Soroban contract id (C...).`,
+        });
+        continue;
+      }
+      if (!ceilingRaw || !/^\d+$/.test(ceilingRaw)) {
+        issues.push({
+          variable: "VELLAR_X402_ASSETS",
+          message: `Ceiling for ${asset} must be a non-negative integer in base units, got "${ceilingRaw}".`,
+        });
+        continue;
+      }
+      if (BigInt(ceilingRaw) === 0n) {
+        issues.push({
+          variable: "VELLAR_X402_ASSETS",
+          message: `Ceiling for ${asset} is 0, which would refuse every payment.`,
+        });
+        continue;
+      }
+      if (seen.has(asset)) {
+        issues.push({
+          variable: "VELLAR_X402_ASSETS",
+          message: `Asset ${asset} is listed more than once.`,
+        });
+        continue;
+      }
+      seen.add(asset);
+      sawValidEntry = true;
+    }
+    if (!sawValidEntry && !issues.some((i) => i.variable === "VELLAR_X402_ASSETS")) {
+      issues.push({
+        variable: "VELLAR_X402_ASSETS",
+        message: "No usable <assetContractId>:<sessionCeiling> pairs were found.",
+      });
+    }
+  }
+
+  const walletAddress = env.VELLAR_X402_WALLET?.trim();
+  if (walletAddress && !isValidContractId(walletAddress)) {
+    issues.push({
+      variable: "VELLAR_X402_WALLET",
+      message: `Must be a Soroban contract id (C...), got "${walletAddress}".`,
+    });
+  }
+
+  const policiesRaw = env.VELLAR_X402_POLICIES?.trim();
+  if (policiesRaw) {
+    const policies = policiesRaw
+      .split(",")
+      .map((p) => p.trim())
+      .filter((p) => p !== "");
+    for (const policy of policies) {
+      if (!isValidContractId(policy)) {
+        issues.push({
+          variable: "VELLAR_X402_POLICIES",
+          message: `"${policy}" is not a Soroban contract id (C...).`,
+        });
+      }
+    }
+    if (policies.length > 0 && !walletAddress) {
+      issues.push({
+        variable: "VELLAR_X402_POLICIES",
+        message: "Policies are set but VELLAR_X402_WALLET is not. Policies only apply to a smart account signer.",
+      });
+    }
+  }
+
+  const maxResponseBytesRaw = env.VELLAR_X402_MAX_RESPONSE_BYTES?.trim();
+  if (maxResponseBytesRaw) {
+    if (!/^\d+$/.test(maxResponseBytesRaw) || Number(maxResponseBytesRaw) <= 0) {
+      issues.push({
+        variable: "VELLAR_X402_MAX_RESPONSE_BYTES",
+        message: `Must be a positive integer, got "${maxResponseBytesRaw}".`,
+      });
+    }
+  }
+
+  return { ready: issues.length === 0, issues };
+}
+
+function main() {
+  const notReady = checkReadiness({});
+  console.log("Empty environment:");
+  console.log(JSON.stringify(notReady, null, 2));
+
+  const ready = checkReadiness({
+    VELLAR_X402_SECRET: "SBPTZAOFHOKY7ZZE7HGXXVGWCVTAMLLI4KYY2EI7DGZY6L4KTAWWZ2XY",
+    VELLAR_X402_ASSETS: "CBIN4HTPJM2QLJ32DTRO6OCLIMM7TR7D74JDIPVQYLNYGL7SBWOXH5ND:5000000",
+    VELLAR_X402_NETWORK: "testnet",
+  });
+  console.log("\nFully configured environment:");
+  console.log(JSON.stringify(ready, null, 2));
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main();
+}


### PR DESCRIPTION
## Summary

Adds a standalone `checkReadiness` helper for `@vellar/mcp-x402-payer` consumers who want to verify the server's environment is correctly configured before starting it, instead of finding out only when `loadConfig` throws at startup.

closes #278

## What's included

- `checkReadiness(env?)` — a pure function that mirrors the validation rules in `packages/mcp-x402-payer/src/config.ts` (secret presence/shape, network, asset allowlist/ceilings, wallet address, policies, max response bytes) and returns a typed `{ ready, issues }` result instead of throwing.
- Never reads file contents for `VELLAR_X402_SECRET_FILE` and never echoes secret material in any issue message — this follows the same non-negotiable rule the package itself documents in `config.ts`.
- 16 tests covering a fully ready configuration, a completely empty environment, every individual invalid-configuration case (both secret forms set, malformed secret, malformed/duplicate/zero-ceiling assets, invalid network, invalid wallet/policy ids, policies without a wallet, invalid max response bytes), and a check that no issue message ever contains a secret value.
- A README documenting the helper's usage, result shape, and what is/isn't checked.

## Placement note

This is submitted under `contrib/examples/issue-278-x402-payer-readiness-check/` per the contributor scope rule (contributor PRs may only touch `contrib/`). The issue also asks for the helper to be documented in `packages/mcp-x402-payer`'s own README — since that file is outside `contrib/`, I've documented the helper fully in this example's own README instead; a maintainer can fold a summary into the package README when merging.

## Test plan

- [x] `npx vitest run contrib/examples/issue-278-x402-payer-readiness-check` — 16/16 passing
- [x] Standalone strict typecheck of the new files passes with no errors