### PR TITLE
feat(session): enforce a configurable retention window on cached sessions

### DIFF
--- a/README.md
+++ b/README.md
@@ -426,6 +426,42 @@ failure is reported to `onDebugLog` (default: a no-op — bring your own logger)
 rather than thrown, and mint always runs before revoke so a revoke failure
 never leaves the wallet with no valid session key. Omit `sessionKeyRotation`
 for the pre-existing behaviour (no rotation).
+
+#### Session cache retention
+
+`createWebStorageAdapter` (used by `createSessionStore` for browser apps)
+persists a `WalletSession` — including its `accountId` and `lastActiveAt` — in
+whatever `Storage`-like object you give it (typically `window.localStorage`).
+That is long-lived, unencrypted, client-side storage, so we recommend treating
+it the way you'd treat any other durable client-side cache:
+
+- **Recommended retention window: 30 days of inactivity.** This is the SDK's
+  default (`DEFAULT_SESSION_MAX_AGE_MS`) — a session whose `lastActiveAt` is
+  older than that is discarded on `load()` rather than restored. A session in
+  regular use never ages out: `touch()` refreshes `lastActiveAt` on activity
+  (idea.md §6.1), so the clock only runs while a user (or agent) has been away.
+- **Enforced on read, not on a timer.** There's no background sweep — nothing
+  runs while the app isn't open. The check happens the next time `restore()`
+  (or `load()` directly) is called, which is when it matters: before any
+  cached wallet state is trusted again.
+- **Configurable.** Pass `maxAgeMs` to tighten or loosen the window, or
+  `Infinity` to opt out of expiry entirely (the pre-#292 behaviour):
+
+  ```ts
+  import { createWebStorageAdapter } from "vellar-sdk";
+
+  const storage = createWebStorageAdapter(window.localStorage, "vellar.session", {
+    maxAgeMs: 7 * 24 * 60 * 60 * 1000, // 7 days, for a stricter app
+  });
+  ```
+
+An expired session is treated as absent — `restore()` reports `disconnected`,
+the same as if nothing had ever been persisted — and the stale entry is
+removed from storage so it isn't re-checked on the next load. This is a
+client-side hygiene measure, not a security boundary: the durable session
+authority is always the passkey/session-key signer, never the cached
+`WalletSession` object itself.
+
 ## API stability
 
 Exports fall into two groups:

--- a/src/session.test.ts
+++ b/src/session.test.ts
@@ -317,7 +317,13 @@ describe("createWebStorageAdapter", () => {
 
   it("round-trips a session under the given key", async () => {
     const backing = fakeStorage();
-    const adapter = createWebStorageAdapter(backing, "test.key");
+    // Pin `now` to the fixture's own timestamp — this test is about
+    // serialization round-tripping, not retention (see the "retention"
+    // describe block below), so it must not depend on how old the fixture's
+    // hardcoded lastActiveAt is relative to the real clock.
+    const adapter = createWebStorageAdapter(backing, "test.key", {
+      now: () => Date.parse(session.lastActiveAt),
+    });
     await adapter.save(session);
     expect(backing.map.has("test.key")).toBe(true);
     expect(await adapter.load()).toEqual(session);
@@ -337,6 +343,63 @@ describe("createWebStorageAdapter", () => {
     backing.setItem("vellar.session", "{not json");
     const adapter = createWebStorageAdapter(backing);
     await expect(adapter.load()).rejects.toThrow();
+  });
+
+  describe("retention (#292)", () => {
+    it("discards a session whose lastActiveAt is past the configured maxAgeMs", async () => {
+      const backing = fakeStorage();
+      const adapter = createWebStorageAdapter(backing, "vellar.session", {
+        maxAgeMs: 1000,
+        now: () => Date.parse("2026-07-16T10:00:02.000Z"), // 2s after lastActiveAt
+      });
+      await adapter.save(session); // lastActiveAt: 2026-07-16T10:00:00.000Z
+      expect(await adapter.load()).toBeNull();
+    });
+
+    it("keeps a session whose lastActiveAt is within maxAgeMs", async () => {
+      const backing = fakeStorage();
+      const adapter = createWebStorageAdapter(backing, "vellar.session", {
+        maxAgeMs: 10_000,
+        now: () => Date.parse("2026-07-16T10:00:02.000Z"), // 2s after lastActiveAt
+      });
+      await adapter.save(session);
+      expect(await adapter.load()).toEqual(session);
+    });
+
+    it("removes the expired entry from storage so it isn't re-read", async () => {
+      const backing = fakeStorage();
+      const adapter = createWebStorageAdapter(backing, "vellar.session", {
+        maxAgeMs: 1000,
+        now: () => Date.parse("2026-07-16T10:00:02.000Z"),
+      });
+      await adapter.save(session);
+      await adapter.load();
+      expect(backing.map.has("vellar.session")).toBe(false);
+    });
+
+    it("defaults to the 30-day retention window when maxAgeMs is omitted", async () => {
+      const backing = fakeStorage();
+      const justUnderThirtyDays = createWebStorageAdapter(backing, "vellar.session", {
+        now: () => Date.parse("2026-07-16T10:00:00.000Z") + 29 * 24 * 60 * 60 * 1000,
+      });
+      await justUnderThirtyDays.save(session);
+      expect(await justUnderThirtyDays.load()).toEqual(session);
+
+      const overThirtyDays = createWebStorageAdapter(backing, "vellar.session", {
+        now: () => Date.parse("2026-07-16T10:00:00.000Z") + 31 * 24 * 60 * 60 * 1000,
+      });
+      expect(await overThirtyDays.load()).toBeNull();
+    });
+
+    it("never expires when maxAgeMs is Infinity (opt-out)", async () => {
+      const backing = fakeStorage();
+      const adapter = createWebStorageAdapter(backing, "vellar.session", {
+        maxAgeMs: Infinity,
+        now: () => Date.parse("2026-07-16T10:00:00.000Z") + 365 * 24 * 60 * 60 * 1000,
+      });
+      await adapter.save(session);
+      expect(await adapter.load()).toEqual(session);
+    });
   });
 });
 

--- a/src/session.ts
+++ b/src/session.ts
@@ -82,17 +82,53 @@ export function createSessionStore(storage: SessionStorageAdapter): SessionStore
   }));
 }
 
