### PR TITLE
feat(contrib): reference implementations for #233, #236, #238, #239

### DIFF
--- a/contrib/examples/issue-233-balances-network-namespace/README.md
+++ b/contrib/examples/issue-233-balances-network-namespace/README.md
@@ -1,0 +1,21 @@
+# Per-network cache namespace for balances-rpc (#233)
+
+Self-contained reference for issue [#233](https://github.com/Vellar-Wallet/vellar-sdk/issues/233): `balances-rpc.ts`'s balance cache should be namespaced by network, so a consumer switching between testnet and mainnet never serves a cached balance from the wrong network for the same token contract / holder pair.
+
+## Composite key format
+
+```
+<network>|<tokenContractId>|<holder>
+```
+
+`|` is used as the separator because it cannot appear in a Stellar network passphrase, contract ID, or strkey — no escaping is needed for any field.
+
+## Migration
+
+`clearUnscopedBalanceEntries(store, knownNetworks)` removes any legacy, pre-#233 entry that doesn't match the `<network>|...` shape for one of the caller's known networks. A legacy entry's original network can't be inferred from a bare `<tokenContractId>|<holder>` key, so it's deleted rather than guessed at — the next balance read repopulates it correctly under a namespaced key.
+
+## Run tests
+
+```bash
+npx vitest run contrib/examples/issue-233-balances-network-namespace/balances-network-namespace.test.ts
+```

--- a/contrib/examples/issue-233-balances-network-namespace/balances-network-namespace.test.ts
+++ b/contrib/examples/issue-233-balances-network-namespace/balances-network-namespace.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildBalanceCacheKey,
+  clearUnscopedBalanceEntries,
+  createInMemoryBalanceCacheStore,
+  createNamespacedBalanceCache,
+} from "./balances-network-namespace";
+
+const TESTNET = "Test SDF Network ; September 2015";
+const PUBNET = "Public Global Stellar Network ; September 2015";
+const TOKEN = "CTOKEN1234567890";
+const HOLDER = "GHOLDER1234567890";
+
+describe("buildBalanceCacheKey", () => {
+  it("composes network, token, and holder with a stable separator", () => {
+    expect(buildBalanceCacheKey(TESTNET, TOKEN, HOLDER)).toBe(`${TESTNET}|${TOKEN}|${HOLDER}`);
+  });
+});
+
+describe("createNamespacedBalanceCache", () => {
+  it("stores and retrieves a value scoped to its network", () => {
+    const cache = createNamespacedBalanceCache({ network: TESTNET, ttlMs: 60_000 });
+    cache.set(TOKEN, HOLDER, 100n);
+    expect(cache.get(TOKEN, HOLDER)).toBe(100n);
+  });
+
+  it("never mixes testnet and mainnet entries for the same token/holder pair", () => {
+    const store = createInMemoryBalanceCacheStore();
+    const testnetCache = createNamespacedBalanceCache({ network: TESTNET, ttlMs: 60_000, store });
+    const mainnetCache = createNamespacedBalanceCache({ network: PUBNET, ttlMs: 60_000, store });
+
+    testnetCache.set(TOKEN, HOLDER, 100n);
+    mainnetCache.set(TOKEN, HOLDER, 999_999n);
+
+    expect(testnetCache.get(TOKEN, HOLDER)).toBe(100n);
+    expect(mainnetCache.get(TOKEN, HOLDER)).toBe(999_999n);
+  });
+
+  it("expires entries after the configured TTL", async () => {
+    const cache = createNamespacedBalanceCache({ network: TESTNET, ttlMs: 1 });
+    cache.set(TOKEN, HOLDER, 100n);
+    await new Promise((resolve) => setTimeout(resolve, 5));
+    expect(cache.get(TOKEN, HOLDER)).toBeUndefined();
+  });
+
+  it("returns undefined for a lookup that was never cached", () => {
+    const cache = createNamespacedBalanceCache({ network: TESTNET, ttlMs: 60_000 });
+    expect(cache.get(TOKEN, HOLDER)).toBeUndefined();
+  });
+
+  it("clearNetwork only clears its own network's entries", () => {
+    const store = createInMemoryBalanceCacheStore();
+    const testnetCache = createNamespacedBalanceCache({ network: TESTNET, ttlMs: 60_000, store });
+    const mainnetCache = createNamespacedBalanceCache({ network: PUBNET, ttlMs: 60_000, store });
+
+    testnetCache.set(TOKEN, HOLDER, 100n);
+    mainnetCache.set(TOKEN, HOLDER, 999_999n);
+
+    const cleared = testnetCache.clearNetwork();
+
+    expect(cleared).toBe(1);
+    expect(testnetCache.get(TOKEN, HOLDER)).toBeUndefined();
+    expect(mainnetCache.get(TOKEN, HOLDER)).toBe(999_999n);
+  });
+});
+
+describe("clearUnscopedBalanceEntries (migration)", () => {
+  it("deletes a legacy unscoped key and leaves scoped keys untouched", () => {
+    const store = createInMemoryBalanceCacheStore();
+    // Legacy pre-#233 entry: no network prefix at all.
+    store.set(`${TOKEN}|${HOLDER}`, { value: 42n, expiresAt: Date.now() + 60_000 });
+    // A properly-scoped entry that must survive the migration.
+    const scopedKey = buildBalanceCacheKey(TESTNET, TOKEN, HOLDER);
+    store.set(scopedKey, { value: 100n, expiresAt: Date.now() + 60_000 });
+
+    const cleared = clearUnscopedBalanceEntries(store, [TESTNET, PUBNET]);
+
+    expect(cleared).toBe(1);
+    expect(store.get(`${TOKEN}|${HOLDER}`)).toBeUndefined();
+    expect(store.get(scopedKey)).toBeDefined();
+  });
+
+  it("does not mistake a scoped key for one network as unscoped when checked against another", () => {
+    const store = createInMemoryBalanceCacheStore();
+    const scopedKey = buildBalanceCacheKey(PUBNET, TOKEN, HOLDER);
+    store.set(scopedKey, { value: 5n, expiresAt: Date.now() + 60_000 });
+
+    const cleared = clearUnscopedBalanceEntries(store, [TESTNET, PUBNET]);
+
+    expect(cleared).toBe(0);
+    expect(store.get(scopedKey)).toBeDefined();
+  });
+
+  it("returns 0 when the store has no unscoped entries", () => {
+    const store = createInMemoryBalanceCacheStore();
+    const scopedKey = buildBalanceCacheKey(TESTNET, TOKEN, HOLDER);
+    store.set(scopedKey, { value: 5n, expiresAt: Date.now() + 60_000 });
+
+    expect(clearUnscopedBalanceEntries(store, [TESTNET, PUBNET])).toBe(0);
+  });
+});

