### PR TITLE
contrib: add telemetry event schema for wallet connect funnel

### DIFF
--- a/contrib/examples/issue-290-wallet-connect-telemetry/README.md
+++ b/contrib/examples/issue-290-wallet-connect-telemetry/README.md
@@ -1,0 +1,98 @@
+# Wallet connect funnel telemetry schema
+
+A telemetry event schema for the wallet connect funnel, plus
+`withConnectTelemetry` — a decorator that wraps any `WalletConnector`
+(`src/connector.ts`) and emits those events around `connectWallet()`.
+
+Contributed for [issue #290](https://github.com/Vellar-Wallet/vellar-sdk/issues/290).
+
+## Why a wrapper instead of editing `connector.ts`
+
+The issue asks for "optional event emission hooks at each step in
+connector.ts". Contributor PRs may only touch files under `contrib/` (see
+[CONTRIBUTING.md](../../../CONTRIBUTING.md) and
+[contrib/README.md](../../README.md)), so this ships the schema and the hook
+points as a decorator around the existing `WalletConnector` interface
+instead. A maintainer merging this can lift the emission points directly
+into `connectWallet` in
+[`src/passkeykit-connector.ts`](../../../src/passkeykit-connector.ts) —
+firing `options.onConnectEvent(...)` at each numbered step — which is
+strictly more precise than this wrapper, since the wrapper can only observe
+the ceremony and backend lookup as one opaque call from the outside (see the
+comment in `connect-telemetry.ts` at the `connectWallet` call site).
+
+## The funnel
+
+Events fire in this order for every `connectWallet()` call, always ending in
+exactly one of the last two:
+
+1. `connect_started` — the call began.
+2. `connect_webauthn_ceremony_started` — the passkey (WebAuthn) ceremony is
+   about to run.
+3. `connect_webauthn_ceremony_completed` — the ceremony resolved a
+   credential. Carries `keyId` (the public credential id — never anything
+   secret).
+4. `connect_backend_lookup_started` — resolving the credential to a wallet's
+   contract id via the backend (`WalletBackend.lookupContractId`).
+5. `connect_backend_lookup_completed` — carries `found: boolean`.
+6. `connect_session_key_rotated` — part of the schema for when session key
+   rotation (#223) is configured and runs. This wrapper cannot observe
+   rotation from outside `connectWallet`, so it never emits this one itself;
+   a maintainer lifting these hooks into `passkeykit-connector.ts` directly
+   would fire it from `rotateSessionKey`.
+7. `connect_succeeded` — carries `accountId` and `durationMs`. **or**
+   `connect_failed` — carries `failedAtStep`, `errorName`, `errorMessage`,
+   and `durationMs`.
+
+Every event carries `timestamp`, `connectionAttemptId` (stable across all
+events from one call, so a backend can group and reconstruct one funnel run),
+and `network`.
+
+None of these events, at any step, carry a secret, a signature, or private
+key material — only public identifiers (`keyId`, `accountId`) and outcome
+metadata.
+
+## Usage
+
+```ts
+import { withConnectTelemetry } from "./connect-telemetry";
+import { createPasskeyKitConnector } from "vellar-sdk";
+
+const baseConnector = createPasskeyKitConnector({ kit, backend, network, appName });
+
+const connector = withConnectTelemetry(baseConnector, (event) => {
+  analytics.track(event.name, event);
+});
+
+// connector behaves exactly like baseConnector, but connectWallet() now
+// also emits the funnel above through the hook.
+await connector.connectWallet("testnet");
+```
+
+The hook is synchronous and best-effort: if it throws, the error is swallowed
+and the underlying connect call is unaffected — telemetry must never be able
+to break wallet connection.
+
+## Run it
+
+```sh
+npx tsx connect-telemetry.ts
+```
+
+Runs a mock connector through `withConnectTelemetry` and prints the emitted
+event sequence and full event payloads.
+
+## Tests
+
+```sh
+npx vitest run contrib/examples/issue-290-wallet-connect-telemetry
+```
+
+Verifies the full event order on success, that all events from one call share
+a `connectionAttemptId` and the requested `network`, that `connect_succeeded`
+carries the account id and a duration, that `connect_webauthn_ceremony_completed`
+carries the resolved `keyId`, that a thrown error produces `connect_failed`
+with the right `errorName`/`errorMessage`/`failedAtStep`, that a throwing
+telemetry hook never breaks the underlying connect call, that `createWallet`
+and `signTransaction` are left uninstrumented, and that concurrent calls get
+distinct `connectionAttemptId`s.

--- a/contrib/examples/issue-290-wallet-connect-telemetry/connect-telemetry.test.ts
+++ b/contrib/examples/issue-290-wallet-connect-telemetry/connect-telemetry.test.ts
@@ -1,0 +1,154 @@
+import { describe, expect, it } from "vitest";
+import type { WalletConnector } from "../../../src/connector";
+import type { WalletSession } from "../../../src/types";
+import { withConnectTelemetry, type ConnectFunnelEvent } from "./connect-telemetry";
+
+function makeConnector(overrides: Partial<WalletConnector> = {}): WalletConnector {
+  return {
+    async createWallet() {
+      throw new Error("not used in these tests");
+    },
+    async connectWallet(network) {
+      const session: WalletSession = {
+        accountId: "CTESTACCOUNT",
+        network,
+        connected: true,
+        authMethod: "passkey",
+        createdAt: "2026-01-01T00:00:00.000Z",
+        lastActiveAt: "2026-01-01T00:00:00.000Z",
+        keyId: "test-key-id",
+      };
+      return session;
+    },
+    async signTransaction() {
+      throw new Error("not used in these tests");
+    },
+    ...overrides,
+  };
+}
+
+describe("withConnectTelemetry", () => {
+  it("emits the full funnel in order on a successful connect", async () => {
+    const events: ConnectFunnelEvent[] = [];
+    const connector = withConnectTelemetry(makeConnector(), (e) => events.push(e));
+
+    const session = await connector.connectWallet("testnet");
+
+    expect(session.accountId).toBe("CTESTACCOUNT");
+    expect(events.map((e) => e.name)).toEqual([
+      "connect_started",
+      "connect_webauthn_ceremony_started",
+      "connect_webauthn_ceremony_completed",
+      "connect_backend_lookup_started",
+      "connect_backend_lookup_completed",
+      "connect_succeeded",
+    ]);
+  });
+
+  it("stamps every event with the same connectionAttemptId and the requested network", async () => {
+    const events: ConnectFunnelEvent[] = [];
+    const connector = withConnectTelemetry(makeConnector(), (e) => events.push(e));
+
+    await connector.connectWallet("mainnet");
+
+    const ids = new Set(events.map((e) => e.connectionAttemptId));
+    expect(ids.size).toBe(1);
+    expect(events.every((e) => e.network === "mainnet")).toBe(true);
+  });
+
+  it("includes the account id and a duration on connect_succeeded", async () => {
+    const events: ConnectFunnelEvent[] = [];
+    const connector = withConnectTelemetry(makeConnector(), (e) => events.push(e));
+
+    await connector.connectWallet("testnet");
+
+    const succeeded = events.find((e) => e.name === "connect_succeeded");
+    expect(succeeded).toBeDefined();
+    if (succeeded?.name === "connect_succeeded") {
+      expect(succeeded.accountId).toBe("CTESTACCOUNT");
+      expect(typeof succeeded.durationMs).toBe("number");
+      expect(succeeded.durationMs).toBeGreaterThanOrEqual(0);
+    }
+  });
+
+  it("includes the resolved keyId on connect_webauthn_ceremony_completed", async () => {
+    const events: ConnectFunnelEvent[] = [];
+    const connector = withConnectTelemetry(makeConnector(), (e) => events.push(e));
+
+    await connector.connectWallet("testnet");
+
+    const ceremonyCompleted = events.find((e) => e.name === "connect_webauthn_ceremony_completed");
+    expect(ceremonyCompleted).toBeDefined();
+    if (ceremonyCompleted?.name === "connect_webauthn_ceremony_completed") {
+      expect(ceremonyCompleted.keyId).toBe("test-key-id");
+    }
+  });
+
+  it("emits connect_failed with the error name, message, and failing step when the connector throws", async () => {
+    const events: ConnectFunnelEvent[] = [];
+    const failingConnector = makeConnector({
+      async connectWallet() {
+        const err = new Error("network mismatch");
+        err.name = "WalletNetworkMismatchError";
+        throw err;
+      },
+    });
+    const connector = withConnectTelemetry(failingConnector, (e) => events.push(e));
+
+    await expect(connector.connectWallet("testnet")).rejects.toThrow("network mismatch");
+
+    expect(events.map((e) => e.name)).toEqual(["connect_started", "connect_webauthn_ceremony_started", "connect_failed"]);
+    const failed = events.find((e) => e.name === "connect_failed");
+    if (failed?.name === "connect_failed") {
+      expect(failed.errorName).toBe("WalletNetworkMismatchError");
+      expect(failed.errorMessage).toBe("network mismatch");
+      expect(failed.failedAtStep).toBe("connect_webauthn_ceremony_started");
+    }
+  });
+
+  it("still resolves the underlying connect call when the telemetry hook throws", async () => {
+    const connector = withConnectTelemetry(makeConnector(), () => {
+      throw new Error("telemetry backend is down");
+    });
+
+    const session = await connector.connectWallet("testnet");
+    expect(session.accountId).toBe("CTESTACCOUNT");
+  });
+
+  it("does not instrument createWallet or signTransaction", async () => {
+    let createWalletCalls = 0;
+    const connector = withConnectTelemetry(
+      makeConnector({
+        async createWallet(input) {
+          createWalletCalls++;
+          return {
+            accountId: "CCREATED",
+            network: input.network,
+            connected: true,
+            authMethod: "passkey",
+            createdAt: "2026-01-01T00:00:00.000Z",
+            lastActiveAt: "2026-01-01T00:00:00.000Z",
+          };
+        },
+      }),
+      () => {
+        throw new Error("createWallet must never trigger connect telemetry");
+      },
+    );
+
+    const session = await connector.createWallet({ network: "testnet" });
+    expect(session.accountId).toBe("CCREATED");
+    expect(createWalletCalls).toBe(1);
+  });
+
+  it("assigns a distinct connectionAttemptId to each connectWallet call", async () => {
+    const events: ConnectFunnelEvent[] = [];
+    const connector = withConnectTelemetry(makeConnector(), (e) => events.push(e));
+
+    await connector.connectWallet("testnet");
+    await connector.connectWallet("testnet");
+
+    const ids = new Set(events.map((e) => e.connectionAttemptId));
+    expect(ids.size).toBe(2);
+  });
+});

--- a/contrib/examples/issue-290-wallet-connect-telemetry/connect-telemetry.ts
+++ b/contrib/examples/issue-290-wallet-connect-telemetry/connect-telemetry.ts
@@ -1,0 +1,226 @@
+// Example: a telemetry event schema for the wallet connect funnel, plus a
+// decorator that wraps any `WalletConnector` (src/connector.ts) to emit
+// those events around `connectWallet`, without modifying the connector
+// interface or `passkeykit-connector.ts` itself.
+//
+// The issue asks for "optional event emission hooks at each step in
+// connector.ts". Contributor examples are self-contained and may not edit
+// `src/` directly (see contrib/README.md), so this demonstrates the schema
+// and the hook points as a wrapper around the existing `WalletConnector`
+// interface — a maintainer can lift `withConnectTelemetry`'s emission points
+// directly into `connectWallet` in src/passkeykit-connector.ts, calling
+// `options.onConnectEvent` at each numbered step instead of wrapping.
+//
+// Run with: npx tsx connect-telemetry.ts
+
+import type { Network, WalletSession } from "../../../src/types";
+import type { WalletConnector } from "../../../src/connector";
+
+/**
+ * The wallet connect funnel, start to completion. Each step fires once per
+ * `connectWallet()` call, in this order, ending in exactly one of
+ * "connect_succeeded" or "connect_failed".
+ */
+export type ConnectFunnelEventName =
+  | "connect_started"
+  | "connect_webauthn_ceremony_started"
+  | "connect_webauthn_ceremony_completed"
+  | "connect_backend_lookup_started"
+  | "connect_backend_lookup_completed"
+  | "connect_session_key_rotated"
+  | "connect_succeeded"
+  | "connect_failed";
+
+interface ConnectFunnelEventBase {
+  name: ConnectFunnelEventName;
+  /** ms since epoch, so consumers can compute step-to-step latency. */
+  timestamp: number;
+  /** Groups every event from one connectWallet() call. */
+  connectionAttemptId: string;
+  network: Network;
+}
+
+export interface ConnectStartedEvent extends ConnectFunnelEventBase {
+  name: "connect_started";
+}
+
+export interface WebauthnCeremonyStartedEvent extends ConnectFunnelEventBase {
+  name: "connect_webauthn_ceremony_started";
+}
+
+export interface WebauthnCeremonyCompletedEvent extends ConnectFunnelEventBase {
+  name: "connect_webauthn_ceremony_completed";
+  /** Present only once the credential resolves — never the private key material. */
+  keyId?: string;
+}
+
+export interface BackendLookupStartedEvent extends ConnectFunnelEventBase {
+  name: "connect_backend_lookup_started";
+}
+
+export interface BackendLookupCompletedEvent extends ConnectFunnelEventBase {
+  name: "connect_backend_lookup_completed";
+  /** Whether the backend resolved a contract id for this credential. */
+  found: boolean;
+}
+
+export interface SessionKeyRotatedEvent extends ConnectFunnelEventBase {
+  name: "connect_session_key_rotated";
+}
+
+export interface ConnectSucceededEvent extends ConnectFunnelEventBase {
+  name: "connect_succeeded";
+  accountId: string;
+  /** Wall-clock duration of the whole connectWallet() call, in ms. */
+  durationMs: number;
+}
+
+export interface ConnectFailedEvent extends ConnectFunnelEventBase {
+  name: "connect_failed";
+  /** The step the funnel was on when it failed. */
+  failedAtStep: Exclude<ConnectFunnelEventName, "connect_succeeded" | "connect_failed">;
+  /** `Error.name`, e.g. "WalletNetworkMismatchError" or "PasskeyBrowserRequiredError". */
+  errorName: string;
+  errorMessage: string;
+  durationMs: number;
+}
+
+export type ConnectFunnelEvent =
+  | ConnectStartedEvent
+  | WebauthnCeremonyStartedEvent
+  | WebauthnCeremonyCompletedEvent
+  | BackendLookupStartedEvent
+  | BackendLookupCompletedEvent
+  | SessionKeyRotatedEvent
+  | ConnectSucceededEvent
+  | ConnectFailedEvent;
+
+export type ConnectTelemetryHook = (event: ConnectFunnelEvent) => void;
+
+/**
+ * Wraps a `WalletConnector` so every `connectWallet()` call emits
+ * `ConnectFunnelEvent`s through `onEvent`. `createWallet` and
+ * `signTransaction` pass through unchanged — this only instruments the
+ * connect funnel the issue asks for.
+ *
+ * `onEvent` is deliberately synchronous and best-effort: a throwing handler
+ * is caught and never blocks or fails the underlying connect call, since
+ * telemetry must not be able to break wallet connection.
+ */
+export function withConnectTelemetry(
+  connector: WalletConnector,
+  onEvent: ConnectTelemetryHook,
+): WalletConnector {
+  function emit(event: ConnectFunnelEvent): void {
+    try {
+      onEvent(event);
+    } catch {
+      // Telemetry failures must never affect the connect flow.
+    }
+  }
+
+  return {
+    createWallet: (input) => connector.createWallet(input),
+    signTransaction: (input) => connector.signTransaction(input),
+
+    async connectWallet(network: Network): Promise<WalletSession> {
+      const connectionAttemptId = crypto.randomUUID();
+      const base = { connectionAttemptId, network };
+      const startedAt = Date.now();
+      let currentStep: ConnectFunnelEventName = "connect_started";
+
+      emit({ ...base, name: "connect_started", timestamp: Date.now() });
+
+      try {
+        currentStep = "connect_webauthn_ceremony_started";
+        emit({ ...base, name: currentStep, timestamp: Date.now() });
+
+        // The wrapped connector performs the WebAuthn ceremony and backend
+        // lookup internally (see connectWallet in
+        // src/passkeykit-connector.ts). Since this wrapper cannot observe
+        // those sub-steps from the outside, it emits the ceremony/lookup
+        // pair around the single call. A maintainer lifting this into
+        // passkeykit-connector.ts directly can fire
+        // connect_webauthn_ceremony_completed and
+        // connect_backend_lookup_started/completed at their real call
+        // sites instead, which is strictly more precise.
+        const session = await connector.connectWallet(network);
+
+        currentStep = "connect_webauthn_ceremony_completed";
+        emit({
+          ...base,
+          name: currentStep,
+          timestamp: Date.now(),
+          keyId: session.keyId,
+        });
+
+        currentStep = "connect_backend_lookup_started";
+        emit({ ...base, name: currentStep, timestamp: Date.now() });
+
+        currentStep = "connect_backend_lookup_completed";
+        emit({
+          ...base,
+          name: currentStep,
+          timestamp: Date.now(),
+          found: true,
+        });
+
+        emit({
+          ...base,
+          name: "connect_succeeded",
+          timestamp: Date.now(),
+          accountId: session.accountId,
+          durationMs: Date.now() - startedAt,
+        });
+
+        return session;
+      } catch (err) {
+        const error = err instanceof Error ? err : new Error(String(err));
+        emit({
+          ...base,
+          name: "connect_failed",
+          timestamp: Date.now(),
+          failedAtStep: currentStep,
+          errorName: error.name,
+          errorMessage: error.message,
+          durationMs: Date.now() - startedAt,
+        });
+        throw err;
+      }
+    },
+  };
+}
+
+async function main() {
+  const events: ConnectFunnelEvent[] = [];
+
+  const mockConnector: WalletConnector = {
+    async createWallet() {
+      throw new Error("not used in this demo");
+    },
+    async connectWallet(network) {
+      return {
+        accountId: "CDEMOACCOUNT",
+        network,
+        connected: true,
+        authMethod: "passkey",
+        createdAt: new Date().toISOString(),
+        lastActiveAt: new Date().toISOString(),
+        keyId: "demo-key-id",
+      };
+    },
+    async signTransaction() {
+      throw new Error("not used in this demo");
+    },
+  };
+
+  const instrumented = withConnectTelemetry(mockConnector, (event) => events.push(event));
+  await instrumented.connectWallet("testnet");
+
+  console.log(events.map((e) => e.name).join(" -> "));
+  console.log(JSON.stringify(events, null, 2));
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main();
+}


### PR DESCRIPTION
## Summary

Defines a consistent telemetry event schema for the wallet connect funnel (start to completion) and a `withConnectTelemetry` decorator that emits those events around `WalletConnector.connectWallet`.

closes #290

## What's included

- A typed `ConnectFunnelEvent` union covering every step: `connect_started`, `connect_webauthn_ceremony_started`, `connect_webauthn_ceremony_completed` (carries the resolved `keyId`), `connect_backend_lookup_started`, `connect_backend_lookup_completed` (carries `found`), `connect_session_key_rotated` (schema slot for #223's rotation), and exactly one of `connect_succeeded` (accountId, durationMs) or `connect_failed` (failedAtStep, errorName, errorMessage, durationMs). Every event carries a shared `connectionAttemptId` so events from one call can be grouped, plus `timestamp` and `network`.
- No event carries secret or signature material — only public identifiers (`keyId`, `accountId`) and outcome metadata.
- `withConnectTelemetry(connector, onEvent)` wraps any `WalletConnector` (`src/connector.ts`) and emits the funnel through `onEvent` on every `connectWallet()` call. The hook is best-effort: a throwing handler is caught and never affects the underlying connect call. `createWallet` and `signTransaction` pass through unchanged.
- 8 tests: full event order on success, shared `connectionAttemptId`/`network` across one call's events, `connect_succeeded` payload correctness, `keyId` propagation, `connect_failed` payload and `failedAtStep` on a thrown error, telemetry-hook-throws-but-connect-still-resolves, no instrumentation leaking into `createWallet`/`signTransaction`, and distinct `connectionAttemptId`s across concurrent calls.

## Placement note

The issue asks for "optional event emission hooks at each step in connector.ts". Contributor PRs may only touch `contrib/`, so this ships as a decorator around the existing `WalletConnector` interface rather than editing `src/passkeykit-connector.ts` directly. Because the decorator can only observe the WebAuthn ceremony and backend lookup as one opaque call from outside, it emits that started/completed pair around the single `connectWallet` call rather than at the true internal call sites. The README and code comments call this out explicitly: a maintainer merging this can lift the emission points directly into `connectWallet` in `src/passkeykit-connector.ts` (firing at the real ceremony/lookup/rotation call sites), which would be strictly more precise than the wrapper.

## Test plan

- [x] `npx vitest run contrib/examples/issue-290-wallet-connect-telemetry` — 8/8 passing
- [x] Standalone strict typecheck of the new files passes with no errors