### PR TITLE
refactor(x402): split payment submission out of x402-client

### DIFF
--- a/src/x402-client.test.ts
+++ b/src/x402-client.test.ts
@@ -140,28 +140,13 @@ describe("createPayment — direct-path guards", () => {
   });
 });
 
-describe("expirationOffsetFor — derived from maxTimeoutSeconds (bug #5)", () => {
-  it("derives a SHORT expiration for a short server timeout (no fixed +12)", () => {
-    // 30s window ≈ 6 ledgers; minus the safety margin (2) = 4. A fixed +12 would
-    // exceed the facilitator's ~6-ledger maxLedger and be rejected.
-    expect(expirationOffsetFor(30)).toBe(4);
-  });
-
-  it("derives a wider expiration for a long timeout", () => {
-    // 120s ≈ 24 ledgers − 2 = 22.
+describe("expirationOffsetFor — re-exported from ./x402-payment (#299)", () => {
+  // Full derivation-math coverage lives in x402-payment.test.ts, next to the
+  // function's new home. This just pins that the re-export from ./x402-client
+  // still works, so existing `import { expirationOffsetFor } from "./x402-client"`
+  // call sites are unaffected by the split.
+  it("is callable via the ./x402-client re-export", () => {
     expect(expirationOffsetFor(120)).toBe(22);
-  });
-
-  it("floors at the minimum for a tiny timeout", () => {
-    expect(expirationOffsetFor(1)).toBe(3); // MIN_EXPIRATION_LEDGERS
-  });
-
-  it("respects an explicit ceiling", () => {
-    expect(expirationOffsetFor(120, 10)).toBe(10);
-  });
-
-  it("defaults to the 120s window when maxTimeoutSeconds is undefined", () => {
-    expect(expirationOffsetFor(undefined)).toBe(22);
   });
 });
 

--- a/src/x402-client.ts
+++ b/src/x402-client.ts
@@ -1,20 +1,28 @@
-// x402 client — the fetch wrapper + payment builder (smart-account path).
+// x402 client — the fetch wrapper + payment orchestration (smart-account path).
 //
 // Flow (proven in scripts/x402-spike/): request → 402 → decode requirements →
 // build SEP-41 transfer(from=C-address, to=payTo, amount) → sign the wallet auth
 // entry as V1 (via the injected signer) → retry with the `PAYMENT-SIGNATURE`
 // header → return the unlocked response + on-chain settlement.
 //
-// The PURE decision layer (decode / select / validate) lives in ./x402-guards so
-// payers that don't share this signing path can reuse it — see that file. It is
-// re-exported here so this module's public API is unchanged.
+// This module is deliberately just the orchestration layer now (#299 split it
+// into two focused pieces):
+//   - the PURE decision layer (decode / select / validate a 402 challenge)
+//     lives in ./x402-guards, so payers that don't share this signing path can
+//     reuse it — see that file. Re-exported here so this module's public API
+//     is unchanged.
+//   - the payment-BUILDING layer (simulate the transfer, derive the signature
+//     expiration, verify + sign the auth entry) lives in ./x402-payment.
+//
+// What's left here: turning `X402ClientDeps` into a `rpc.Server` + signed
+// fetch, running the guards/budget checks BEFORE a payment is built, wiring
+// the 402 → pay → retry flow, and recording settlement/spend after the
+// facilitator actually accepts a payment.
 //
 // Structural deps (rpc, an AssembledTransaction builder, fetch) keep this
 // unit-testable without a network. The signer is injected (ed25519 or passkey).
 
-import { Address, nativeToScVal, rpc, xdr } from "@stellar/stellar-sdk";
-import { AssembledTransaction } from "@stellar/stellar-sdk/contract";
-import { assertAuthEntryInvocation, type ExpectedInvocation } from "./x402-auth-entry";
+import { rpc } from "@stellar/stellar-sdk";
 import type { Network } from "./types";
 import {
   createSignedFetch,
@@ -30,14 +38,13 @@ import {
 } from "./x402-budget-attributes";
 import {
   CAIP2_BY_NETWORK,
-  NETWORKS,
   decodePaymentRequired,
   decodeSettlementHeader,
   extractRejectionReason,
   parseAmount,
   selectRequirements,
-  utf8ToBase64,
 } from "./x402-guards";
+import { buildSignedPayment, readSettlement } from "./x402-payment";
 import {
   assertValidX402RpcUrl,
   DisallowedAssetError,
@@ -55,6 +62,10 @@ import {
 
 // The pure guard layer is part of this module's published surface.
 export * from "./x402-guards";
+// The payment-building layer's public exports are part of this module's
+// published surface too, so existing imports of `expirationOffsetFor` from
+// "./x402-client" keep working unchanged.
+export { expirationOffsetFor } from "./x402-payment";
 
 /** Minimal fetch surface (injectable for tests). */
 export type FetchLike = (url: string, init?: RequestInit) => Promise<Response>;
@@ -99,47 +110,6 @@ export interface X402ClientDeps {
   now?: () => Date;
 }
 
-// Estimated ledger close time (seconds). The facilitator fetches its own estimate
-// from Horizon (~5s on testnet/pubnet); we use the same constant so our derived
-// expiration tracks its `maxLedger = current + ceil(maxTimeoutSeconds / ~5)`.
-const ESTIMATED_LEDGER_SECONDS = 5;
-// Ledgers we stay UNDER the facilitator's computed maxLedger, to absorb drift
-// between our getLatestLedger() read and the facilitator's (it reads a beat
-// later, so ITS current ledger is ≥ ours; a margin keeps us inside its window
-// even though it grants a +2 tolerance).
-const EXPIRATION_SAFETY_MARGIN = 2;
-// Never sign an expiration less than this many ledgers out, even for a tiny
-// server timeout — below this the payment can't realistically round-trip.
-const MIN_EXPIRATION_LEDGERS = 3;
-/**
- * Default ceiling on seller-requested signature lifetime (security audit V-7).
- * `maxTimeoutSeconds` is attacker-controlled and previously had no upper bound
- * here unless a caller passed `expirationLedgerOffset`. 300s / 5s = 60 ledgers,
- * less the safety margin. See the scheme client for the measurement behind 300s.
- */
-const DEFAULT_MAX_EXPIRATION_LEDGERS = 58;
-
-/**
- * Ledgers-from-now to set as the signature expiration. Derived from the server's
- * `maxTimeoutSeconds` so we stay inside the facilitator's own `maxLedger` window
- * (a fixed offset would exceed a short server timeout and be rejected as
- * `expiration_too_far`). Kept a safety margin below the facilitator's ceiling,
- * floored at MIN_EXPIRATION_LEDGERS, and optionally capped by `ceiling`.
- *
- * Exported for testing; the ceiling is the client's `expirationLedgerOffset`.
- */
-export function expirationOffsetFor(
-  maxTimeoutSeconds: number | undefined,
-  ceiling?: number,
-): number {
-  const windowLedgers = Math.ceil((maxTimeoutSeconds ?? 120) / ESTIMATED_LEDGER_SECONDS);
-  let offset = windowLedgers - EXPIRATION_SAFETY_MARGIN;
-  // An explicit ceiling still wins; absent one, fall back to the default bound
-  // rather than honouring whatever the seller asked for.
-  offset = Math.min(offset, ceiling ?? DEFAULT_MAX_EXPIRATION_LEDGERS);
-  return Math.max(offset, MIN_EXPIRATION_LEDGERS);
-}
-
 export function createX402Client(deps: X402ClientDeps): X402Client {
   // Fail here, with the actionable error, not inside rpc.Server's URL parse.
   assertValidX402RpcUrl(deps.rpcUrl);
@@ -170,90 +140,22 @@ export function createX402Client(deps: X402ClientDeps): X402Client {
     };
   }
 
-  async function buildSignedPayment(
+  async function buildPaymentFor(
     requirements: PaymentRequirements,
   ): Promise<{ header: string; amount: bigint }> {
-    const net = NETWORKS[requirements.network];
-    if (!net) throw new NoUsablePaymentOptionError(`Unknown network ${requirements.network}`);
-
     // Attribute-scoped budget check (#225) — BEFORE simulation, so an
     // out-of-budget payment never even round-trips to the RPC. Independent of
     // (checked in addition to) maxAmount / allowedAssets in createPayment.
     const budgetRequest = budgetRequestFor(requirements);
     await assertBudgetAttributes(budgetAttributes, budgetRequest, deps.budgetAttributeTracker);
 
-    // Build the SEP-41 transfer(from = C-address, to = payTo, amount).
-    const tx = await AssembledTransaction.build({
-      contractId: requirements.asset,
-      method: "transfer",
-      args: [
-        nativeToScVal(deps.signer.address, { type: "address" }),
-        nativeToScVal(requirements.payTo, { type: "address" }),
-        nativeToScVal(parseAmount(requirements.amount), { type: "i128" }),
-      ],
-      networkPassphrase: net.passphrase,
+    return buildSignedPayment(requirements, {
+      signer: deps.signer,
       rpcUrl: deps.rpcUrl,
-      publicKey: deps.simulationSourceAccount,
-      parseResultXdr: (r: unknown) => r,
+      server,
+      simulationSourceAccount: deps.simulationSourceAccount,
+      expirationCeiling,
     });
-
-    const latest = await server.getLatestLedger();
-    const expirationLedger =
-      latest.sequence + expirationOffsetFor(requirements.maxTimeoutSeconds, expirationCeiling);
-
-    if (!tx.built) {
-      throw new Error(
-        "x402: failed to build the transfer transaction (simulation returned nothing).",
-      );
-    }
-    const built = tx.built;
-
-    // What we intend to authorise. `built` came back from the RPC's simulation,
-    // so its auth entries are untrusted input until compared against this.
-    const expected: ExpectedInvocation = {
-      contract: requirements.asset,
-      functionName: "transfer",
-      from: deps.signer.address,
-      to: requirements.payTo,
-      amount: parseAmount(requirements.amount),
-    };
-
-    // Sign every wallet auth entry (V1) via the injected signer.
-    const op = built.operations[0] as { auth?: xdr.SorobanAuthorizationEntry[] };
-    const auth = op.auth ?? [];
-    let signed = 0;
-    for (let i = 0; i < auth.length; i++) {
-      const entry = auth[i]!;
-      if (entry.credentials().switch().name !== "sorobanCredentialsAddress") continue;
-      const addr = Address.fromScAddress(entry.credentials().address().address()).toString();
-      if (addr !== deps.signer.address) continue;
-
-      // Security audit V-1. The credential address only establishes that the
-      // entry is ours to sign; this establishes WHAT it does. Predates the
-      // smart-account work — the classic path has always had this gap.
-      assertAuthEntryInvocation(entry, expected);
-
-      const signedXdr = await deps.signer.signAuthEntry(entry.toXDR("base64"), {
-        networkPassphrase: net.passphrase,
-        expirationLedger,
-      });
-      auth[i] = xdr.SorobanAuthorizationEntry.fromXDR(signedXdr, "base64");
-      signed++;
-    }
-    if (signed === 0) {
-      throw new Error("No wallet auth entry found to sign for the payer address.");
-    }
-    op.auth = auth;
-
-    const payload = {
-      x402Version: 2,
-      accepted: requirements,
-      payload: { transaction: built.toXDR() },
-    };
-    return {
-      header: utf8ToBase64(JSON.stringify(payload)),
-      amount: parseAmount(requirements.amount),
-    };
   }
 
   async function createPayment(
@@ -269,7 +171,7 @@ export function createX402Client(deps: X402ClientDeps): X402Client {
     if (required > opts.maxAmount) {
       throw new MaxAmountExceededError(required, opts.maxAmount, requirements.asset);
     }
-    const { header, amount } = await buildSignedPayment(requirements);
+    const { header, amount } = await buildPaymentFor(requirements);
     return { header, requirements, amount };
   }
 
@@ -298,7 +200,7 @@ export function createX402Client(deps: X402ClientDeps): X402Client {
 
     const decoded = decodePaymentRequired(first);
     const requirements = selectRequirements(decoded, init, ourCaip2);
-    const { header, amount } = await buildSignedPayment(requirements);
+    const { header, amount } = await buildPaymentFor(requirements);
 
     const paid = await doFetch(url, {
       ...baseInit,
@@ -314,7 +216,12 @@ export function createX402Client(deps: X402ClientDeps): X402Client {
       );
     }
 
-    const settlement = readSettlement(paid, requirements, amount, deps.network);
+    const settlement = readSettlement(
+      decodeSettlementHeader(paid),
+      requirements,
+      amount,
+      deps.network,
+    );
 
     // Record spend only now that the facilitator has actually accepted the
     // payment — a request rejected above (over-budget on-chain, or any other
@@ -330,21 +237,4 @@ export function createX402Client(deps: X402ClientDeps): X402Client {
   }
 
   return { fetch: x402Fetch, createPayment };
-}
-
-function readSettlement(
-  res: Response,
-  requirements: PaymentRequirements,
-  amount: bigint,
-  network: Network,
-): X402Response["settlement"] {
-  const decoded = decodeSettlementHeader(res);
-  if (!decoded) return undefined;
-  return {
-    transaction: decoded.transaction,
-    payer: decoded.payer ?? requirements.payTo,
-    asset: requirements.asset,
-    amount,
-    network,
-  };
 }

--- a/src/x402-payment.test.ts
+++ b/src/x402-payment.test.ts
@@ -1,0 +1,60 @@
+// Module-level tests for ./x402-payment — the payment-building/signing layer
+// split out of ./x402-client (#299).
+//
+// `expirationOffsetFor`'s derivation math lived in x402-client.test.ts before
+// the split; it moves here with the function. `buildSignedPayment`'s own
+// wiring (guard-before-signing, budget checks) stays covered end-to-end via
+// x402-client.test.ts, since that's the orchestration this module doesn't own —
+// what belongs here is this module's own error paths.
+
+import { rpc } from "@stellar/stellar-sdk";
+import { describe, expect, it } from "vitest";
+import { expirationOffsetFor, buildSignedPayment } from "./x402-payment";
+import { NoUsablePaymentOptionError, type SmartAccountX402Signer } from "./x402-types";
+import { C_ADDRESS, SIM_SOURCE, requirements } from "./x402-test-fixtures";
+
+describe("expirationOffsetFor — derived from maxTimeoutSeconds (bug #5)", () => {
+  it("derives a SHORT expiration for a short server timeout (no fixed +12)", () => {
+    // 30s window ≈ 6 ledgers; minus the safety margin (2) = 4. A fixed +12 would
+    // exceed the facilitator's ~6-ledger maxLedger and be rejected.
+    expect(expirationOffsetFor(30)).toBe(4);
+  });
+
+  it("derives a wider expiration for a long timeout", () => {
+    // 120s ≈ 24 ledgers − 2 = 22.
+    expect(expirationOffsetFor(120)).toBe(22);
+  });
+
+  it("floors at the minimum for a tiny timeout", () => {
+    expect(expirationOffsetFor(1)).toBe(3); // MIN_EXPIRATION_LEDGERS
+  });
+
+  it("respects an explicit ceiling", () => {
+    expect(expirationOffsetFor(120, 10)).toBe(10);
+  });
+
+  it("defaults to the 120s window when maxTimeoutSeconds is undefined", () => {
+    expect(expirationOffsetFor(undefined)).toBe(22);
+  });
+});
+
+const stubSigner: SmartAccountX402Signer = {
+  address: C_ADDRESS,
+  async signAuthEntry() {
+    throw new Error("signer should not have been called");
+  },
+};
+
+describe("buildSignedPayment — unknown network", () => {
+  it("throws NoUsablePaymentOptionError for a network not in NETWORKS, before touching RPC", async () => {
+    const server = new rpc.Server("https://rpc.invalid.example");
+    await expect(
+      buildSignedPayment(requirements({ network: "eip155:1" }), {
+        signer: stubSigner,
+        rpcUrl: "https://rpc.invalid.example",
+        server,
+        simulationSourceAccount: SIM_SOURCE,
+      }),
+    ).rejects.toBeInstanceOf(NoUsablePaymentOptionError);
+  });
+});

--- a/src/x402-payment.ts
+++ b/src/x402-payment.ts
@@ -1,0 +1,178 @@
+// x402 payment submission — builds and signs the SEP-41 transfer that satisfies
+// a decoded x402 payment requirement.
+//
+// Split out of ./x402-client (#299): that module now owns orchestration (the
+// fetch/retry flow, budget-attribute wiring, settlement reading) while this one
+// owns the actual "turn PaymentRequirements into a signed PAYMENT-SIGNATURE
+// header" step — simulate the transfer, derive a signature-expiration ledger
+// from the server's timeout, verify the auth entry says what we think it says,
+// and sign it with the injected smart-account signer.
+//
+// Pairs with ./x402-guards (the pure decode/select layer) — together they are
+// the module split this issue asks for: discovery (guards) vs. payment
+// submission (this file). ./x402-client composes both plus the signer/RPC deps
+// into the public X402Client.
+
+import { Address, nativeToScVal, rpc, xdr } from "@stellar/stellar-sdk";
+import { AssembledTransaction } from "@stellar/stellar-sdk/contract";
+import { assertAuthEntryInvocation, type ExpectedInvocation } from "./x402-auth-entry";
+import type { Network } from "./types";
+import { NETWORKS, parseAmount, utf8ToBase64 } from "./x402-guards";
+import { NoUsablePaymentOptionError, type PaymentRequirements, type SmartAccountX402Signer } from "./x402-types";
+
+// Estimated ledger close time (seconds). The facilitator fetches its own estimate
+// from Horizon (~5s on testnet/pubnet); we use the same constant so our derived
+// expiration tracks its `maxLedger = current + ceil(maxTimeoutSeconds / ~5)`.
+const ESTIMATED_LEDGER_SECONDS = 5;
+// Ledgers we stay UNDER the facilitator's computed maxLedger, to absorb drift
+// between our getLatestLedger() read and the facilitator's (it reads a beat
+// later, so ITS current ledger is ≥ ours; a margin keeps us inside its window
+// even though it grants a +2 tolerance).
+const EXPIRATION_SAFETY_MARGIN = 2;
+// Never sign an expiration less than this many ledgers out, even for a tiny
+// server timeout — below this the payment can't realistically round-trip.
+const MIN_EXPIRATION_LEDGERS = 3;
+/**
+ * Default ceiling on seller-requested signature lifetime (security audit V-7).
+ * `maxTimeoutSeconds` is attacker-controlled and previously had no upper bound
+ * here unless a caller passed `expirationLedgerOffset`. 300s / 5s = 60 ledgers,
+ * less the safety margin. See the scheme client for the measurement behind 300s.
+ */
+const DEFAULT_MAX_EXPIRATION_LEDGERS = 58;
+
+/**
+ * Ledgers-from-now to set as the signature expiration. Derived from the server's
+ * `maxTimeoutSeconds` so we stay inside the facilitator's own `maxLedger` window
+ * (a fixed offset would exceed a short server timeout and be rejected as
+ * `expiration_too_far`). Kept a safety margin below the facilitator's ceiling,
+ * floored at MIN_EXPIRATION_LEDGERS, and optionally capped by `ceiling`.
+ *
+ * Exported for testing; the ceiling is the client's `expirationLedgerOffset`.
+ */
+export function expirationOffsetFor(
+  maxTimeoutSeconds: number | undefined,
+  ceiling?: number,
+): number {
+  const windowLedgers = Math.ceil((maxTimeoutSeconds ?? 120) / ESTIMATED_LEDGER_SECONDS);
+  let offset = windowLedgers - EXPIRATION_SAFETY_MARGIN;
+  // An explicit ceiling still wins; absent one, fall back to the default bound
+  // rather than honouring whatever the seller asked for.
+  offset = Math.min(offset, ceiling ?? DEFAULT_MAX_EXPIRATION_LEDGERS);
+  return Math.max(offset, MIN_EXPIRATION_LEDGERS);
+}
+
+/** Deps a payment build needs from the client — RPC access and the signer. */
+export interface BuildSignedPaymentDeps {
+  signer: SmartAccountX402Signer;
+  rpcUrl: string;
+  server: rpc.Server;
+  simulationSourceAccount: string;
+  /** Hard ceiling on the derived expiration offset (undefined ⇒ no ceiling). */
+  expirationCeiling?: number;
+}
+
+/**
+ * Build and sign the SEP-41 transfer for `requirements`, returning the
+ * base64 `PAYMENT-SIGNATURE` header value and the amount that will be paid.
+ *
+ * Callers (./x402-client) are expected to have already run the guard checks
+ * (maxAmount, allowedAssets, budget attributes) — this function does not
+ * re-check them; it only builds, simulates, and signs.
+ */
+export async function buildSignedPayment(
+  requirements: PaymentRequirements,
+  deps: BuildSignedPaymentDeps,
+): Promise<{ header: string; amount: bigint }> {
+  const net = NETWORKS[requirements.network];
+  if (!net) throw new NoUsablePaymentOptionError(`Unknown network ${requirements.network}`);
+
+  // Build the SEP-41 transfer(from = C-address, to = payTo, amount).
+  const tx = await AssembledTransaction.build({
+    contractId: requirements.asset,
+    method: "transfer",
+    args: [
+      nativeToScVal(deps.signer.address, { type: "address" }),
+      nativeToScVal(requirements.payTo, { type: "address" }),
+      nativeToScVal(parseAmount(requirements.amount), { type: "i128" }),
+    ],
+    networkPassphrase: net.passphrase,
+    rpcUrl: deps.rpcUrl,
+    publicKey: deps.simulationSourceAccount,
+    parseResultXdr: (r: unknown) => r,
+  });
+
+  const latest = await deps.server.getLatestLedger();
+  const expirationLedger =
+    latest.sequence + expirationOffsetFor(requirements.maxTimeoutSeconds, deps.expirationCeiling);
+
+  if (!tx.built) {
+    throw new Error(
+      "x402: failed to build the transfer transaction (simulation returned nothing).",
+    );
+  }
+  const built = tx.built;
+
+  // What we intend to authorise. `built` came back from the RPC's simulation,
+  // so its auth entries are untrusted input until compared against this.
+  const expected: ExpectedInvocation = {
+    contract: requirements.asset,
+    functionName: "transfer",
+    from: deps.signer.address,
+    to: requirements.payTo,
+    amount: parseAmount(requirements.amount),
+  };
+
+  // Sign every wallet auth entry (V1) via the injected signer.
+  const op = built.operations[0] as { auth?: xdr.SorobanAuthorizationEntry[] };
+  const auth = op.auth ?? [];
+  let signed = 0;
+  for (let i = 0; i < auth.length; i++) {
+    const entry = auth[i]!;
+    if (entry.credentials().switch().name !== "sorobanCredentialsAddress") continue;
+    const addr = Address.fromScAddress(entry.credentials().address().address()).toString();
+    if (addr !== deps.signer.address) continue;
+
+    // Security audit V-1. The credential address only establishes that the
+    // entry is ours to sign; this establishes WHAT it does. Predates the
+    // smart-account work — the classic path has always had this gap.
+    assertAuthEntryInvocation(entry, expected);
+
+    const signedXdr = await deps.signer.signAuthEntry(entry.toXDR("base64"), {
+      networkPassphrase: net.passphrase,
+      expirationLedger,
+    });
+    auth[i] = xdr.SorobanAuthorizationEntry.fromXDR(signedXdr, "base64");
+    signed++;
+  }
+  if (signed === 0) {
+    throw new Error("No wallet auth entry found to sign for the payer address.");
+  }
+  op.auth = auth;
+
+  const payload = {
+    x402Version: 2,
+    accepted: requirements,
+    payload: { transaction: built.toXDR() },
+  };
+  return {
+    header: utf8ToBase64(JSON.stringify(payload)),
+    amount: parseAmount(requirements.amount),
+  };
+}
+
+/** Build the `X402Settlement` shape from a paid response's settlement header. */
+export function readSettlement(
+  decoded: { transaction: string; payer?: string } | undefined,
+  requirements: PaymentRequirements,
+  amount: bigint,
+  network: Network,
+): { transaction: string; payer: string; asset: string; amount: bigint; network: Network } | undefined {
+  if (!decoded) return undefined;
+  return {
+    transaction: decoded.transaction,
+    payer: decoded.payer ?? requirements.payTo,
+    asset: requirements.asset,
+    amount,
+    network,
+  };
+}


### PR DESCRIPTION
closes #299

## Summary

x402-client.ts mixed two concerns: request/retry orchestration and the actual payment-building/signing logic (simulate the SEP-41 transfer, derive the signature expiration ledger, verify the auth entry invocation, sign it with the injected signer). This splits the payment-building piece into a new `src/x402-payment.ts` module.

The pure discovery layer (decode a 402, select the usable requirement, parse amounts) already lived in `src/x402-guards.ts` prior to this PR and needed no changes — it is the "discovery" half of the split this issue asks for. This PR is the "payment submission" half.

## What moved

- `expirationOffsetFor` — the ledger-expiration derivation math
- `buildSignedPayment` — build the transfer via `AssembledTransaction`, verify the auth entry against the expected invocation, sign it
- `readSettlement` — shape a decoded settlement header into `X402Settlement`

`x402-client.ts` is left owning: `createX402Client`'s wiring, the budget-attribute checks that must run before a payment is built, the `fetch`/retry flow, and settlement/spend recording after the facilitator accepts a payment.

## Compatibility

- `x402-client.ts` re-exports `expirationOffsetFor` (and, as before, everything from `x402-guards`), so existing imports from `"./x402-client"` are unaffected.
- No behavior changes — this is a pure extraction. `buildSignedPayment` takes the same inputs it did as a closure inside `createX402Client`, now as an explicit `deps` argument.

## Tests

- All existing `x402-client.test.ts` and `x402-guards.test.ts` tests pass unchanged (assertions untouched).
- Added `src/x402-payment.test.ts` with module-level tests for the newly extracted module, including moving the `expirationOffsetFor` derivation tests there from `x402-client.test.ts` (next to the function's new home) and a new test for the unknown-network error path.
- `npm test`, `npm run typecheck`, and `npm run build` all show the same pre-existing, unrelated failures as an unmodified checkout of `dev` (a `tx-rpc.ts` DTS/typecheck issue and a handful of contrib WebAuthn-environment test failures) — nothing new introduced by this change.

## Test plan

- [x] `npx vitest run src/x402-client.test.ts src/x402-payment.test.ts src/x402-guards.test.ts src/x402-facade.test.ts` — all pass
- [x] `npm run typecheck` — no new errors vs. base `dev`
- [x] `npm run build` — no new errors vs. base `dev`