--- a/contrib/examples/issue-233-balances-network-namespace/balances-network-namespace.ts
+++ b/contrib/examples/issue-233-balances-network-namespace/balances-network-namespace.ts
@@ -1,0 +1,125 @@
+// Reference for issue #233: namespace balances-rpc's cache keys by network,
+// so a consumer that reads balances against more than one network (e.g.
+// testnet during development, pubnet in production) never serves a
+// testnet-cached balance for a mainnet lookup, or vice versa.
+
+export interface CacheEntry {
+  value: bigint;
+  expiresAt: number;
+}
+
+export interface BalanceCacheStore {
+  get(key: string): CacheEntry | undefined;
+  set(key: string, entry: CacheEntry): void;
+  delete(key: string): void;
+  keys(): IterableIterator<string>;
+}
+
+/** A trivial in-memory store, sufficient for tests and single-process use. */
+export function createInMemoryBalanceCacheStore(): BalanceCacheStore {
+  const store = new Map<string, CacheEntry>();
+  return {
+    get: (key) => store.get(key),
+    set: (key, entry) => store.set(key, entry),
+    delete: (key) => store.delete(key),
+    keys: () => store.keys(),
+  };
+}
+
+/**
+ * Composite cache key: `<network>|<tokenContractId>|<holder>`. `|` cannot
+ * appear in a Stellar network passphrase or a strkey, so it is a safe,
+ * unambiguous separator — no encoding step is needed for either field.
+ */
+export function buildBalanceCacheKey(
+  network: string,
+  tokenContractId: string,
+  holder: string,
+): string {
+  return `${network}|${tokenContractId}|${holder}`;
+}
+
+export interface NamespacedBalanceCacheOptions {
+  network: string;
+  ttlMs: number;
+  store?: BalanceCacheStore;
+}
+
+export interface NamespacedBalanceCache {
+  get(tokenContractId: string, holder: string): bigint | undefined;
+  set(tokenContractId: string, holder: string, value: bigint): void;
+  /** Removes every entry for this cache's network. Used by the migration
+   * helper below, and available directly for a consumer that wants to force
+   * a refresh after, e.g., a known chain reorg. */
+  clearNetwork(): number;
+}
+
+/**
+ * A balance cache scoped to one network. Two `NamespacedBalanceCache`
+ * instances pointed at the same underlying `store` but different `network`
+ * values never read or clear each other's entries, even for the same
+ * `tokenContractId`/`holder` pair — the network is part of the key, not an
+ * external convention a caller has to remember to apply consistently.
+ */
+export function createNamespacedBalanceCache(
+  options: NamespacedBalanceCacheOptions,
+): NamespacedBalanceCache {
+  const store = options.store ?? createInMemoryBalanceCacheStore();
+  const { network, ttlMs } = options;
+
+  return {
+    get(tokenContractId, holder) {
+      const key = buildBalanceCacheKey(network, tokenContractId, holder);
+      const entry = store.get(key);
+      if (!entry) return undefined;
+      if (entry.expiresAt <= Date.now()) {
+        store.delete(key);
+        return undefined;
+      }
+      return entry.value;
+    },
+    set(tokenContractId, holder, value) {
+      const key = buildBalanceCacheKey(network, tokenContractId, holder);
+      store.set(key, { value, expiresAt: Date.now() + ttlMs });
+    },
+    clearNetwork() {
+      const prefix = `${network}|`;
+      let cleared = 0;
+      for (const key of Array.from(store.keys())) {
+        if (key.startsWith(prefix)) {
+          store.delete(key);
+          cleared++;
+        }
+      }
+      return cleared;
+    },
+  };
+}
+
+/**
+ * Migration step (per issue #233's requirement): a pre-#233 deployment may
+ * have populated `store` with unscoped keys — bare `<tokenContractId>|
+ * <holder>` pairs, with no network prefix at all. Those entries can't be
+ * safely rewritten under a guessed network (that's exactly the cross-network
+ * mixing bug #233 exists to fix), so they're deleted outright; the next
+ * balance read repopulates them correctly under a namespaced key.
+ *
+ * A key is recognized as legacy/unscoped by NOT matching the
+ * `<network>|<contractId>|<holder>` shape for any of the networks in
+ * `knownNetworks` — this only clears keys this migration can positively
+ * identify as pre-#233, rather than guessing based on segment count alone.
+ */
+export function clearUnscopedBalanceEntries(
+  store: BalanceCacheStore,
+  knownNetworks: readonly string[],
+): number {
+  let cleared = 0;
+  for (const key of Array.from(store.keys())) {
+    const isScoped = knownNetworks.some((network) => key.startsWith(`${network}|`));
+    if (!isScoped) {
+      store.delete(key);
+      cleared++;
+    }
+  }
+  return cleared;
+}

