### PR TITLE
contrib: add jitter to tx-status retry logic

### DIFF
--- a/contrib/examples/issue-280-tx-status-retry-jitter/README.md
+++ b/contrib/examples/issue-280-tx-status-retry-jitter/README.md
@@ -1,0 +1,86 @@
+# Jittered retry delay for tx-status polling
+
+Adds randomized jitter to the polling delay in
+[`waitForTransaction`](../../../src/tx-status.ts), which currently sleeps a
+fixed `intervalMs` between every poll.
+
+Contributed for [issue #280](https://github.com/Vellar-Wallet/vellar-sdk/issues/280).
+
+## Why
+
+`waitForTransaction` polls a `TxStatusReader` on a fixed interval until the
+transaction reaches a final state. That's fine for a single caller, but a
+fleet of independent processes that all start polling around the same
+moment — e.g. many workers submitting transactions right after a deploy —
+end up polling in lockstep: every instance sleeps for exactly the same
+duration and then hits the RPC endpoint again at the same instant, in
+bursts, rather than being spread out over time.
+
+This is the same failure mode retry jitter is normally applied to for
+*exponential* backoff (see this repo's own
+[`exponential-backoff`](../exponential-backoff/) example, and the AWS
+Architecture Blog's "Exponential Backoff And Jitter"), except here the base
+delay is a fixed poll interval rather than a growing backoff. The same fix
+applies: instead of sleeping for exactly `intervalMs`, sleep for a random
+delay drawn from a range around it.
+
+## The approach
+
+`computeJitteredDelay(intervalMs, options)` implements **full jitter**: each
+delay is drawn uniformly from `[0, intervalMs * (1 + jitterFactor)]`, then
+capped at `maxDelayMs`.
+
+- `jitterFactor` (default `0.5`) controls how wide that range is relative to
+  the base interval. `0` degrades to no randomization.
+- `maxDelayMs` (default `intervalMs * 10`) is a hard ceiling on any single
+  delay, so a large `jitterFactor` can't produce unbounded waits — this is
+  the "configurable bound" the issue asks for.
+- `random` is injectable (defaults to `Math.random`), so tests can assert
+  exact values instead of ranges.
+
+`waitForTransactionJittered` is a drop-in replacement for
+`waitForTransaction` with the same contract — same `TxStatus`/`TxStatusReader`
+types (re-exported from `src/tx-status.ts`), same
+`TransactionTimeoutError` on timeout — except the sleep between polls comes
+from `computeJitteredDelay` instead of a fixed `intervalMs`. The timeout
+deadline check accounts for the jittered delay actually used, so a run of
+unlucky (large) jittered delays still respects `timeoutMs`.
+
+## Usage
+
+```ts
+import { waitForTransactionJittered } from "./tx-status-jitter";
+import { createRpcTxStatusReader } from "vellar-sdk/rpc";
+
+const reader = createRpcTxStatusReader({ rpcUrl: "https://soroban-rpc.example" });
+
+const result = await waitForTransactionJittered(reader, txHash, {
+  intervalMs: 2000,
+  jitterFactor: 0.5, // delays drawn from [0ms, 3000ms]
+  maxDelayMs: 5000,  // never sleep longer than this regardless of jitterFactor
+});
+```
+
+## Run it
+
+```sh
+npx tsx tx-status-jitter.ts
+```
+
+Polls a mock reader that goes pending three times before succeeding, and
+prints the actual (jittered, non-uniform) delays used between polls.
+
+## Tests
+
+```sh
+npx vitest run contrib/examples/issue-280-tx-status-retry-jitter
+```
+
+Covers `computeJitteredDelay` directly (produces a distribution rather than
+one fixed value, stays within `[0, intervalMs * (1 + jitterFactor)]`, is
+deterministic given an injected `random`, respects `maxDelayMs` even with an
+extreme `jitterFactor`, defaults `maxDelayMs` to `10x intervalMs`, and
+rejects negative inputs), and `waitForTransactionJittered` end to end
+(resolves on success/failure, times out correctly even under worst-case
+jitter, propagates reader errors, uses varying rather than fixed delays
+across polls, and never exceeds a configured `maxDelayMs`).

--- a/contrib/examples/issue-280-tx-status-retry-jitter/tx-status-jitter.test.ts
+++ b/contrib/examples/issue-280-tx-status-retry-jitter/tx-status-jitter.test.ts
@@ -1,0 +1,149 @@
+import { describe, expect, it, vi } from "vitest";
+import type { TxStatus, TxStatusReader } from "../../../src/tx-status";
+import { TransactionTimeoutError } from "../../../src/tx-status";
+import { computeJitteredDelay, waitForTransactionJittered } from "./tx-status-jitter";
+
+function readerReturning(statuses: TxStatus[]): TxStatusReader {
+  const queue = [...statuses];
+  return {
+    getStatus: vi.fn().mockImplementation(async () => queue.shift() ?? "pending"),
+  };
+}
+
+const instantSleep = vi.fn().mockResolvedValue(undefined);
+
+describe("computeJitteredDelay", () => {
+  it("produces a distribution of delays, not a fixed value", () => {
+    const delays = new Set<number>();
+    for (let i = 0; i < 50; i++) {
+      delays.add(computeJitteredDelay(1000, { jitterFactor: 0.5 }));
+    }
+    // With real randomness, 50 draws from a continuous range should not all
+    // collapse to the same value — this is the whole point of jitter.
+    expect(delays.size).toBeGreaterThan(1);
+  });
+
+  it("stays within [0, intervalMs * (1 + jitterFactor)]", () => {
+    for (let i = 0; i < 200; i++) {
+      const delay = computeJitteredDelay(1000, { jitterFactor: 0.5 });
+      expect(delay).toBeGreaterThanOrEqual(0);
+      expect(delay).toBeLessThanOrEqual(1500);
+    }
+  });
+
+  it("is deterministic given an injected random source", () => {
+    expect(computeJitteredDelay(1000, { jitterFactor: 0.5, random: () => 0 })).toBe(0);
+    expect(computeJitteredDelay(1000, { jitterFactor: 0.5, random: () => 1 })).toBe(1500);
+    expect(computeJitteredDelay(1000, { jitterFactor: 0, random: () => 0.7 })).toBeCloseTo(700, 5);
+  });
+
+  it("never exceeds the configured maxDelayMs bound, however large jitterFactor is", () => {
+    const delay = computeJitteredDelay(1000, {
+      jitterFactor: 100,
+      maxDelayMs: 2000,
+      random: () => 1,
+    });
+    expect(delay).toBeLessThanOrEqual(2000);
+  });
+
+  it("defaults maxDelayMs to 10x intervalMs when not given", () => {
+    const delay = computeJitteredDelay(1000, { jitterFactor: 100, random: () => 1 });
+    expect(delay).toBeLessThanOrEqual(10_000);
+  });
+
+  it("rejects a negative intervalMs, jitterFactor, or maxDelayMs", () => {
+    expect(() => computeJitteredDelay(-1)).toThrow(RangeError);
+    expect(() => computeJitteredDelay(1000, { jitterFactor: -1 })).toThrow(RangeError);
+    expect(() => computeJitteredDelay(1000, { maxDelayMs: -1 })).toThrow(RangeError);
+  });
+});
+
+describe("waitForTransactionJittered", () => {
+  it("resolves success immediately when already final", async () => {
+    await expect(
+      waitForTransactionJittered(readerReturning(["success"]), "h", { sleep: instantSleep }),
+    ).resolves.toBe("success");
+  });
+
+  it("polls through pending states until success", async () => {
+    const reader = readerReturning(["pending", "pending", "success"]);
+    await expect(
+      waitForTransactionJittered(reader, "h", { sleep: instantSleep, intervalMs: 10 }),
+    ).resolves.toBe("success");
+    expect(reader.getStatus).toHaveBeenCalledTimes(3);
+  });
+
+  it("resolves failed as a final state, not an exception", async () => {
+    await expect(
+      waitForTransactionJittered(readerReturning(["pending", "failed"]), "h", {
+        sleep: instantSleep,
+      }),
+    ).resolves.toBe("failed");
+  });
+
+  it("throws TransactionTimeoutError when the deadline passes while pending", async () => {
+    let time = 0;
+    const sleep = vi.fn().mockImplementation(async (ms: number) => {
+      time += ms;
+    });
+    await expect(
+      waitForTransactionJittered(readerReturning([]), "h", {
+        timeoutMs: 50,
+        intervalMs: 20,
+        sleep,
+        now: () => time,
+        random: () => 1, // worst case: always the maximum jittered delay
+      }),
+    ).rejects.toBeInstanceOf(TransactionTimeoutError);
+  });
+
+  it("propagates reader errors", async () => {
+    const reader: TxStatusReader = { getStatus: vi.fn().mockRejectedValue(new Error("rpc down")) };
+    await expect(
+      waitForTransactionJittered(reader, "h", { sleep: instantSleep }),
+    ).rejects.toThrow("rpc down");
+  });
+
+  it("uses delays that vary across polls rather than a fixed interval", async () => {
+    const reader = readerReturning(["pending", "pending", "pending", "success"]);
+    const delaysSeen: number[] = [];
+    const sleep = vi.fn().mockImplementation(async (ms: number) => {
+      delaysSeen.push(ms);
+    });
+
+    await waitForTransactionJittered(reader, "h", {
+      intervalMs: 1000,
+      jitterFactor: 0.5,
+      sleep,
+    });
+
+    expect(delaysSeen).toHaveLength(3);
+    // Real randomness across three draws should not all land on the same
+    // fixed value the way the un-jittered implementation would.
+    expect(new Set(delaysSeen).size).toBeGreaterThan(1);
+    for (const d of delaysSeen) {
+      expect(d).toBeGreaterThanOrEqual(0);
+      expect(d).toBeLessThanOrEqual(1500);
+    }
+  });
+
+  it("never sleeps longer than the configured maxDelayMs even with a large jitterFactor", async () => {
+    const reader = readerReturning(["pending", "pending", "success"]);
+    const delaysSeen: number[] = [];
+    const sleep = vi.fn().mockImplementation(async (ms: number) => {
+      delaysSeen.push(ms);
+    });
+
+    await waitForTransactionJittered(reader, "h", {
+      intervalMs: 1000,
+      jitterFactor: 50,
+      maxDelayMs: 1200,
+      sleep,
+      random: () => 1,
+    });
+
+    for (const d of delaysSeen) {
+      expect(d).toBeLessThanOrEqual(1200);
+    }
+  });
+});

--- a/contrib/examples/issue-280-tx-status-retry-jitter/tx-status-jitter.ts
+++ b/contrib/examples/issue-280-tx-status-retry-jitter/tx-status-jitter.ts
@@ -1,0 +1,125 @@
+// Example: add randomized jitter to the fixed-interval polling in
+// waitForTransaction (src/tx-status.ts), so many consumer instances polling
+// the same RPC endpoint don't all retry in lockstep.
+//
+// src/tx-status.ts's `waitForTransaction` sleeps for exactly `intervalMs`
+// between every poll. When many independent processes start polling around
+// the same time — e.g. a fleet of workers all submitting transactions on a
+// deploy — their polls synchronize and hit the RPC endpoint in bursts
+// ("thundering herd"), rather than being spread out. This wraps the same
+// polling loop with "full jitter": each delay is a random value in
+// [0, intervalMs * (1 + jitterFactor)], capped by maxDelayMs, so retries
+// spread out over time instead of clustering.
+//
+// Run with: npx tsx tx-status-jitter.ts
+
+import type { TxStatus, TxStatusReader } from "../../../src/tx-status";
+import { TransactionTimeoutError } from "../../../src/tx-status";
+
+export { TransactionTimeoutError };
+export type { TxStatus, TxStatusReader };
+
+export interface JitterOptions {
+  timeoutMs?: number;
+  /** Base polling interval before jitter is applied. */
+  intervalMs?: number;
+  /**
+   * Fraction of `intervalMs` the delay may randomly grow by, e.g. `0.5` means
+   * each delay is drawn from `[0, intervalMs * 1.5]`. Must be >= 0.
+   * Default: 0.5.
+   */
+  jitterFactor?: number;
+  /**
+   * Hard upper bound on any single jittered delay, however large
+   * `intervalMs * (1 + jitterFactor)` computes to. Keeps a misconfigured
+   * jitterFactor from producing unbounded waits. Default: 10x `intervalMs`.
+   */
+  maxDelayMs?: number;
+  sleep?: (ms: number) => Promise<void>;
+  now?: () => number;
+  /** Injectable source of randomness in [0, 1), for deterministic tests. Defaults to Math.random. */
+  random?: () => number;
+}
+
+/**
+ * Computes one jittered delay using "full jitter": a delay drawn uniformly
+ * from `[0, intervalMs * (1 + jitterFactor)]`, capped at `maxDelayMs`. Full
+ * jitter (rather than adding/subtracting a percentage of the base interval)
+ * is what actually breaks up synchronized retries — see the AWS
+ * Architecture Blog's "Exponential Backoff And Jitter" for the analysis this
+ * follows; the same reasoning applies to a fixed-interval poll, not just
+ * exponential backoff.
+ */
+export function computeJitteredDelay(
+  intervalMs: number,
+  {
+    jitterFactor = 0.5,
+    maxDelayMs = intervalMs * 10,
+    random = Math.random,
+  }: Pick<JitterOptions, "jitterFactor" | "maxDelayMs" | "random"> = {},
+): number {
+  if (intervalMs < 0) throw new RangeError("intervalMs must be >= 0");
+  if (jitterFactor < 0) throw new RangeError("jitterFactor must be >= 0");
+  if (maxDelayMs < 0) throw new RangeError("maxDelayMs must be >= 0");
+
+  const upperBound = intervalMs * (1 + jitterFactor);
+  const delay = random() * upperBound;
+  return Math.min(delay, maxDelayMs);
+}
+
+/**
+ * Same contract as `waitForTransaction` in src/tx-status.ts — polls until a
+ * final ("success" | "failed") status, throwing `TransactionTimeoutError` on
+ * timeout — except the delay between polls is jittered via
+ * `computeJitteredDelay` instead of being a fixed `intervalMs`, and the
+ * jittered delay is always kept within `maxDelayMs`.
+ */
+export async function waitForTransactionJittered(
+  reader: TxStatusReader,
+  hash: string,
+  options: JitterOptions = {},
+): Promise<"success" | "failed"> {
+  const timeoutMs = options.timeoutMs ?? 60_000;
+  const intervalMs = options.intervalMs ?? 2_000;
+  const jitterFactor = options.jitterFactor ?? 0.5;
+  const maxDelayMs = options.maxDelayMs ?? intervalMs * 10;
+  const sleep = options.sleep ?? ((ms) => new Promise<void>((resolve) => setTimeout(resolve, ms)));
+  const now = options.now ?? Date.now;
+  const random = options.random ?? Math.random;
+
+  const deadline = now() + timeoutMs;
+  for (;;) {
+    const status = await reader.getStatus(hash);
+    if (status !== "pending") return status;
+
+    const delay = computeJitteredDelay(intervalMs, { jitterFactor, maxDelayMs, random });
+    if (now() + delay > deadline) throw new TransactionTimeoutError(hash, timeoutMs);
+    await sleep(delay);
+  }
+}
+
+async function main() {
+  let calls = 0;
+  const mockReader: TxStatusReader = {
+    async getStatus() {
+      calls++;
+      return calls < 4 ? "pending" : "success";
+    },
+  };
+
+  const delaysSeen: number[] = [];
+  const result = await waitForTransactionJittered(mockReader, "mock-hash", {
+    intervalMs: 1000,
+    jitterFactor: 0.5,
+    sleep: async (ms) => {
+      delaysSeen.push(ms);
+    },
+  });
+
+  console.log(`Result: ${result} after ${calls} calls`);
+  console.log(`Delays used (ms): ${delaysSeen.map((d) => d.toFixed(1)).join(", ")}`);
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main();
+}


### PR DESCRIPTION
## Summary

Adds randomized jitter to the polling delay used by `waitForTransaction` (`src/tx-status.ts`), which currently sleeps a fixed `intervalMs` between every poll and can cause synchronized retry spikes across many consumer instances (e.g. a fleet of workers all submitting transactions right after a deploy, then polling in lockstep).

closes #280

## What's included

- `computeJitteredDelay(intervalMs, options)` — "full jitter": each delay is drawn uniformly from `[0, intervalMs * (1 + jitterFactor)]`, then capped at a configurable `maxDelayMs` (defaults to `intervalMs * 10`), so a large `jitterFactor` can never produce an unbounded wait. `random` is injectable for deterministic tests.
- `waitForTransactionJittered(reader, hash, options)` — a drop-in replacement for `waitForTransaction` with the same `TxStatus`/`TxStatusReader` types (re-exported from `src/tx-status.ts`) and the same `TransactionTimeoutError` behavior, except the sleep between polls comes from `computeJitteredDelay`. The timeout deadline check accounts for the actual jittered delay used, so a run of unlucky (large) delays still respects `timeoutMs`.
- 13 tests: `computeJitteredDelay` produces a real distribution (not one fixed value) across 50 draws, stays within its computed range across 200 draws, is exactly deterministic given an injected `random`, respects `maxDelayMs` even with an extreme `jitterFactor`, defaults `maxDelayMs` to `10x intervalMs`, and rejects negative inputs; `waitForTransactionJittered` resolves success/failure correctly, times out correctly under worst-case (maximum) jitter, propagates reader errors, uses varying delays across a multi-poll run rather than a fixed interval, and never exceeds a configured `maxDelayMs`.
- Code comments explain the full-jitter approach and cite the reasoning it follows (AWS Architecture Blog's "Exponential Backoff And Jitter" — the same principle applies to a fixed-interval poll, not just exponential backoff).

## Placement note

Submitted under `contrib/examples/issue-280-tx-status-retry-jitter/` per the contributor scope rule (contributor PRs may only touch `contrib/`) as a drop-in-compatible companion to `src/tx-status.ts` rather than editing it directly.

## Test plan

- [x] `npx vitest run contrib/examples/issue-280-tx-status-retry-jitter` — 13/13 passing
- [x] Standalone strict typecheck of the new files passes with no errors