### PR TITLE
Fix/sdk issues

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,11 +10,19 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - uses: actions/setup-node@v4
         with:
           node-version: 22
           cache: npm
       - run: npm ci
+      - name: Validate Changeset
+        if: github.event_name == 'pull_request'
+        env:
+          GITHUB_BASE_REF: ${{ github.base_ref }}
+          PR_LABELS: ${{ join(github.event.pull_request.labels.*.name, ',') }}
+        run: node scripts/validate-changeset.mjs
       # Security audit V-8. Blocking at `high` matches the sibling repos. Fixes
       # are lockfile-only by policy: anything needing a `package.json` range
       # change is reported and decided, not forced through by CI.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,13 +41,14 @@ start — pull requests that don't follow them will be closed.
 
 ## Before you open a PR
 
-Make sure the package still typechecks, tests, and builds:
+Make sure the package still typechecks, tests, and builds, and that the pre-release smoke test passes:
 
 ```sh
 npm install
 npm run typecheck
 npm test
 npm run build
+node scripts/smoke-test.mjs
 ```
 
 New code is expected to come with tests.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,6 +39,13 @@ start — pull requests that don't follow them will be closed.
 5. **Questions go to the Telegram group.** Don't open issues for questions —
    ask in [our Telegram](https://t.me/+RWPCKXXJTj45Njk0).
 
+6. **All pull requests modifying source files must include a changeset.**
+   We use changesets to generate our changelog. If your PR modifies files in `src/` or `packages/`, you must add a changeset by running:
+   ```sh
+   npx changeset
+   ```
+   and following the prompts. If your PR contains only documentation, website, or infrastructure changes that do not need a changelog entry, you can ask a maintainer to add the `skip-changeset` label to your PR.
+
 ## Before you open a PR
 
 Make sure the package still typechecks, tests, and builds, and that the pre-release smoke test passes:

--- a/README.md
+++ b/README.md
@@ -299,6 +299,12 @@ signers (`createSessionKeySigner`, `createPasskeyX402Signer`), the
 RPC-backed readers (`vellar-sdk/rpc`, imported separately so
 `@stellar/stellar-sdk` stays out of bundles that don't read balances).
 
+### Stellar RPC Retry & Circuit Breaker Policy
+
+When querying Stellar RPC through the SDK (e.g., for checking balances or transaction status via `vellar-sdk/rpc`), requests are run using a wrapped `Server` instead of `@stellar/stellar-sdk`'s raw `rpc.Server`. This wrapper implements:
+- **Exponential Backoff with Jitter**: Failsafe retries up to 3 times (4 attempts total) with exponential delays (100ms base, 1000ms max) and random jitter to spread the load and prevent overloading degraded servers.
+- **Circuit Breaker**: Governed globally per RPC URL. 5 consecutive failures trip the breaker to `OPEN` for a 10-second cooldown period, during which all subsequent requests fail fast with `RpcCircuitBreakerError` to protect the backend. A successful request in `HALF_OPEN` state resets the breaker to `CLOSED`.
+
 ## License
 
 Apache-2.0

--- a/README.md
+++ b/README.md
@@ -249,13 +249,16 @@ const vellar = createVellarWallet({
   },
 });
 
-const { response, paid, settlement } = await vellar.x402.fetch("https://api.example.com/paid", {
+const { response, paid, settlement, isFallback } = await vellar.x402.fetch("https://api.example.com/paid", {
   maxAmount: 1_000_000n, // hard per-request ceiling in the asset's base units
   // allowedAssets: [usdcSac],   // optional — restrict which asset(s) you'll pay in
+  timeoutMs: 5000,              // optional — timeout for initial discovery request in ms
+  fallbackResponse: myFallback, // optional — custom response on timeout
 });
 
+if (isFallback) console.log("discovery timed out, returned fallback (may be partial)");
 if (paid) console.log("settled on-chain:", settlement.transaction);
-const data = await response.json(); // the unlocked resource
+const data = await response.json(); // the unlocked resource (or fallback)
 ```
 
 Two signers ship, both satisfying the same `SmartAccountX402Signer` interface:
@@ -277,6 +280,8 @@ Errors are typed: `MaxAmountExceededError`, `DisallowedAssetError`,
 (the facilitator rejected it — e.g. an over-budget payment blocked by the policy),
 and `X402NotConfiguredError` (no `x402` config). Lower-level: `createX402Client`
 for a client without the wallet handle.
+
+If the initial request to discover payment requirements (the discovery call) times out (configured via `timeoutMs`), the request does not fail. Instead, the client returns either the custom `fallbackResponse` or a default 504 Gateway Timeout Response, with `isFallback: true` on the result so consumers know data may be partial.
 
 > **Facilitator note:** a policy-governed payment runs the policy inside
 > `__check_auth`, which costs more resource fee than a plain transfer. Hosted

--- a/package.json
+++ b/package.json
@@ -107,7 +107,7 @@
     "check:docs": "node scripts/check-doc-snippets.mjs",
     "test": "vitest run",
     "test:integration": "npm run test:integration --workspace @vellar/mcp-x402-payer",
-    "prepublishOnly": "npm run typecheck && npm test && npm run build",
+    "prepublishOnly": "npm run typecheck && npm test && npm run build && node scripts/smoke-test.mjs",
     "verify:merged": "node scripts/verify-merged.mjs"
   },
   "peerDependencies": {

--- a/scripts/smoke-test.mjs
+++ b/scripts/smoke-test.mjs
@@ -1,0 +1,110 @@
+import { createVellarWallet } from "../dist/index.js";
+import { nativeToken } from "../dist/balances.js";
+import { isValidStellarAddress } from "../dist/rpc.js";
+import { selectRequirements } from "../dist/x402-guards.js";
+import { renderUntrusted } from "../dist/x402-untrusted.js";
+
+// Mock globals for browser WebAuthn context
+globalThis.window = {};
+globalThis.navigator = { credentials: {} };
+
+async function run() {
+  console.log("Starting pre-release smoke test...");
+
+  // 1. Verify balances export
+  const token = nativeToken("Test SDF Network ; September 2015");
+  if (!token || token.symbol !== "XLM" || token.decimals !== 7) {
+    throw new Error("balances core export nativeToken failed");
+  }
+
+  // 2. Verify rpc export
+  if (!isValidStellarAddress("GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF")) {
+    throw new Error("rpc core export isValidStellarAddress failed");
+  }
+
+  // 3. Verify x402-guards export
+  const selected = selectRequirements({
+    x402Version: 2,
+    accepts: [{
+      scheme: "exact",
+      network: "stellar:testnet",
+      asset: "CASSET",
+      amount: "100",
+      payTo: "GPAYTO",
+      maxTimeoutSeconds: 120,
+      extra: { areFeesSponsored: true }
+    }]
+  }, { maxAmount: 1000n }, "stellar:testnet");
+  if (selected.amount !== "100") {
+    throw new Error("x402-guards core export selectRequirements failed");
+  }
+
+  // 4. Verify x402-untrusted export
+  const fenced = renderUntrusted("label", "untrusted text");
+  if (!fenced.includes("BEGIN UNTRUSTED RESOURCE DATA")) {
+    throw new Error("x402-untrusted core export renderUntrusted failed");
+  }
+
+  // 5. Verify client creation and mock connection/payment flow
+  const kit = {
+    createWallet: async () => ({ keyIdBase64: "key123", contractId: "CWALLET", signedTx: "signed-deploy-xdr" }),
+    connectWallet: async () => ({ keyIdBase64: "key123", contractId: "CWALLET" }),
+    sign: async (tx) => tx,
+    wallet: undefined,
+  };
+
+  const backend = {
+    submitWalletCreation: async () => ({ sessionId: "sess-1" }),
+    lookupContractId: async () => ({ contractId: "CWALLET", sessionId: "sess-2" }),
+    submitTransaction: async () => ({ hash: "txhash-abc" }),
+  };
+
+  const transferSpy = [];
+  const sac = {
+    getSACClient: () => ({
+      transfer: async (args, opts) => {
+        transferSpy.push({ args, opts });
+        return "built-transfer-xdr";
+      }
+    })
+  };
+
+  const wallet = createVellarWallet({
+    network: "testnet",
+    appName: "Smoke Test App",
+    kit,
+    backend,
+    sac,
+    isValidAddress: () => true,
+  });
+
+  if (wallet.session !== null) {
+    throw new Error("Wallet should start with null session");
+  }
+
+  const session = await wallet.connect();
+  if (session.accountId !== "CWALLET" || wallet.session !== session) {
+    throw new Error("Wallet connect failed to set session");
+  }
+
+  const txRes = await wallet.pay({
+    to: "GTO",
+    amount: 1000n,
+    token: { contractId: "CTOKEN", symbol: "USDC", decimals: 7 },
+  });
+
+  if (txRes.hash !== "txhash-abc") {
+    throw new Error("Wallet pay failed to return transaction hash");
+  }
+
+  if (transferSpy.length !== 1 || transferSpy[0].args.amount !== 1000n) {
+    throw new Error("Wallet pay did not execute transfer correctly");
+  }
+
+  console.log("Pre-release smoke test passed successfully!");
+}
+
+run().catch((err) => {
+  console.error("Smoke test failed:", err);
+  process.exit(1);
+});

--- a/scripts/validate-changeset.mjs
+++ b/scripts/validate-changeset.mjs
@@ -1,0 +1,60 @@
+import { execSync } from "child_process";
+
+export function validateChangeset({ changedFiles, labels }) {
+  if (labels.includes("skip-changeset") || labels.includes("no-changeset")) {
+    return { valid: true, reason: "Skip label present" };
+  }
+
+  const sourceFiles = changedFiles.filter(f => f.startsWith("src/") || f.startsWith("packages/"));
+  if (sourceFiles.length === 0) {
+    return { valid: true, reason: "No source files changed" };
+  }
+
+  const changesets = changedFiles.filter(f => f.startsWith(".changeset/") && f.endsWith(".md"));
+  if (changesets.length === 0) {
+    return {
+      valid: false,
+      reason: "Source files changed but no changeset entry (.changeset/*.md) was added or modified."
+    };
+  }
+
+  return { valid: true, reason: "Changeset present" };
+}
+
+// Check if running as script directly
+const isMain = process.argv[1] && (
+  process.argv[1].endsWith("validate-changeset.mjs") ||
+  process.argv[1].endsWith("validate-changeset.js")
+);
+
+if (isMain) {
+  try {
+    const baseRef = process.env.GITHUB_BASE_REF || "main";
+    const labelsEnv = process.env.PR_LABELS || "";
+    const labels = labelsEnv.split(",").map(l => l.trim()).filter(Boolean);
+
+    console.log(`Running changeset validation against base branch: ${baseRef}`);
+    console.log(`PR Labels: ${JSON.stringify(labels)}`);
+
+    // Fetch base branch to compare
+    execSync(`git fetch origin ${baseRef} --depth=1`, { stdio: "inherit" });
+    const diffOutput = execSync(`git diff --name-only origin/${baseRef}...HEAD`, { encoding: "utf8" });
+    const changedFiles = diffOutput.split("\n").map(f => f.trim()).filter(Boolean);
+
+    console.log(`Changed files in PR:\n${changedFiles.map(f => `  - ${f}`).join("\n")}`);
+
+    const result = validateChangeset({ changedFiles, labels });
+    console.log(`Result: ${result.reason}`);
+
+    if (!result.valid) {
+      console.error("\n[ERROR] Changeset Validation Failed!");
+      console.error("This pull request modifies source files (in src/ or packages/) but does not include a changeset.");
+      console.error("Please add a changeset by running 'npx changeset' or ask a maintainer to add the 'skip-changeset' label if a changeset is not required.\n");
+      process.exit(1);
+    }
+    console.log("Changeset validation passed!");
+  } catch (err) {
+    console.error("Failed to validate changesets:", err.message);
+    process.exit(1);
+  }
+}

--- a/src/balances-rpc.ts
+++ b/src/balances-rpc.ts
@@ -8,6 +8,7 @@ import {
   TransactionBuilder,
 } from "@stellar/stellar-sdk";
 import type { BalanceReader, TokenInfo } from "./balances";
+import { Server } from "./rpc-server";
 
 // RPC-backed BalanceReader: simulates the token contract's `balance(id)`
 // read — no signature, no fee, works for contract (C...) and classic (G...)
@@ -31,7 +32,7 @@ export interface RpcBalanceReaderOptions {
 }
 
 export function createRpcBalanceReader(options: RpcBalanceReaderOptions): BalanceReader {
-  const server = new rpc.Server(options.rpcUrl);
+  const server = new Server(options.rpcUrl);
 
   return {
     async getTokenBalance(tokenContractId, holder) {

--- a/src/rpc-server.test.ts
+++ b/src/rpc-server.test.ts
@@ -1,0 +1,99 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { rpc } from "@stellar/stellar-sdk";
+import { Server, getBreaker, resetBreakerRegistry, RpcCircuitBreakerError } from "./rpc-server";
+
+describe("RpcServer backoff and circuit breaker", () => {
+  beforeEach(() => {
+    resetBreakerRegistry();
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it("retries on failure with exponential backoff and eventually propagates error", async () => {
+    const getLatestLedgerSpy = vi.spyOn(rpc.Server.prototype, "getLatestLedger")
+      .mockRejectedValue(new Error("RPC Degraded"));
+
+    const server = new Server("https://mock-rpc-url.org");
+    const promise = server.getLatestLedger();
+
+    // 1st attempt fails immediately.
+    await vi.advanceTimersByTimeAsync(0);
+
+    // baseDelay is 100ms. Since we have jitter, the delay is between 50ms and 100ms.
+    expect(getLatestLedgerSpy).toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(100);
+    expect(getLatestLedgerSpy).toHaveBeenCalledTimes(2);
+
+    // 2nd retry has delay of baseDelay * 2 = 200ms (jittered: 100ms-200ms).
+    await vi.advanceTimersByTimeAsync(200);
+    expect(getLatestLedgerSpy).toHaveBeenCalledTimes(3);
+
+    // 3rd retry has delay of baseDelay * 4 = 400ms (jittered: 200ms-400ms).
+    await vi.advanceTimersByTimeAsync(400);
+    expect(getLatestLedgerSpy).toHaveBeenCalledTimes(4); // 1 initial + 3 retries = 4 attempts total
+
+    await expect(promise).rejects.toThrow("RPC Degraded");
+  });
+
+  it("circuit breaker transitions to OPEN after 5 failures and blocks requests", async () => {
+    const getLatestLedgerSpy = vi.spyOn(rpc.Server.prototype, "getLatestLedger")
+      .mockRejectedValue(new Error("RPC Degraded"));
+
+    const server = new Server("https://mock-rpc-url-2.org");
+
+    // Make 1 call that fails 4 times (1 initial + 3 retries). This records 4 failures on the breaker.
+    await expect(server.getLatestLedger()).rejects.toThrow("RPC Degraded");
+    expect(getLatestLedgerSpy).toHaveBeenCalledTimes(4);
+
+    const breaker = getBreaker("https://mock-rpc-url-2.org");
+    expect(breaker.state).toBe("CLOSED");
+    expect(breaker.failureCount).toBe(4);
+
+    // Run one more call. The first attempt of this call will be the 5th failure.
+    // This should immediately trip the breaker to OPEN.
+    const promise = server.getLatestLedger();
+    await vi.advanceTimersByTimeAsync(0);
+
+    await expect(promise).rejects.toThrow(RpcCircuitBreakerError);
+    expect(breaker.state).toBe("OPEN");
+    // Only 1 more call got through (the 5th failure). Retries were blocked by the breaker!
+    expect(getLatestLedgerSpy).toHaveBeenCalledTimes(5);
+
+    // Subsequent calls should fail fast immediately without even hitting the spy.
+    await expect(server.getLatestLedger()).rejects.toThrow(RpcCircuitBreakerError);
+    expect(getLatestLedgerSpy).toHaveBeenCalledTimes(5); // Still 5 calls
+  });
+
+  it("circuit breaker cooldown leads to HALF_OPEN and recovers on success", async () => {
+    const getLatestLedgerSpy = vi.spyOn(rpc.Server.prototype, "getLatestLedger")
+      .mockRejectedValue(new Error("RPC Degraded"));
+
+    const server = new Server("https://mock-rpc-url-3.org");
+    const breaker = getBreaker("https://mock-rpc-url-3.org");
+
+    // Trip the breaker to OPEN: need 5 failures.
+    // 1st request makes 4 attempts (4 failures)
+    await expect(server.getLatestLedger()).rejects.toThrow("RPC Degraded");
+    // 2nd request makes 1 attempt (5th failure) and trips breaker to OPEN
+    await expect(server.getLatestLedger()).rejects.toThrow(RpcCircuitBreakerError);
+    expect(breaker.state).toBe("OPEN");
+    expect(getLatestLedgerSpy).toHaveBeenCalledTimes(5);
+
+    // Fast-forward by 10s (cooldown period)
+    await vi.advanceTimersByTimeAsync(10000);
+
+    // Next request should transition the breaker to HALF_OPEN and allow a test request.
+    getLatestLedgerSpy.mockResolvedValue({ sequence: 100 } as any);
+
+    const result = await server.getLatestLedger();
+    expect(result.sequence).toBe(100);
+    expect(breaker.state).toBe("CLOSED");
+    expect(breaker.failureCount).toBe(0);
+    expect(getLatestLedgerSpy).toHaveBeenCalledTimes(6);
+  });
+});

--- a/src/rpc-server.ts
+++ b/src/rpc-server.ts
@@ -1,0 +1,132 @@
+import { rpc } from "@stellar/stellar-sdk";
+
+export class RpcCircuitBreakerError extends Error {
+  constructor(readonly url: string) {
+    super(`Stellar RPC Circuit Breaker is OPEN for ${url}. Request blocked.`);
+    this.name = "RpcCircuitBreakerError";
+  }
+}
+
+type BreakerState = "CLOSED" | "OPEN" | "HALF_OPEN";
+
+class CircuitBreaker {
+  state: BreakerState = "CLOSED";
+  failureCount = 0;
+  nextAllowedTime = 0;
+
+  constructor(
+    readonly url: string,
+    readonly failureThreshold = 5,
+    readonly cooldownMs = 10000,
+  ) {}
+
+  checkCall() {
+    if (this.state === "OPEN") {
+      if (Date.now() >= this.nextAllowedTime) {
+        this.state = "HALF_OPEN";
+      } else {
+        throw new RpcCircuitBreakerError(this.url);
+      }
+    }
+  }
+
+  recordSuccess() {
+    this.state = "CLOSED";
+    this.failureCount = 0;
+  }
+
+  recordFailure() {
+    this.failureCount++;
+    if (this.state === "HALF_OPEN" || this.failureCount >= this.failureThreshold) {
+      this.state = "OPEN";
+      this.nextAllowedTime = Date.now() + this.cooldownMs;
+    }
+  }
+}
+
+// Global registry to share breaker state for the same RPC URLs
+const breakerRegistry = new Map<string, CircuitBreaker>();
+
+export function getBreaker(url: string): CircuitBreaker {
+  let breaker = breakerRegistry.get(url);
+  if (!breaker) {
+    breaker = new CircuitBreaker(url);
+    breakerRegistry.set(url, breaker);
+  }
+  return breaker;
+}
+
+export function resetBreakerRegistry() {
+  breakerRegistry.clear();
+}
+
+export class Server extends rpc.Server {
+  private readonly _url: string;
+
+  constructor(serverURL: string, opts?: rpc.Server.Options) {
+    super(serverURL, opts);
+    this._url = serverURL;
+  }
+
+  private async _executeWithRetry<T>(fn: () => Promise<T>): Promise<T> {
+    const breaker = getBreaker(this._url);
+    breaker.checkCall();
+
+    const maxRetries = 3;
+    const baseDelay = 100; // ms
+    const maxDelay = 1000; // ms
+
+    for (let attempt = 0; attempt <= maxRetries; attempt++) {
+      try {
+        const result = await fn();
+        breaker.recordSuccess();
+        return result;
+      } catch (err: any) {
+        breaker.recordFailure();
+
+        if (attempt === maxRetries) {
+          throw err;
+        }
+
+        const delay = Math.min(maxDelay, baseDelay * Math.pow(2, attempt));
+        const jitteredDelay = delay * (0.5 + 0.5 * Math.random());
+        await new Promise((resolve) => setTimeout(resolve, jitteredDelay));
+
+        breaker.checkCall();
+      }
+    }
+    throw new Error("Stellar RPC call failed after retries");
+  }
+
+  override getTransaction(hash: string): Promise<rpc.Api.GetTransactionResponse> {
+    return this._executeWithRetry(() => super.getTransaction(hash));
+  }
+
+  override simulateTransaction(transaction: any): Promise<rpc.Api.SimulateTransactionResponse> {
+    return this._executeWithRetry(() => super.simulateTransaction(transaction));
+  }
+
+  override getLatestLedger(): Promise<rpc.Api.GetLatestLedgerResponse> {
+    return this._executeWithRetry(() => super.getLatestLedger());
+  }
+
+  override getAccount(address: string): Promise<any> {
+    return this._executeWithRetry(() => super.getAccount(address));
+  }
+
+  override sendTransaction(transaction: any): Promise<rpc.Api.SendTransactionResponse> {
+    return this._executeWithRetry(() => super.sendTransaction(transaction));
+  }
+
+  override getEvents(opts: any): Promise<any> {
+    return this._executeWithRetry(() => super.getEvents(opts));
+  }
+
+  override getLedgerEntries(...args: any[]): Promise<any> {
+    return this._executeWithRetry(() => super.getLedgerEntries(...args as any));
+  }
+
+  override getNetwork(): Promise<rpc.Api.GetNetworkResponse> {
+    return this._executeWithRetry(() => super.getNetwork());
+  }
+}

--- a/src/rpc.ts
+++ b/src/rpc.ts
@@ -3,3 +3,4 @@
 // touch the network don't bundle the SDK.
 export * from "./balances-rpc";
 export * from "./tx-rpc";
+export { Server, RpcCircuitBreakerError } from "./rpc-server";

--- a/src/tx-rpc.ts
+++ b/src/tx-rpc.ts
@@ -1,5 +1,6 @@
 import { rpc, StrKey } from "@stellar/stellar-sdk";
 import type { TxStatus, TxStatusReader } from "./tx-status";
+import { Server } from "./rpc-server";
 
 // RPC-backed pieces of the payment flow (subpath export — see rpc.ts).
 
@@ -9,7 +10,7 @@ export function isValidStellarAddress(address: string): boolean {
 }
 
 export function createRpcTxStatusReader(options: { rpcUrl: string }): TxStatusReader {
-  const server = new rpc.Server(options.rpcUrl);
+  const server = new Server(options.rpcUrl);
   return {
     async getStatus(hash): Promise<TxStatus> {
       const res = await server.getTransaction(hash);

--- a/src/validate-changeset.test.ts
+++ b/src/validate-changeset.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+import { validateChangeset } from "../scripts/validate-changeset.mjs";
+
+describe("validateChangeset", () => {
+  it("returns valid if skip label is present", () => {
+    const result = validateChangeset({
+      changedFiles: ["src/client.ts"],
+      labels: ["skip-changeset"],
+    });
+    expect(result.valid).toBe(true);
+    expect(result.reason).toContain("Skip label present");
+  });
+
+  it("returns valid if no-changeset label is present", () => {
+    const result = validateChangeset({
+      changedFiles: ["src/client.ts"],
+      labels: ["no-changeset"],
+    });
+    expect(result.valid).toBe(true);
+    expect(result.reason).toContain("Skip label present");
+  });
+
+  it("returns valid if no source files are changed", () => {
+    const result = validateChangeset({
+      changedFiles: ["README.md", "website/content/docs/facilitator.md"],
+      labels: [],
+    });
+    expect(result.valid).toBe(true);
+    expect(result.reason).toContain("No source files changed");
+  });
+
+  it("returns invalid if source files changed but no changeset is added", () => {
+    const result = validateChangeset({
+      changedFiles: ["src/client.ts", "package.json"],
+      labels: [],
+    });
+    expect(result.valid).toBe(false);
+    expect(result.reason).toContain("no changeset entry");
+  });
+
+  it("returns valid if source files changed and a changeset is added", () => {
+    const result = validateChangeset({
+      changedFiles: ["src/client.ts", ".changeset/funny-slug.md"],
+      labels: [],
+    });
+    expect(result.valid).toBe(true);
+    expect(result.reason).toContain("Changeset present");
+  });
+});

--- a/src/x402-client.test.ts
+++ b/src/x402-client.test.ts
@@ -176,3 +176,60 @@ describe("body replay (bug #3)", () => {
     expect(fetchImpl).not.toHaveBeenCalled();
   });
 });
+
+describe("x402 fetch — timeout and fallback", () => {
+  it("returns default fallback response on timeout", async () => {
+    const fetchImpl = vi.fn(async (url, init) => {
+      if (init?.signal) {
+        await new Promise((resolve, reject) => {
+          const onAbort = () => reject(new DOMException("The user aborted a request.", "AbortError"));
+          if (init.signal.aborted) {
+            onAbort();
+          } else {
+            init.signal.addEventListener("abort", onAbort);
+          }
+        });
+      }
+      return new Response("ok", { status: 200 });
+    });
+
+    const c = client(fetchImpl);
+    const out = await c.fetch("https://res.test/paid", {
+      maxAmount: 10n,
+      timeoutMs: 10,
+    });
+
+    expect(out.paid).toBe(false);
+    expect(out.isFallback).toBe(true);
+    expect(out.response.status).toBe(504);
+    const body = await out.response.json();
+    expect(body.partial).toBe(true);
+  });
+
+  it("returns custom fallback response on timeout", async () => {
+    const fetchImpl = vi.fn(async (url, init) => {
+      if (init?.signal) {
+        await new Promise((resolve, reject) => {
+          init.signal.addEventListener("abort", () => {
+            reject(new DOMException("The user aborted a request.", "AbortError"));
+          });
+        });
+      }
+      return new Response("ok", { status: 200 });
+    });
+
+    const customRes = new Response("custom fallback data", { status: 200 });
+    const c = client(fetchImpl);
+    const out = await c.fetch("https://res.test/paid", {
+      maxAmount: 10n,
+      timeoutMs: 10,
+      fallbackResponse: customRes,
+    });
+
+    expect(out.paid).toBe(false);
+    expect(out.isFallback).toBe(true);
+    expect(out.response).toBe(customRes);
+    const text = await out.response.text();
+    expect(text).toBe("custom fallback data");
+  });
+});

--- a/src/x402-client.ts
+++ b/src/x402-client.ts
@@ -228,7 +228,52 @@ export function createX402Client(deps: X402ClientDeps): X402Client {
       body: init.body ?? undefined,
     };
 
-    const first = await doFetch(url, baseInit);
+    let first: Response;
+    let timedOut = false;
+
+    if (init.timeoutMs !== undefined && init.timeoutMs > 0) {
+      const controller = new AbortController();
+      const signal = controller.signal;
+      const timeoutId = setTimeout(() => {
+        timedOut = true;
+        controller.abort();
+      }, init.timeoutMs);
+
+      const callerSignal = init.requestInit?.signal;
+      if (callerSignal) {
+        if (callerSignal.aborted) {
+          controller.abort();
+        } else {
+          callerSignal.addEventListener("abort", () => controller.abort());
+        }
+      }
+
+      try {
+        first = await doFetch(url, { ...baseInit, signal });
+      } catch (err: any) {
+        if (timedOut || err.name === "AbortError") {
+          const fallbackRes = init.fallbackResponse ?? new Response(
+            JSON.stringify({ error: "Discovery timed out", partial: true }),
+            {
+              status: 504,
+              statusText: "Gateway Timeout",
+              headers: { "Content-Type": "application/json" },
+            }
+          );
+          return {
+            response: fallbackRes,
+            paid: false,
+            isFallback: true,
+          };
+        }
+        throw err;
+      } finally {
+        clearTimeout(timeoutId);
+      }
+    } else {
+      first = await doFetch(url, baseInit);
+    }
+
     if (first.status !== 402) {
       return { response: first, paid: false };
     }

--- a/src/x402-types.ts
+++ b/src/x402-types.ts
@@ -79,6 +79,10 @@ export interface X402FetchInit extends X402PayOptions {
   body?: BodyInit | null;
   /** Passed through to the underlying fetch (signal, credentials, …). */
   requestInit?: Omit<RequestInit, "method" | "headers" | "body">;
+  /** Timeout in milliseconds for the initial discovery request. */
+  timeoutMs?: number;
+  /** Fallback response when the discovery call times out. */
+  fallbackResponse?: Response;
 }
 
 /** A signed, ready-to-send payment payload (the `PAYMENT-SIGNATURE` header value). */
@@ -109,6 +113,8 @@ export interface X402Response {
   paid: boolean;
   /** Present when `paid` — the on-chain settlement. */
   settlement?: X402Settlement;
+  /** True when the discovery call timed out and a fallback was used. */
+  isFallback?: boolean;
 }
 
 /** The public x402 facade on the wallet handle. */


### PR DESCRIPTION
closes #279 
closes #288 
closes #285 
closes #287 

## Summary
This PR resolves four critical resilience, quality, and CI issues in the SDK:
1. **Fallback path for x402-client discovery timeout**: Adds support for a client-configurable timeout (`timeoutMs`) and fallback response (`fallbackResponse`) to handle degraded resource server discovery requests gracefully. Fallback responses are marked with `isFallback: true`.
2. **Pre-release smoke test script**: Adds `scripts/smoke-test.mjs` to exercise all primary SDK exports against simulated components. The script is wired to run automatically during the `prepublishOnly` phase to ensure no registry publication contains broken export trees.
3. **Automated changeset validation in CI**: Adds automated validation checking that pull requests modifying source files (`src/` or `packages/`) include a corresponding changeset markdown file (`.changeset/*.md`). Allows explicit bypass via the `skip-changeset` or `no-changeset` label.
4. **Stellar RPC Retry Storm Fix**: Upgrades the RPC server helper with exponential backoff, random jitter, and a shared circuit breaker (5 failures trigger a 10s cooldown) to protect backend nodes and prevent query storms during outages.

## Proposed Changes

### x402 Client Fallback & Timeout 
- `src/x402-types.ts`: Extended type definitions with `timeoutMs`, `fallbackResponse` and `isFallback`.
- `src/x402-client.ts`: Wrapped initial discovery calls in an `AbortController` timeout wrapper.
- `src/x402-client.test.ts`: Added tests verifying default and custom fallback responses on timeout.
- `README.md`: Documented the new options and properties.

### Pre-release Smoke Test 
- `scripts/smoke-test.mjs`: Script importing and invoking all core package exports.
- `package.json`: Appended smoke test run to the `prepublishOnly` lifecycle hook.
- `CONTRIBUTING.md`: Included instructions on manual smoke test invocation.

### Changeset Verification Check 
- `scripts/validate-changeset.mjs`: Node helper script to analyze git diffs and enforce changesets.
- `src/validate-changeset.test.ts`: Unit tests validating the validation logic scenarios.
- `.github/workflows/ci.yml`: Added step executing changeset check for incoming PR events and configured full checkout fetch depth.
- `CONTRIBUTING.md`: Added rule 6 describing the changeset requirement and label skip bypasses.

### RPC Backoff and Circuit Breaker 
- `src/rpc-server.ts`: Implemented wrapped `Server` overriding RPC methods with exponential backoff and registry-managed circuit breakers.
- `src/rpc-server.test.ts`: Added comprehensive unit tests simulating server degradation and testing backoff delay and breaker transitions (`CLOSED` -> `OPEN` -> `HALF_OPEN` -> `CLOSED`).
- `src/rpc.ts`: Exported custom `Server` wrapper and `RpcCircuitBreakerError` type.
- `src/balances-rpc.ts` and `src/tx-rpc.ts`: Migrated queries to use the wrapped `Server`.
- `README.md`: Added a reference section detailing the RPC retry and circuit breaker policies.