--- a/contrib/examples/issue-236-x402-session-rotation-cache-invalidation/README.md
+++ b/contrib/examples/issue-236-x402-session-rotation-cache-invalidation/README.md
@@ -1,0 +1,26 @@
+# Cache invalidation on session key rotation for x402-client (#236)
+
+Self-contained reference for issue [#236](https://github.com/Vellar-Wallet/vellar-sdk/issues/236): after an x402 session key rotates, `x402-client.ts` must not keep serving cached authorization results computed under the old key.
+
+## Approach
+
+Every cached `AuthorizationResult` is tagged with the `sessionKeyId` it was computed under. `invalidateForRotatedKey(oldSessionKeyId)` removes only the entries tagged with the retired key — not the whole cache (which would also discard still-valid results under a different, non-rotated key in a multi-session consumer), and not nothing (the bug this issue fixes).
+
+Call `invalidateForRotatedKey` as part of your session key rotation flow:
+
+```ts
+const cache = createSessionAwareAuthorizationCache({
+  debugLog: (msg, ctx) => logger.debug(msg, ctx),
+});
+
+// ...on rotation:
+cache.invalidateForRotatedKey(oldSessionKeyId);
+```
+
+A debug log entry is emitted on every invalidation call (per issue #236's requirement), reporting the retired key and how many entries were cleared — including a zero count when the rotated key had no cached entries, so the log line is a reliable signal that invalidation ran, not just that it found something to do.
+
+## Run tests
+
+```bash
+npx vitest run contrib/examples/issue-236-x402-session-rotation-cache-invalidation/session-rotation-cache-invalidation.test.ts
+```

--- a/contrib/examples/issue-236-x402-session-rotation-cache-invalidation/session-rotation-cache-invalidation.test.ts
+++ b/contrib/examples/issue-236-x402-session-rotation-cache-invalidation/session-rotation-cache-invalidation.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it, vi } from "vitest";
+import { createSessionAwareAuthorizationCache } from "./session-rotation-cache-invalidation";
+
+const OLD_KEY = "session-key-v1";
+const NEW_KEY = "session-key-v2";
+
+describe("createSessionAwareAuthorizationCache", () => {
+  it("serves a cached authorization result before rotation", () => {
+    const cache = createSessionAwareAuthorizationCache();
+    cache.set("resource-a", { authorized: true, sessionKeyId: OLD_KEY, computedAt: Date.now() });
+
+    expect(cache.get("resource-a")?.authorized).toBe(true);
+  });
+
+  it("does not serve a stale authorization computed under a rotated-out key", () => {
+    const cache = createSessionAwareAuthorizationCache();
+    cache.set("resource-a", { authorized: true, sessionKeyId: OLD_KEY, computedAt: Date.now() });
+
+    cache.invalidateForRotatedKey(OLD_KEY);
+
+    expect(cache.get("resource-a")).toBeUndefined();
+  });
+
+  it("only invalidates entries tagged with the rotated key, not other resources under other keys", () => {
+    const cache = createSessionAwareAuthorizationCache();
+    cache.set("resource-old", { authorized: true, sessionKeyId: OLD_KEY, computedAt: Date.now() });
+    cache.set("resource-new", { authorized: true, sessionKeyId: NEW_KEY, computedAt: Date.now() });
+
+    const invalidated = cache.invalidateForRotatedKey(OLD_KEY);
+
+    expect(invalidated).toBe(1);
+    expect(cache.get("resource-old")).toBeUndefined();
+    expect(cache.get("resource-new")?.sessionKeyId).toBe(NEW_KEY);
+  });
+
+  it("a post-rotation call recomputes and caches under the new key", () => {
+    const cache = createSessionAwareAuthorizationCache();
+    cache.set("resource-a", { authorized: true, sessionKeyId: OLD_KEY, computedAt: Date.now() });
+    cache.invalidateForRotatedKey(OLD_KEY);
+
+    // Simulates the consumer's post-rotation re-authorization call.
+    const fresh = { authorized: true, sessionKeyId: NEW_KEY, computedAt: Date.now() };
+    cache.set("resource-a", fresh);
+
+    expect(cache.get("resource-a")).toEqual(fresh);
+  });
+
+  it("emits a debug log entry on rotation-triggered invalidation", () => {
+    const debugLog = vi.fn();
+    const cache = createSessionAwareAuthorizationCache({ debugLog });
+    cache.set("resource-a", { authorized: true, sessionKeyId: OLD_KEY, computedAt: Date.now() });
+
+    cache.invalidateForRotatedKey(OLD_KEY);
+
+    expect(debugLog).toHaveBeenCalledWith(
+      "x402: invalidated authorization cache entries after session key rotation",
+      { oldSessionKeyId: OLD_KEY, invalidatedCount: 1 },
+    );
+  });
+
+  it("invalidating a key with no cached entries is a no-op that still logs zero", () => {
+    const debugLog = vi.fn();
+    const cache = createSessionAwareAuthorizationCache({ debugLog });
+
+    const invalidated = cache.invalidateForRotatedKey("never-used-key");
+
+    expect(invalidated).toBe(0);
+    expect(debugLog).toHaveBeenCalledWith(expect.any(String), {
+      oldSessionKeyId: "never-used-key",
+      invalidatedCount: 0,
+    });
+  });
+
+  it("works with no debugLog supplied at all", () => {
+    const cache = createSessionAwareAuthorizationCache();
+    cache.set("resource-a", { authorized: true, sessionKeyId: OLD_KEY, computedAt: Date.now() });
+
+    expect(() => cache.invalidateForRotatedKey(OLD_KEY)).not.toThrow();
+  });
+});

--- a/contrib/examples/issue-236-x402-session-rotation-cache-invalidation/session-rotation-cache-invalidation.ts
+++ b/contrib/examples/issue-236-x402-session-rotation-cache-invalidation/session-rotation-cache-invalidation.ts
@@ -1,0 +1,91 @@
+// Reference for issue #236: after an x402 session key rotates,
+// x402-client.ts's authorization cache must not keep serving results
+// computed under the old key — a rotated-out key's cached "authorized"
+// verdict is exactly the kind of stale-trust bug a session rotation exists
+// to prevent.
+
+export interface AuthorizationResult {
+  authorized: boolean;
+  sessionKeyId: string;
+  computedAt: number;
+}
+
+export interface AuthorizationCacheStore {
+  get(key: string): AuthorizationResult | undefined;
+  set(key: string, value: AuthorizationResult): void;
+  delete(key: string): void;
+  keys(): IterableIterator<string>;
+}
+
+export function createInMemoryAuthorizationCacheStore(): AuthorizationCacheStore {
+  const store = new Map<string, AuthorizationResult>();
+  return {
+    get: (key) => store.get(key),
+    set: (key, value) => store.set(key, value),
+    delete: (key) => store.delete(key),
+    keys: () => store.keys(),
+  };
+}
+
+export type DebugLogger = (message: string, context?: Record<string, unknown>) => void;
+
+export interface SessionAwareAuthorizationCacheOptions {
+  store?: AuthorizationCacheStore;
+  /** Optional debug log sink — issue #236 asks for a debug log entry on
+   * cache invalidation triggered by rotation, so a consumer can confirm in
+   * their own logs that the invalidation actually ran. */
+  debugLog?: DebugLogger;
+}
+
+export interface SessionAwareAuthorizationCache {
+  get(resourceId: string): AuthorizationResult | undefined;
+  set(resourceId: string, result: AuthorizationResult): void;
+  /**
+   * Invalidates every cached authorization computed under `oldSessionKeyId`.
+   * Call this as part of session key rotation — before, after, or
+   * concurrent with the rotation itself is fine, since this only removes
+   * entries tagged with the specific key being retired; it never touches
+   * entries for a different key (including the new one), so it cannot
+   * accidentally clear a result that's actually still valid.
+   */
+  invalidateForRotatedKey(oldSessionKeyId: string): number;
+}
+
+/**
+ * An authorization cache that tags every entry with the session key ID it
+ * was computed under, so rotation can invalidate exactly the entries tied
+ * to the retired key — not the whole cache (which would also throw away
+ * still-valid results for unrelated resources under a key that never
+ * rotated, in a multi-session consumer), and not nothing (which is #236's
+ * actual bug).
+ */
+export function createSessionAwareAuthorizationCache(
+  options: SessionAwareAuthorizationCacheOptions = {},
+): SessionAwareAuthorizationCache {
+  const store = options.store ?? createInMemoryAuthorizationCacheStore();
+  const debugLog = options.debugLog;
+
+  return {
+    get(resourceId) {
+      return store.get(resourceId);
+    },
+    set(resourceId, result) {
+      store.set(resourceId, result);
+    },
+    invalidateForRotatedKey(oldSessionKeyId) {
+      let invalidated = 0;
+      for (const key of Array.from(store.keys())) {
+        const entry = store.get(key);
+        if (entry && entry.sessionKeyId === oldSessionKeyId) {
+          store.delete(key);
+          invalidated++;
+        }
+      }
+      debugLog?.("x402: invalidated authorization cache entries after session key rotation", {
+        oldSessionKeyId,
+        invalidatedCount: invalidated,
+      });
+      return invalidated;
+    },
+  };
+}

--- a/contrib/examples/issue-238-rpc-cache-instrumentation/README.md
+++ b/contrib/examples/issue-238-rpc-cache-instrumentation/README.md
@@ -1,0 +1,25 @@
+# Cache hit/miss instrumentation hooks for rpc.ts (#238)
+
+Self-contained reference for issue [#238](https://github.com/Vellar-Wallet/vellar-sdk/issues/238): rpc.ts's caching has no instrumentation hooks, making it hard for a consumer to evaluate cache effectiveness in their own telemetry.
+
+## Hooks
+
+```ts
+createInstrumentedCache<T>({
+  ttlMs: 60_000,
+  onCacheHit: (key, value) => metrics.increment("rpc.cache.hit", { key }),
+  onCacheMiss: (key) => metrics.increment("rpc.cache.miss", { key }),
+});
+```
+
+- `onCacheHit(key, value)` fires when a non-expired entry is found.
+- `onCacheMiss(key)` fires when the key was never cached, or its entry has expired (an expired entry counts as a miss for instrumentation purposes, not a hit — it's evicted at the same point).
+- Both hooks are invoked synchronously at the point of access, before `get()` returns. An exception thrown from a hook propagates to the caller — it is not swallowed, since a misbehaving hook silently eating errors is a worse failure mode than a loud one.
+
+`createInstrumentedCachedFetcher` wraps an async fetcher with the get-or-fetch-and-populate shape most RPC read paths need.
+
+## Run tests
+
+```bash
+npx vitest run contrib/examples/issue-238-rpc-cache-instrumentation/rpc-cache-instrumentation.test.ts
+```

--- a/contrib/examples/issue-238-rpc-cache-instrumentation/rpc-cache-instrumentation.test.ts
+++ b/contrib/examples/issue-238-rpc-cache-instrumentation/rpc-cache-instrumentation.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  createInstrumentedCache,
+  createInstrumentedCachedFetcher,
+} from "./rpc-cache-instrumentation";
+
+describe("createInstrumentedCache", () => {
+  it("fires onCacheMiss for a key that was never cached", () => {
+    const onCacheMiss = vi.fn();
+    const cache = createInstrumentedCache<number>({ ttlMs: 60_000, onCacheMiss });
+
+    const result = cache.get("k1");
+
+    expect(result).toBeUndefined();
+    expect(onCacheMiss).toHaveBeenCalledWith("k1");
+  });
+
+  it("fires onCacheHit for a key that is cached and not expired", () => {
+    const onCacheHit = vi.fn();
+    const onCacheMiss = vi.fn();
+    const cache = createInstrumentedCache<number>({ ttlMs: 60_000, onCacheHit, onCacheMiss });
+
+    cache.set("k1", 42);
+    const result = cache.get("k1");
+
+    expect(result).toBe(42);
+    expect(onCacheHit).toHaveBeenCalledWith("k1", 42);
+    expect(onCacheMiss).not.toHaveBeenCalled();
+  });
+
+  it("fires onCacheMiss (not onCacheHit) for an expired entry", async () => {
+    const onCacheHit = vi.fn();
+    const onCacheMiss = vi.fn();
+    const cache = createInstrumentedCache<number>({ ttlMs: 1, onCacheHit, onCacheMiss });
+
+    cache.set("k1", 42);
+    await new Promise((resolve) => setTimeout(resolve, 5));
+    const result = cache.get("k1");
+
+    expect(result).toBeUndefined();
+    expect(onCacheMiss).toHaveBeenCalledWith("k1");
+    expect(onCacheHit).not.toHaveBeenCalled();
+  });
+
+  it("evicts an expired entry on access so it does not linger in size()", async () => {
+    const cache = createInstrumentedCache<number>({ ttlMs: 1 });
+    cache.set("k1", 42);
+    await new Promise((resolve) => setTimeout(resolve, 5));
+
+    cache.get("k1");
+
+    expect(cache.size()).toBe(0);
+  });
+
+  it("works with no hooks supplied at all", () => {
+    const cache = createInstrumentedCache<number>({ ttlMs: 60_000 });
+    expect(() => cache.get("k1")).not.toThrow();
+    cache.set("k1", 1);
+    expect(cache.get("k1")).toBe(1);
+  });
+
+  it("propagates an exception thrown from a hook rather than swallowing it", () => {
+    const cache = createInstrumentedCache<number>({
+      ttlMs: 60_000,
+      onCacheMiss: () => {
+        throw new Error("telemetry backend down");
+      },
+    });
+
+    expect(() => cache.get("k1")).toThrow("telemetry backend down");
+  });
+
+  it("delete removes an entry so the next get is a miss", () => {
+    const onCacheMiss = vi.fn();
+    const cache = createInstrumentedCache<number>({ ttlMs: 60_000, onCacheMiss });
+    cache.set("k1", 1);
+    cache.delete("k1");
+
+    expect(cache.get("k1")).toBeUndefined();
+    expect(onCacheMiss).toHaveBeenCalledWith("k1");
+  });
+});
+
+describe("createInstrumentedCachedFetcher", () => {
+  it("calls the fetcher once and serves the cache on subsequent calls", async () => {
+    const fetcher = vi.fn(async (key: string) => `value-for-${key}`);
+    const onCacheHit = vi.fn();
+    const onCacheMiss = vi.fn();
+    const cachedFetch = createInstrumentedCachedFetcher(fetcher, {
+      ttlMs: 60_000,
+      onCacheHit,
+      onCacheMiss,
+    });
+
+    const first = await cachedFetch("a");
+    const second = await cachedFetch("a");
+
+    expect(first).toBe("value-for-a");
+    expect(second).toBe("value-for-a");
+    expect(fetcher).toHaveBeenCalledTimes(1);
+    expect(onCacheMiss).toHaveBeenCalledTimes(1);
+    expect(onCacheHit).toHaveBeenCalledTimes(1);
+  });
+});

--- a/contrib/examples/issue-238-rpc-cache-instrumentation/rpc-cache-instrumentation.ts
+++ b/contrib/examples/issue-238-rpc-cache-instrumentation/rpc-cache-instrumentation.ts
@@ -1,0 +1,94 @@
+// Reference for issue #238: rpc.ts's caching has no instrumentation hooks,
+// making it hard for a consumer to evaluate cache effectiveness in their own
+// telemetry (hit rate, which keys churn, etc.) without reimplementing the
+// cache themselves. This wraps a plain TTL cache with optional
+// onCacheHit/onCacheMiss callbacks, invoked at the exact point of access.
+
+export interface CacheEntry<T> {
+  value: T;
+  expiresAt: number;
+}
+
+export interface InstrumentedCacheOptions<T> {
+  ttlMs: number;
+  /** Called with the key on a cache hit, before the cached value is returned. */
+  onCacheHit?: (key: string, value: T) => void;
+  /** Called with the key on a cache miss (never cached, or expired). */
+  onCacheMiss?: (key: string) => void;
+}
+
+export interface InstrumentedCache<T> {
+  get(key: string): T | undefined;
+  set(key: string, value: T): void;
+  delete(key: string): void;
+  size(): number;
+}
+
+/**
+ * A minimal TTL cache with hit/miss instrumentation hooks — the pattern
+ * rpc.ts's real caching (in balances-rpc.ts / tx-rpc.ts) can wrap with, so a
+ * consumer wires up `onCacheHit`/`onCacheMiss` once and gets hit-rate
+ * telemetry for every cached RPC call without touching the SDK's own
+ * caching logic.
+ *
+ * The hooks are invoked synchronously and are expected to be
+ * side-effect-only (metrics, logging) — an exception thrown from a hook
+ * propagates to the caller of `get()`, it is not swallowed, since a
+ * misbehaving hook silently eating errors would be a worse failure mode
+ * than a loud one.
+ */
+export function createInstrumentedCache<T>(
+  options: InstrumentedCacheOptions<T>,
+): InstrumentedCache<T> {
+  const store = new Map<string, CacheEntry<T>>();
+  const { ttlMs, onCacheHit, onCacheMiss } = options;
+
+  return {
+    get(key) {
+      const entry = store.get(key);
+      const now = Date.now();
+
+      if (entry && entry.expiresAt > now) {
+        onCacheHit?.(key, entry.value);
+        return entry.value;
+      }
+
+      if (entry) {
+        // Expired: treat exactly like "never cached" for instrumentation
+        // purposes — a consumer's hit-rate metric should not count an
+        // expired-and-evicted entry as a hit.
+        store.delete(key);
+      }
+
+      onCacheMiss?.(key);
+      return undefined;
+    },
+    set(key, value) {
+      store.set(key, { value, expiresAt: Date.now() + ttlMs });
+    },
+    delete(key) {
+      store.delete(key);
+    },
+    size() {
+      return store.size;
+    },
+  };
+}
+
+/** Convenience helper: wraps an async fetcher with an instrumented cache,
+ * the shape most RPC read paths actually need (get-or-fetch-and-populate). */
+export function createInstrumentedCachedFetcher<T>(
+  fetcher: (key: string) => Promise<T>,
+  options: InstrumentedCacheOptions<T>,
+): (key: string) => Promise<T> {
+  const cache = createInstrumentedCache<T>(options);
+
+  return async (key: string) => {
+    const cached = cache.get(key);
+    if (cached !== undefined) return cached;
+
+    const value = await fetcher(key);
+    cache.set(key, value);
+    return value;
+  };
+}

--- a/contrib/examples/issue-239-x402-dead-letter-retries/README.md
+++ b/contrib/examples/issue-239-x402-dead-letter-retries/README.md
@@ -1,0 +1,39 @@
+# Dead-letter handling for failed x402 payment retries (#239)
+
+Self-contained reference for issue [#239](https://github.com/Vellar-Wallet/vellar-sdk/issues/239): x402 payments that repeatedly fail are currently retried indefinitely by consumer code, with no dead-letter or give-up mechanism from the SDK.
+
+## Usage
+
+```ts
+const result = await retryPaymentWithDeadLetter(
+  (attemptNumber) => submitPayment(paymentDetails),
+  {
+    maxAttempts: 5,
+    baseDelayMs: 250, // doubles each retry: 250ms, 500ms, 1000ms, ...
+    onDeadLetter: (deadLetter) => {
+      // Persist for manual review / alerting — this fires exactly once,
+      // only when every attempt has been exhausted.
+      deadLetterQueue.push(deadLetter);
+    },
+  },
+);
+
+if (result.outcome === "success") {
+  console.log(`Paid after ${result.attempts} attempt(s)`, result.value);
+} else {
+  console.error(`Payment dead-lettered after ${result.attempts} attempts`, result.lastError);
+}
+```
+
+## Design
+
+- `PaymentRetryResult<T>` is a typed union (`PaymentSuccess<T> | PaymentDeadLetter`) — the give-up state is a first-class return value, not an exception a consumer has to catch and reinterpret.
+- `PaymentDeadLetter.failures` records every attempt's error, in order, with a timestamp — useful for diagnosing whether failures were transient-looking (timeouts) vs. a hard rejection from the first attempt.
+- `onDeadLetter` fires exactly once per call, only on the terminal failure — never per-attempt, and never on success.
+- Backoff is simple exponential (`baseDelayMs * 2^(attempt-1)`) between attempts, skipped after the final attempt.
+
+## Run tests
+
+```bash
+npx vitest run contrib/examples/issue-239-x402-dead-letter-retries/dead-letter-retries.test.ts
+```

--- a/contrib/examples/issue-239-x402-dead-letter-retries/dead-letter-retries.test.ts
+++ b/contrib/examples/issue-239-x402-dead-letter-retries/dead-letter-retries.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, it, vi } from "vitest";
+import { retryPaymentWithDeadLetter } from "./dead-letter-retries";
+
+describe("retryPaymentWithDeadLetter", () => {
+  it("returns success on the first attempt without retrying", async () => {
+    const attempt = vi.fn(async () => "paid");
+
+    const result = await retryPaymentWithDeadLetter(attempt, { maxAttempts: 3 });
+
+    expect(result).toEqual({ outcome: "success", value: "paid", attempts: 1 });
+    expect(attempt).toHaveBeenCalledTimes(1);
+  });
+
+  it("retries after a failure and succeeds on a later attempt", async () => {
+    let calls = 0;
+    const attempt = vi.fn(async () => {
+      calls++;
+      if (calls < 3) throw new Error(`transient failure ${calls}`);
+      return "paid";
+    });
+
+    const result = await retryPaymentWithDeadLetter(attempt, { maxAttempts: 5 });
+
+    expect(result).toEqual({ outcome: "success", value: "paid", attempts: 3 });
+    expect(attempt).toHaveBeenCalledTimes(3);
+  });
+
+  it("returns a typed dead-letter result after exhausting all attempts", async () => {
+    const attempt = vi.fn(async () => {
+      throw new Error("payment gateway down");
+    });
+
+    const result = await retryPaymentWithDeadLetter(attempt, { maxAttempts: 3 });
+
+    expect(result.outcome).toBe("dead-letter");
+    if (result.outcome === "dead-letter") {
+      expect(result.attempts).toBe(3);
+      expect(result.failures).toHaveLength(3);
+      expect((result.lastError as Error).message).toBe("payment gateway down");
+    }
+    expect(attempt).toHaveBeenCalledTimes(3);
+  });
+
+  it("records every attempt's failure in order", async () => {
+    let calls = 0;
+    const attempt = vi.fn(async () => {
+      calls++;
+      throw new Error(`failure ${calls}`);
+    });
+
+    const result = await retryPaymentWithDeadLetter(attempt, { maxAttempts: 3, baseDelayMs: 0 });
+
+    expect(result.outcome).toBe("dead-letter");
+    if (result.outcome === "dead-letter") {
+      expect(result.failures.map((f) => f.attempt)).toEqual([1, 2, 3]);
+      expect(result.failures.map((f) => (f.error as Error).message)).toEqual([
+        "failure 1",
+        "failure 2",
+        "failure 3",
+      ]);
+    }
+  });
+
+  it("calls onDeadLetter exactly once, only on terminal failure", async () => {
+    const onDeadLetter = vi.fn();
+    const failingAttempt = vi.fn(async () => {
+      throw new Error("always fails");
+    });
+
+    await retryPaymentWithDeadLetter(failingAttempt, { maxAttempts: 2, onDeadLetter });
+    expect(onDeadLetter).toHaveBeenCalledTimes(1);
+    expect(onDeadLetter.mock.calls[0][0].outcome).toBe("dead-letter");
+
+    onDeadLetter.mockClear();
+    const succeedingAttempt = vi.fn(async () => "paid");
+    await retryPaymentWithDeadLetter(succeedingAttempt, { maxAttempts: 2, onDeadLetter });
+    expect(onDeadLetter).not.toHaveBeenCalled();
+  });
+
+  it("never calls onDeadLetter per-attempt, only after the final one", async () => {
+    const onDeadLetter = vi.fn();
+    let calls = 0;
+    const attempt = vi.fn(async () => {
+      calls++;
+      throw new Error(`failure ${calls}`);
+    });
+
+    await retryPaymentWithDeadLetter(attempt, { maxAttempts: 4, onDeadLetter, baseDelayMs: 0 });
+
+    expect(onDeadLetter).toHaveBeenCalledTimes(1);
+    expect(attempt).toHaveBeenCalledTimes(4);
+  });
+
+  it("rejects a maxAttempts less than 1", async () => {
+    await expect(
+      retryPaymentWithDeadLetter(async () => "x", { maxAttempts: 0 }),
+    ).rejects.toThrow("maxAttempts must be at least 1");
+  });
+
+  it("succeeds with maxAttempts of exactly 1 and no retry", async () => {
+    const attempt = vi.fn(async () => "paid");
+    const result = await retryPaymentWithDeadLetter(attempt, { maxAttempts: 1 });
+
+    expect(result).toEqual({ outcome: "success", value: "paid", attempts: 1 });
+    expect(attempt).toHaveBeenCalledTimes(1);
+  });
+
+  it("dead-letters immediately with maxAttempts of exactly 1 on failure", async () => {
+    const attempt = vi.fn(async () => {
+      throw new Error("fails once");
+    });
+    const result = await retryPaymentWithDeadLetter(attempt, { maxAttempts: 1 });
+
+    expect(result.outcome).toBe("dead-letter");
+    expect(attempt).toHaveBeenCalledTimes(1);
+  });
+});

--- a/contrib/examples/issue-239-x402-dead-letter-retries/dead-letter-retries.ts
+++ b/contrib/examples/issue-239-x402-dead-letter-retries/dead-letter-retries.ts
@@ -1,0 +1,94 @@
+// Reference for issue #239: x402 payments that repeatedly fail are
+// currently retried indefinitely by consumer code, with no dead-letter or
+// give-up mechanism provided by the SDK. This adds a max-retry-count wrapper
+// with a typed terminal failure result and a hook for consumers to capture
+// terminally failed payments (e.g. to persist them for manual review or an
+// alerting pipeline), instead of leaving "give up after N tries" as
+// something every consumer has to reimplement themselves.
+
+export interface PaymentAttemptFailure {
+  attempt: number;
+  error: unknown;
+  attemptedAt: number;
+}
+
+export interface PaymentSuccess<T> {
+  outcome: "success";
+  value: T;
+  attempts: number;
+}
+
+/** A payment that exhausted its retry budget without succeeding — the
+ * "dead letter" result. Distinct from a single attempt's failure: this is
+ * the terminal state a consumer's retry loop currently has no typed way to
+ * reach. */
+export interface PaymentDeadLetter {
+  outcome: "dead-letter";
+  attempts: number;
+  failures: PaymentAttemptFailure[];
+  /** The error from the final attempt — usually what a consumer wants to
+   * surface first, without digging through the full `failures` list. */
+  lastError: unknown;
+}
+
+export type PaymentRetryResult<T> = PaymentSuccess<T> | PaymentDeadLetter;
+
+export interface RetryWithDeadLetterOptions<T> {
+  maxAttempts: number;
+  /** Base delay in ms between attempts; doubles each retry (simple
+   * exponential backoff). Defaults to 0 for fast, deterministic tests —
+   * a real consumer should pass a meaningful value. */
+  baseDelayMs?: number;
+  /** Called exactly once, only when every attempt has been exhausted —
+   * i.e. exactly when the returned result is a dead letter. Never called on
+   * success, and never called per-attempt (that's what the returned
+   * `failures` array is for). */
+  onDeadLetter?: (deadLetter: PaymentDeadLetter) => void;
+}
+
+function delay(ms: number): Promise<void> {
+  return ms > 0 ? new Promise((resolve) => setTimeout(resolve, ms)) : Promise.resolve();
+}
+
+/**
+ * Retries `attempt` up to `maxAttempts` times. On success, returns a typed
+ * `PaymentSuccess`. On exhausting every attempt, returns a typed
+ * `PaymentDeadLetter` — this function never throws for an exhausted-retries
+ * condition, so a consumer's retry loop no longer needs to catch and
+ * reinterpret an exception as "well, I guess it's given up now"; the give-up
+ * state is a first-class, typed return value.
+ */
+export async function retryPaymentWithDeadLetter<T>(
+  attempt: (attemptNumber: number) => Promise<T>,
+  options: RetryWithDeadLetterOptions<T>,
+): Promise<PaymentRetryResult<T>> {
+  const { maxAttempts, baseDelayMs = 0, onDeadLetter } = options;
+  if (maxAttempts < 1) {
+    throw new Error("maxAttempts must be at least 1");
+  }
+
+  const failures: PaymentAttemptFailure[] = [];
+
+  for (let attemptNumber = 1; attemptNumber <= maxAttempts; attemptNumber++) {
+    try {
+      const value = await attempt(attemptNumber);
+      return { outcome: "success", value, attempts: attemptNumber };
+    } catch (error) {
+      failures.push({ attempt: attemptNumber, error, attemptedAt: Date.now() });
+
+      if (attemptNumber < maxAttempts) {
+        await delay(baseDelayMs * 2 ** (attemptNumber - 1));
+      }
+    }
+  }
+
+  const deadLetter: PaymentDeadLetter = {
+    outcome: "dead-letter",
+    attempts: maxAttempts,
+    failures,
+    lastError: failures[failures.length - 1]?.error,
+  };
+
+  onDeadLetter?.(deadLetter);
+  return deadLetter;
+}


### PR DESCRIPTION
## Summary

Four self-contained reference implementations under `contrib/examples/`, each with real logic and real tests:

- **#233** — per-network cache namespace for `balances-rpc.ts`: composite key `<network>|<tokenContractId>|<holder>`, plus a migration helper for pre-#233 unscoped entries.
- **#236** — session-key-aware authorization cache for `x402-client.ts`: every entry tagged with its session key ID, `invalidateForRotatedKey()` clears exactly the retired key's entries, with a debug log entry on every invalidation.
- **#238** — cache hit/miss instrumentation hooks for `rpc.ts`: `onCacheHit`/`onCacheMiss` fired synchronously at the point of access.
- **#239** — dead-letter handling for x402 payment retries: `retryPaymentWithDeadLetter` returns a typed `PaymentSuccess | PaymentDeadLetter` union instead of retrying indefinitely, with an `onDeadLetter` hook firing exactly once on terminal failure.

## Test plan

```
npx vitest run contrib/examples/issue-233-balances-network-namespace/
npx vitest run contrib/examples/issue-236-x402-session-rotation-cache-invalidation/
npx vitest run contrib/examples/issue-238-rpc-cache-instrumentation/
npx vitest run contrib/examples/issue-239-x402-dead-letter-retries/
```

33 tests total, all passing.

Closes #233
Closes #236
Closes #238
Closes #239