### PR TITLE
feat(rpc): add shared retry-with-backoff utility for tx-rpc and balances-rpc

### DIFF
--- a/src/balances-rpc.test.ts
+++ b/src/balances-rpc.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it, vi } from "vitest";
+import { createRpcBalanceReader } from "./balances-rpc";
+
+// Only the retry wiring (#297, shared with tx-rpc.ts via ./rpc-retry) is
+// covered here. The simulation-building and result-decoding logic isn't this
+// issue's concern and needs a real (or heavily mocked) rpc.Server to exercise
+// meaningfully.
+describe("createRpcBalanceReader — retry (#297)", () => {
+  const HOLDER = "GAJS3G2DMB25APEXHSR4SDHZFRZFAW5RTRWDQQ5R2L3AUJSKHQ2GKEPA";
+  const TOKEN = "CBIN4HTPJM2QLJ32DTRO6OCLIMM7TR7D74JDIPVQYLNYGL7SBWOXH5ND";
+  const SUCCESS_SIM = { result: { retval: "success-retval" } };
+
+  function reader(simulateTransaction: ReturnType<typeof vi.fn>, retry?: { attempts: number; sleep: (ms: number) => Promise<void> }) {
+    return createRpcBalanceReader({
+      rpcUrl: "https://rpc.test",
+      networkPassphrase: "Test SDF Network ; September 2015",
+      retry,
+      server: { simulateTransaction } as never,
+    });
+  }
+
+  it("makes a single attempt when no retry option is given (pre-#297 behaviour)", async () => {
+    const simulateTransaction = vi.fn().mockRejectedValue(new Error("network blip"));
+    const balanceReader = reader(simulateTransaction);
+    await expect(
+      balanceReader.getTokenBalance(TOKEN, HOLDER),
+    ).rejects.toThrow("network blip");
+    expect(simulateTransaction).toHaveBeenCalledTimes(1);
+  });
+
+  it("retries the simulation on transient failure and succeeds", async () => {
+    const simulateTransaction = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("network blip"))
+      .mockResolvedValueOnce(SUCCESS_SIM);
+    const balanceReader = reader(simulateTransaction, {
+      attempts: 3,
+      sleep: vi.fn().mockResolvedValue(undefined),
+    });
+
+    // isSimulationSuccess / scValToBigInt come from @stellar/stellar-sdk and
+    // expect a real simulation shape; this test only asserts the retry
+    // wiring called through to a second attempt, not the full decode path,
+    // so a thrown decode error still proves the retry itself worked.
+    await expect(balanceReader.getTokenBalance(TOKEN, HOLDER)).rejects.toThrow();
+    expect(simulateTransaction).toHaveBeenCalledTimes(2);
+  });
+
+  it("gives up and rejects once retry attempts are exhausted", async () => {
+    const simulateTransaction = vi.fn().mockRejectedValue(new Error("still down"));
+    const balanceReader = reader(simulateTransaction, {
+      attempts: 2,
+      sleep: vi.fn().mockResolvedValue(undefined),
+    });
+    await expect(balanceReader.getTokenBalance(TOKEN, HOLDER)).rejects.toThrow(
+      "still down",
+    );
+    expect(simulateTransaction).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/balances-rpc.ts
+++ b/src/balances-rpc.ts
@@ -8,6 +8,7 @@ import {
   TransactionBuilder,
 } from "@stellar/stellar-sdk";
 import type { BalanceReader, TokenInfo } from "./balances";
+import { retryWithBackoff, type RetryOptions } from "./rpc-retry";
 
 // RPC-backed BalanceReader: simulates the token contract's `balance(id)`
 // read — no signature, no fee, works for contract (C...) and classic (G...)
@@ -28,10 +29,19 @@ export function nativeToken(networkPassphrase: string): TokenInfo {
 export interface RpcBalanceReaderOptions {
   rpcUrl: string;
   networkPassphrase: string;
+  /**
+   * Retry the balance simulation with exponential backoff on failure, via the
+   * shared ./rpc-retry utility (#297) — a dropped connection or a transient
+   * RPC-node error shouldn't fail a read that would have succeeded a moment
+   * later. Omit for no retry (the pre-#297 behaviour: one attempt).
+   */
+  retry?: RetryOptions;
+  /** Injected RPC server (for tests). Defaults to a new rpc.Server(rpcUrl). */
+  server?: Pick<rpc.Server, "simulateTransaction">;
 }
 
 export function createRpcBalanceReader(options: RpcBalanceReaderOptions): BalanceReader {
-  const server = new rpc.Server(options.rpcUrl);
+  const server = options.server ?? new rpc.Server(options.rpcUrl);
 
   return {
     async getTokenBalance(tokenContractId, holder) {
@@ -49,7 +59,8 @@ export function createRpcBalanceReader(options: RpcBalanceReaderOptions): Balanc
         .setTimeout(60)
         .build();
 
-      const sim = await server.simulateTransaction(tx);
+      const simulate = () => server.simulateTransaction(tx);
+      const sim = options.retry ? await retryWithBackoff(simulate, options.retry) : await simulate();
       if (!rpc.Api.isSimulationSuccess(sim)) {
         throw new Error(
           `Balance read failed for ${tokenContractId}: ${"error" in sim ? sim.error : "unknown simulation error"}`,

--- a/src/rpc-retry.test.ts
+++ b/src/rpc-retry.test.ts
@@ -1,0 +1,126 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { backoffDelayMs, retryWithBackoff } from "./rpc-retry";
+
+describe("backoffDelayMs — exponential backoff with full jitter", () => {
+  it("scales the cap exponentially with retryIndex before jitter is applied", () => {
+    // Fix random() at 1 (exclusive upper bound) to read the cap itself.
+    const random = () => 1 - Number.EPSILON;
+    expect(backoffDelayMs(1, 100, 10_000, random)).toBeCloseTo(100, 1); // 100 * 2^0
+    expect(backoffDelayMs(2, 100, 10_000, random)).toBeCloseTo(200, 1); // 100 * 2^1
+    expect(backoffDelayMs(3, 100, 10_000, random)).toBeCloseTo(400, 1); // 100 * 2^2
+    expect(backoffDelayMs(4, 100, 10_000, random)).toBeCloseTo(800, 1); // 100 * 2^3
+  });
+
+  it("caps the pre-jitter delay at maxDelayMs", () => {
+    const random = () => 1 - Number.EPSILON;
+    // 2^10 * 100 = 102400, far past a 5000ms cap.
+    expect(backoffDelayMs(10, 100, 5000, random)).toBeCloseTo(5000, 1);
+  });
+
+  it("applies full jitter: delay is uniformly within [0, cap)", () => {
+    expect(backoffDelayMs(3, 100, 10_000, () => 0)).toBe(0);
+    expect(backoffDelayMs(3, 100, 10_000, () => 0.5)).toBeCloseTo(200, 1); // 0.5 * 400
+  });
+
+  it("defaults to Math.random when no random source is injected", () => {
+    const spy = vi.spyOn(Math, "random").mockReturnValue(0.5);
+    try {
+      expect(backoffDelayMs(1, 100, 10_000)).toBeCloseTo(50, 1);
+    } finally {
+      spy.mockRestore();
+    }
+  });
+});
+
+describe("retryWithBackoff", () => {
+  let instantSleep: ReturnType<typeof vi.fn>;
+  beforeEach(() => {
+    instantSleep = vi.fn().mockResolvedValue(undefined);
+  });
+
+  it("resolves on the first successful call without sleeping", async () => {
+    const fn = vi.fn().mockResolvedValue("ok");
+    const result = await retryWithBackoff(fn, { attempts: 3, sleep: instantSleep });
+    expect(result).toBe("ok");
+    expect(fn).toHaveBeenCalledTimes(1);
+    expect(instantSleep).not.toHaveBeenCalled();
+  });
+
+  it("retries on failure and resolves once a later attempt succeeds", async () => {
+    const fn = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("transient"))
+      .mockRejectedValueOnce(new Error("transient"))
+      .mockResolvedValueOnce("ok");
+    const result = await retryWithBackoff(fn, { attempts: 3, sleep: instantSleep });
+    expect(result).toBe("ok");
+    expect(fn).toHaveBeenCalledTimes(3);
+  });
+
+  it("rejects with the last error once all attempts are exhausted", async () => {
+    const fn = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("first"))
+      .mockRejectedValueOnce(new Error("second"))
+      .mockRejectedValueOnce(new Error("third"));
+    await expect(retryWithBackoff(fn, { attempts: 3, sleep: instantSleep })).rejects.toThrow(
+      "third",
+    );
+    expect(fn).toHaveBeenCalledTimes(3);
+  });
+
+  it("never retries when attempts is 1 (fails on the first error)", async () => {
+    const fn = vi.fn().mockRejectedValue(new Error("nope"));
+    await expect(retryWithBackoff(fn, { attempts: 1, sleep: instantSleep })).rejects.toThrow(
+      "nope",
+    );
+    expect(fn).toHaveBeenCalledTimes(1);
+    expect(instantSleep).not.toHaveBeenCalled();
+  });
+
+  it("throws RangeError for attempts < 1 without calling fn", async () => {
+    const fn = vi.fn();
+    await expect(retryWithBackoff(fn, { attempts: 0 })).rejects.toBeInstanceOf(RangeError);
+    expect(fn).not.toHaveBeenCalled();
+  });
+
+  it("stops retrying immediately when isRetryable returns false", async () => {
+    class PermanentError extends Error {}
+    const fn = vi.fn().mockRejectedValue(new PermanentError("bad input"));
+    await expect(
+      retryWithBackoff(fn, {
+        attempts: 5,
+        sleep: instantSleep,
+        isRetryable: (err) => !(err instanceof PermanentError),
+      }),
+    ).rejects.toBeInstanceOf(PermanentError);
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  it("sleeps between attempts using the backoff curve (base doubling, capped, jittered)", async () => {
+    const delays: number[] = [];
+    const sleep = vi.fn(async (ms: number) => {
+      delays.push(ms);
+    });
+    const fn = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("1"))
+      .mockRejectedValueOnce(new Error("2"))
+      .mockResolvedValueOnce("ok");
+    await retryWithBackoff(fn, {
+      attempts: 3,
+      baseDelayMs: 100,
+      maxDelayMs: 10_000,
+      sleep,
+      random: () => 1 - Number.EPSILON, // read the cap directly
+    });
+    expect(delays[0]).toBeCloseTo(100, 1); // before retry 1: 100 * 2^0
+    expect(delays[1]).toBeCloseTo(200, 1); // before retry 2: 100 * 2^1
+  });
+
+  it("uses default baseDelayMs/maxDelayMs when not provided", async () => {
+    const fn = vi.fn().mockRejectedValueOnce(new Error("x")).mockResolvedValueOnce("ok");
+    await retryWithBackoff(fn, { attempts: 2, sleep: instantSleep });
+    expect(fn).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/rpc-retry.ts
+++ b/src/rpc-retry.ts
@@ -1,0 +1,101 @@
+// Shared retry-with-backoff utility for the RPC-backed pieces under the
+// "vellar-sdk/rpc" subpath (#297). Both the tx submitter (tx-rpc.ts) and the
+// balance reader (balances-rpc.ts) make a single Soroban RPC call that can
+// fail transiently (a dropped connection, a 5xx from the RPC node, a moment
+// of node unavailability) — retrying a FEW times with exponential backoff
+// (plus jitter, to avoid a thundering herd of clients retrying in lockstep)
+// smooths over that without masking a genuinely broken call.
+//
+// This is deliberately generic over the operation: it knows nothing about
+// Soroban, XDR, or transactions. Callers decide what's retryable via
+// `isRetryable` — retrying a call that failed for a NON-transient reason
+// (bad input, a real rejection) would just repeat the same failure `attempts`
+// times before giving up, burning time for no benefit.
+
+/** Configuration for {@link retryWithBackoff}. */
+export interface RetryOptions {
+  /** Maximum number of attempts, including the first (non-retry) call. Must be >= 1. */
+  attempts: number;
+  /** Base delay in ms before the first retry (attempt 2). Defaults to 200ms. */
+  baseDelayMs?: number;
+  /** Delay is never allowed to exceed this, before jitter is applied. Defaults to 5000ms. */
+  maxDelayMs?: number;
+  /**
+   * Decides whether a thrown error is worth retrying. Defaults to "always
+   * retry" — pass this when only some failures are transient (e.g. a network
+   * error yes, a validation error no).
+   */
+  isRetryable?: (err: unknown) => boolean;
+  /** Injected sleep, for tests. Defaults to a real `setTimeout`-based sleep. */
+  sleep?: (ms: number) => Promise<void>;
+  /** Injected randomness source for jitter, in `[0, 1)`. Defaults to `Math.random`. */
+  random?: () => number;
+}
+
+const DEFAULT_BASE_DELAY_MS = 200;
+const DEFAULT_MAX_DELAY_MS = 5000;
+
+/**
+ * Delay before retry number `retryIndex` (1 for the first retry, 2 for the
+ * second, ...), in ms: full exponential backoff (`base * 2^(retryIndex-1)`),
+ * capped at `maxDelayMs`, then "full jitter" — a uniform random value in
+ * `[0, cappedDelay)` — per the AWS Architecture Blog's backoff-strategy
+ * comparison. Full jitter (rather than a fixed delay, or backoff without
+ * jitter) is what actually prevents synchronized retries across many clients
+ * from re-colliding on the same schedule.
+ *
+ * Exported for testing the backoff curve directly, independent of an actual
+ * retry loop.
+ */
+export function backoffDelayMs(
+  retryIndex: number,
+  baseDelayMs: number,
+  maxDelayMs: number,
+  random: () => number = Math.random,
+): number {
+  const capped = Math.min(maxDelayMs, baseDelayMs * 2 ** (retryIndex - 1));
+  return random() * capped;
+}
+
+/**
+ * Run `fn`, retrying with exponential backoff + full jitter on failure.
+ *
+ * Resolves with `fn`'s result on the first success. Rejects with the LAST
+ * error seen once `attempts` calls have all failed (or the first non-retryable
+ * error, if `isRetryable` is given and returns false) — never swallows a
+ * failure silently.
+ *
+ * Usage (see tx-rpc.ts / balances-rpc.ts):
+ * ```ts
+ * const res = await retryWithBackoff(() => server.sendTransaction(tx), {
+ *   attempts: 3,
+ *   isRetryable: (err) => err instanceof NetworkError,
+ * });
+ * ```
+ */
+export async function retryWithBackoff<T>(fn: () => Promise<T>, options: RetryOptions): Promise<T> {
+  const attempts = options.attempts;
+  if (attempts < 1) {
+    throw new RangeError(`retryWithBackoff: attempts must be >= 1 (got ${attempts})`);
+  }
+  const baseDelayMs = options.baseDelayMs ?? DEFAULT_BASE_DELAY_MS;
+  const maxDelayMs = options.maxDelayMs ?? DEFAULT_MAX_DELAY_MS;
+  const isRetryable = options.isRetryable ?? (() => true);
+  const sleep = options.sleep ?? ((ms) => new Promise<void>((resolve) => setTimeout(resolve, ms)));
+  const random = options.random ?? Math.random;
+
+  let lastError: unknown;
+  for (let attempt = 1; attempt <= attempts; attempt++) {
+    try {
+      return await fn();
+    } catch (err) {
+      lastError = err;
+      const isLastAttempt = attempt === attempts;
+      if (isLastAttempt || !isRetryable(err)) throw err;
+      await sleep(backoffDelayMs(attempt, baseDelayMs, maxDelayMs, random));
+    }
+  }
+  // Unreachable (the loop always returns or throws), but keeps TS satisfied
+  // and guards against a future refactor silently falling through.
+  throw lastError;
+}

--- a/src/rpc.ts
+++ b/src/rpc.ts
@@ -3,3 +3,7 @@
 // touch the network don't bundle the SDK.
 export * from "./balances-rpc";
 export * from "./tx-rpc";
+// The shared retry-with-backoff utility (#297) used by both of the above.
+// Pure (no @stellar/stellar-sdk import), but exported here since it's the
+// natural place a caller configuring `retry` options on either would look.
+export * from "./rpc-retry";

--- a/src/tx-rpc.test.ts
+++ b/src/tx-rpc.test.ts
@@ -5,6 +5,20 @@ import {
   TokenBucket,
 } from "./tx-rpc";
 
+// Transaction.fromXDR(signedXdr, "base64") is called unconditionally before
+// the injected `server` is ever touched. Stub it so these tests (which are
+// only exercising the retry wiring, not XDR parsing) don't depend on the
+// installed @stellar/stellar-sdk version's exact static API — a pre-existing,
+// unrelated mismatch (see the tsc error on this line) that is out of scope
+// for the #297 retry-utility work.
+vi.mock("@stellar/stellar-sdk", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@stellar/stellar-sdk")>();
+  return {
+    ...actual,
+    Transaction: { fromXDR: vi.fn(() => ({}) as never) },
+  };
+});
+
 describe("TokenBucket", () => {
   it("allows burst calls up to bucket size then rejects", () => {
     let now = 0;
@@ -41,5 +55,55 @@ describe("createRpcTxSubmitter", () => {
 
     await expect(submitter.submitTransaction("AAAA")).rejects.toBeInstanceOf(RateLimitError);
     expect(sendTransaction).not.toHaveBeenCalled();
+  });
+
+  describe("retry (#297 — shared with balances-rpc.ts via ./rpc-retry)", () => {
+    it("makes a single attempt when no retry option is given (pre-#297 behaviour)", async () => {
+      const sendTransaction = vi.fn().mockRejectedValue(new Error("network blip"));
+      const submitter = createRpcTxSubmitter({
+        rpcUrl: "https://rpc.test",
+        server: { sendTransaction } as never,
+      });
+      await expect(submitter.submitTransaction("AAAA")).rejects.toThrow("network blip");
+      expect(sendTransaction).toHaveBeenCalledTimes(1);
+    });
+
+    it("retries sendTransaction on transient failure and succeeds", async () => {
+      const sendTransaction = vi
+        .fn()
+        .mockRejectedValueOnce(new Error("network blip"))
+        .mockResolvedValueOnce({ status: "PENDING", hash: "txhash123" });
+      const submitter = createRpcTxSubmitter({
+        rpcUrl: "https://rpc.test",
+        server: { sendTransaction } as never,
+        retry: { attempts: 3, sleep: vi.fn().mockResolvedValue(undefined) },
+      });
+      const result = await submitter.submitTransaction("AAAA");
+      expect(result.hash).toBe("txhash123");
+      expect(sendTransaction).toHaveBeenCalledTimes(2);
+    });
+
+    it("gives up and rejects once retry attempts are exhausted", async () => {
+      const sendTransaction = vi.fn().mockRejectedValue(new Error("still down"));
+      const submitter = createRpcTxSubmitter({
+        rpcUrl: "https://rpc.test",
+        server: { sendTransaction } as never,
+        retry: { attempts: 2, sleep: vi.fn().mockResolvedValue(undefined) },
+      });
+      await expect(submitter.submitTransaction("AAAA")).rejects.toThrow("still down");
+      expect(sendTransaction).toHaveBeenCalledTimes(2);
+    });
+
+    it("checks the rate limiter before retrying, not once per retry", async () => {
+      const sendTransaction = vi.fn();
+      const submitter = createRpcTxSubmitter({
+        rpcUrl: "https://rpc.test",
+        rateLimit: { bucketSize: 0, refillRate: 0 },
+        server: { sendTransaction } as never,
+        retry: { attempts: 3, sleep: vi.fn().mockResolvedValue(undefined) },
+      });
+      await expect(submitter.submitTransaction("AAAA")).rejects.toBeInstanceOf(RateLimitError);
+      expect(sendTransaction).not.toHaveBeenCalled();
+    });
   });
 });

--- a/src/tx-rpc.ts
+++ b/src/tx-rpc.ts
@@ -1,5 +1,6 @@
 import { rpc, StrKey, Transaction } from "@stellar/stellar-sdk";
 import type { TxStatus, TxStatusReader } from "./tx-status";
+import { retryWithBackoff, type RetryOptions } from "./rpc-retry";
 
 // RPC-backed pieces of the payment flow (subpath export — see rpc.ts).
 
@@ -47,6 +48,15 @@ export interface RpcTxSubmitterOptions {
   rateLimit?: RpcRateLimitOptions;
   /** Injected RPC server (for tests). Defaults to a new rpc.Server(rpcUrl). */
   server?: Pick<rpc.Server, "sendTransaction">;
+  /**
+   * Retry `sendTransaction` with exponential backoff on failure, via the
+   * shared ./rpc-retry utility (#297) — a dropped connection or a transient
+   * RPC-node error shouldn't fail the whole submission. Omit for no retry
+   * (the pre-#297 behaviour: one attempt, fail immediately). `isRetryable`
+   * defaults to "retry any thrown error"; narrow it if some failures (e.g. a
+   * malformed transaction) should fail fast instead.
+   */
+  retry?: RetryOptions;
 }
 
 export interface RpcTxSubmitter {
@@ -100,7 +110,10 @@ export function createRpcTxSubmitter(options: RpcTxSubmitterOptions): RpcTxSubmi
         throw new RateLimitError();
       }
       const tx = Transaction.fromXDR(signedXdr, "base64");
-      const res = await server.sendTransaction(tx);
+
+      const send = () => server.sendTransaction(tx);
+      const res = options.retry ? await retryWithBackoff(send, options.retry) : await send();
+
       if (res.status === "ERROR") {
         throw new Error(
           res.errorResult?.toXDR("base64") ?? "sendTransaction failed",


### PR DESCRIPTION
closes #297

## Summary

src/rpc.ts and src/tx-rpc.ts (the RPC subpath's current contents) had no retry-with-backoff logic of their own to extract — I confirmed this by grepping the full repo history and current src tree before starting (see my comment on the issue). What did exist: two single-attempt RPC calls that both could benefit from the same retry treatment — createRpcTxSubmitter's sendTransaction and createRpcBalanceReader's simulateTransaction (in src/balances-rpc.ts, re-exported alongside tx-rpc.ts via the same rpc.ts subpath barrel). Neither retried on a transient failure.

This adds the shared retry utility as new functionality and wires both call sites to it, which is the DRY outcome the issue asks for even though the starting state wasn't literal duplication.

## Changes

- New `src/rpc-retry.ts`: `retryWithBackoff(fn, options)` — exponential backoff with full jitter (per the AWS backoff-strategy writeup), generic over the operation. `backoffDelayMs` is exported separately so the backoff curve itself is testable independent of the retry loop.
- `createRpcTxSubmitter` (src/tx-rpc.ts) and `createRpcBalanceReader` (src/balances-rpc.ts) both gain an optional `retry: RetryOptions` option. Omitting it keeps the pre-existing single-attempt behaviour on both.
- `createRpcBalanceReader` also gains a `server` injection option (mirroring the one `createRpcTxSubmitter` already had), so its retry wiring is testable without a live RPC connection.
- `src/rpc.ts` re-exports `rpc-retry.ts` alongside the two modules that use it.

## Tests

- `src/rpc-retry.test.ts`: the backoff curve (exponential scaling, cap, full jitter, default random source) and the retry loop itself (succeeds first try, retries then succeeds, exhausts attempts and rejects with the last error, `attempts < 1` throws `RangeError`, `isRetryable` short-circuits, actual sleep durations follow the curve).
- `src/tx-rpc.test.ts`: retry wiring on `createRpcTxSubmitter` — no retry by default, retries and succeeds, exhausts and rejects, and the rate limiter is checked once (not once per retry).
- `src/balances-rpc.test.ts` (new): equivalent retry-wiring coverage for `createRpcBalanceReader`.

Both `tx-rpc.ts`'s `Transaction.fromXDR` and the new tests needed a narrow, test-only mock for that call — the installed `@stellar/stellar-sdk` version's static API doesn't have `Transaction.fromXDR` (a pre-existing mismatch also visible as a `tsc` error on `dev`, unrelated to this change and out of scope here).

## Test plan

- [x] `npx vitest run src/rpc-retry.test.ts src/tx-rpc.test.ts src/balances-rpc.test.ts` — 22 tests pass
- [x] `npm run typecheck` — no new errors vs. base `dev` (the pre-existing `Transaction.fromXDR` and unrelated `balances.test.ts` errors are unchanged)
- [x] `npm test` — same 6 pre-existing failing files (contrib WebAuthn-environment tests, unrelated) as an unmodified `dev` checkout