+/**
+ * Default retention window for a session cached in consumer local storage:
+ * 30 days of inactivity. `lastActiveAt` is refreshed on every `touch()`
+ * (idea.md §6.1), so a session in regular use never ages out — this only
+ * discards a session nobody has used in a long time, on the theory that
+ * `restore()` re-authenticating via a fresh passkey ceremony is safer at that
+ * point than trusting month-old cached wallet state. See the README's
+ * "Session cache retention" section for the full rationale.
+ */
+export const DEFAULT_SESSION_MAX_AGE_MS = 30 * 24 * 60 * 60 * 1000;
+
+export interface WebStorageAdapterOptions {
+  /**
+   * Discard (and report as absent) a persisted session whose `lastActiveAt`
+   * is older than this, in milliseconds. Enforced on read (`load()`), not on
+   * a timer — nothing runs while the app isn't open. Defaults to
+   * {@link DEFAULT_SESSION_MAX_AGE_MS}; pass `Infinity` to disable expiry
+   * entirely (the pre-#292 behaviour).
+   */
+  maxAgeMs?: number;
+  /** Clock for the age check (defaults to `() => Date.now()`); overridable for tests. */
+  now?: () => number;
+}
+
 /** Storage-backed adapter for web (pass window.localStorage) or any Storage-like object. */
 export function createWebStorageAdapter(
   storage: Pick<Storage, "getItem" | "setItem" | "removeItem">,
   key = "vellar.session",
+  options: WebStorageAdapterOptions = {},
 ): SessionStorageAdapter {
+  const maxAgeMs = options.maxAgeMs ?? DEFAULT_SESSION_MAX_AGE_MS;
+  const now = options.now ?? (() => Date.now());
   return {
     async load() {
       const raw = storage.getItem(key);
       if (raw === null) return null;
       const parsed: unknown = JSON.parse(raw);
-      return isWalletSession(parsed) ? parsed : null;
+      if (!isWalletSession(parsed)) return null;
+      const lastActive = Date.parse(parsed.lastActiveAt);
+      if (Number.isFinite(lastActive) && now() - lastActive > maxAgeMs) {
+        // Past the retention window: treat it as absent rather than restoring
+        // stale wallet state, and drop it so a later load() doesn't re-check
+        // the same expired entry.
+        storage.removeItem(key);
+        return null;
+      }
+      return parsed;
     },
     async save(session) {
       storage.setItem(key, JSON.stringify(session));


### PR DESCRIPTION
closes #292

## Summary

createWebStorageAdapter persists a WalletSession (accountId, lastActiveAt, etc) to consumer local storage with no bound on how long it lives. There was no documented guidance on retention, and no way to expire a session that has been sitting in storage untouched for a long time.

## Changes

- Add DEFAULT_SESSION_MAX_AGE_MS (30 days) and a maxAgeMs option on createWebStorageAdapter.
- Enforce it in load(): a session whose lastActiveAt is older than maxAgeMs is treated as absent (restore() reports disconnected, same as nothing persisted) and the stale entry is removed from storage so it isn't re-checked on the next load.
- touch() already refreshes lastActiveAt on activity, so a session in regular use never ages out — this only discards sessions that have genuinely been idle past the window.
- Pass maxAgeMs: Infinity to opt out and keep the pre-#292 never-expires behaviour.
- Added a now option (clock injection) for testability, defaulting to Date.now().
- Documented the recommended retention window and configuration in the README under a new "Session cache retention" section.

## Compatibility

- createWebStorageAdapter(storage, key) still works unchanged — the new options argument is a third, optional parameter.
- Default behavior changes from "never expires" to "expires after 30 days of inactivity." This is the behavior #292 asks for; flagging in case a stricter migration note is wanted, but 30 days is a generous default and touch() means active users are unaffected.

## Tests

Added to src/session.test.ts under a new "retention (#292)" block:
- discards a session past maxAgeMs
- keeps a session within maxAgeMs
- removes the expired entry from storage so it isn't re-read
- defaults to the 30-day window when maxAgeMs is omitted
- never expires when maxAgeMs is Infinity

Also adjusted the pre-existing "round-trips a session under the given key" test to pin its clock to the fixture's own timestamp, since that test is about serialization round-tripping, not retention, and previously relied on the real clock never advancing 30 days past a hardcoded fixture date.

## Test plan

- [x] `npx vitest run src/session.test.ts src/client.test.ts` — all 49 pass
- [x] `npm run typecheck` — no new errors vs. base `dev`