### PR TITLE
Add cleanup helper, rollback docs, fixture validation, and connector audit

### DIFF
--- a/contrib/issue-298-audit.md
+++ b/contrib/issue-298-audit.md
@@ -1,0 +1,25 @@
+# Issue #298 — Legacy Connector Dead Code Audit
+
+## Finding
+
+The issue states that `connector.ts` contains a legacy fallback connection path
+that was superseded and is no longer referenced.
+
+After auditing the codebase, `src/connector.ts` contains only a pure TypeScript
+interface definition (`WalletConnector`) with no implementation code, fallback
+paths, or helper functions. The concrete implementation lives in
+`src/passkeykit-connector.ts`, which contains no legacy fallback paths either.
+
+**No dead code exists to remove.** The legacy fallback path was either already
+cleaned up in a prior release or was never present in the current codebase.
+
+## Verification
+
+- `connector.ts` — 19 lines, interface-only, no functions or helpers
+- `passkeykit-connector.ts` — single implementation path, no fallback branches
+- No callers reference any legacy or fallback connector functions
+- Existing tests (`passkeykit-connector.test.ts`) pass without changes
+
+## Recommendation
+
+This issue can be closed as already resolved. No code changes are required.

--- a/contrib/policy-template-validation.test.ts
+++ b/contrib/policy-template-validation.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from "vitest";
+import {
+  validatePolicyTemplate,
+  validatePolicyTemplates,
+  VALID_SPENDING_LIMIT_TEMPLATE,
+  VALID_SIGNER_LIMITS_TEMPLATE,
+  VALID_NO_ENFORCEMENT_TEMPLATE,
+} from "./policy-template-validation";
+
+describe("validatePolicyTemplate", () => {
+  it("accepts a valid spending_limit template", () => {
+    expect(validatePolicyTemplate(VALID_SPENDING_LIMIT_TEMPLATE)).toEqual({ valid: true, errors: [] });
+  });
+
+  it("accepts a valid signer-limits template", () => {
+    expect(validatePolicyTemplate(VALID_SIGNER_LIMITS_TEMPLATE)).toEqual({ valid: true, errors: [] });
+  });
+
+  it("accepts a valid no-enforcement template", () => {
+    expect(validatePolicyTemplate(VALID_NO_ENFORCEMENT_TEMPLATE)).toEqual({ valid: true, errors: [] });
+  });
+
+  it("rejects non-object input", () => {
+    const result = validatePolicyTemplate(null);
+    expect(result.valid).toBe(false);
+    expect(result.errors).toContain("template is not an object");
+  });
+
+  it("rejects template with missing type", () => {
+    const result = validatePolicyTemplate({ title: "x", description: "y", enforcement: { kind: "none" } });
+    expect(result.valid).toBe(false);
+    expect(result.errors).toContain("missing or non-string 'type'");
+  });
+
+  it("rejects template with invalid enforcement", () => {
+    const result = validatePolicyTemplate({
+      type: "spending_limit",
+      title: "x",
+      description: "y",
+      enforcement: { kind: "unknown_kind" },
+    });
+    expect(result.valid).toBe(false);
+    expect(result.errors).toContain("missing or invalid 'enforcement'");
+  });
+
+  it("rejects policy-contract enforcement without wasmHash", () => {
+    const result = validatePolicyTemplate({
+      type: "spending_limit",
+      title: "x",
+      description: "y",
+      enforcement: { kind: "policy-contract" },
+    });
+    expect(result.valid).toBe(false);
+    expect(result.errors).toContain("missing or invalid 'enforcement'");
+  });
+});
+
+describe("validatePolicyTemplates (batch)", () => {
+  it("validates a list of good fixtures", () => {
+    const result = validatePolicyTemplates([
+      VALID_SPENDING_LIMIT_TEMPLATE,
+      VALID_SIGNER_LIMITS_TEMPLATE,
+      VALID_NO_ENFORCEMENT_TEMPLATE,
+    ]);
+    expect(result.valid).toBe(true);
+    expect(result.errors).toEqual([]);
+  });
+
+  it("detects an invalid fixture in a batch", () => {
+    const result = validatePolicyTemplates([
+      VALID_SPENDING_LIMIT_TEMPLATE,
+      { type: 123, title: null, description: true, enforcement: "bad" },
+      VALID_NO_ENFORCEMENT_TEMPLATE,
+    ]);
+    expect(result.valid).toBe(false);
+    expect(result.errors.length).toBeGreaterThan(0);
+    expect(result.errors[0]).toMatch(/^fixture\[1\]/);
+  });
+
+  it("reports multiple invalid fixtures", () => {
+    const result = validatePolicyTemplates([{}, null, { type: "ok", title: "ok", description: "ok", enforcement: { kind: "none" } }]);
+    expect(result.valid).toBe(false);
+    expect(result.errors.length).toBeGreaterThanOrEqual(2);
+    expect(result.errors[0]).toMatch(/^fixture\[0\]/);
+    expect(result.errors.some((e) => e.startsWith("fixture[1]"))).toBe(true);
+  });
+});

--- a/contrib/policy-template-validation.ts
+++ b/contrib/policy-template-validation.ts
@@ -1,0 +1,85 @@
+/**
+ * Policy template fixture validation.
+ *
+ * Ensures that policy template fixtures used across the test suite match
+ * the current PolicyTemplateInfo schema. Catches silently stale fixtures
+ * when the schema evolves.
+ */
+
+import type { PolicyTemplateInfo, Enforcement } from "../src/policy-types";
+
+export interface ValidationResult {
+  valid: boolean;
+  errors: string[];
+}
+
+function isString(v: unknown): v is string {
+  return typeof v === "string";
+}
+
+function isEnforcement(v: unknown): v is Enforcement {
+  if (typeof v !== "object" || v === null) return false;
+  const obj = v as Record<string, unknown>;
+  switch (obj.kind) {
+    case "policy-contract":
+      return isString(obj.wasmHash);
+    case "signer-limits":
+    case "none":
+    case "custom-contract-pending":
+      return true;
+    default:
+      return false;
+  }
+}
+
+export function validatePolicyTemplate(t: unknown): ValidationResult {
+  const errors: string[] = [];
+  if (typeof t !== "object" || t === null) {
+    return { valid: false, errors: ["template is not an object"] };
+  }
+  const obj = t as Record<string, unknown>;
+
+  if (!isString(obj.type)) errors.push("missing or non-string 'type'");
+  if (!isString(obj.title)) errors.push("missing or non-string 'title'");
+  if (!isString(obj.description)) errors.push("missing or non-string 'description'");
+  if (!isEnforcement(obj.enforcement)) errors.push("missing or invalid 'enforcement'");
+
+  return { valid: errors.length === 0, errors };
+}
+
+export function validatePolicyTemplates(fixtures: unknown[]): ValidationResult {
+  const allErrors: string[] = [];
+  for (let i = 0; i < fixtures.length; i++) {
+    const result = validatePolicyTemplate(fixtures[i]);
+    if (!result.valid) {
+      for (const err of result.errors) {
+        allErrors.push(`fixture[${i}]: ${err}`);
+      }
+    }
+  }
+  return { valid: allErrors.length === 0, errors: allErrors };
+}
+
+/** A valid policy template fixture for use in tests. */
+export const VALID_SPENDING_LIMIT_TEMPLATE: PolicyTemplateInfo = {
+  type: "spending_limit",
+  title: "Spending limit",
+  description: "Limits daily and per-transaction spending.",
+  enforcement: { kind: "policy-contract", wasmHash: "ABCDEF1234567890" },
+};
+
+/** A valid policy template with signer-limits enforcement. */
+export const VALID_SIGNER_LIMITS_TEMPLATE: PolicyTemplateInfo = {
+  type: "signer_limits",
+  title: "Signer limits",
+  description: "Enforced by the smart wallet native signer limits.",
+  enforcement: { kind: "signer-limits" },
+};
+
+/** A valid policy template with no enforcement. */
+export const VALID_NO_ENFORCEMENT_TEMPLATE: PolicyTemplateInfo = {
+  type: "default",
+  title: "Default",
+  description: "Default single-owner behaviour.",
+  enforcement: { kind: "none" },
+};

--- a/contrib/rollback-guidance.md
+++ b/contrib/rollback-guidance.md
@@ -1,0 +1,65 @@
+# Rollback Guidance for Broken Published SDK Versions
+
+When a published SDK version turns out to be broken after release, follow this
+procedure to minimize disruption for consumers.
+
+## 1. Deprecate the broken version on npm
+
+Mark the broken version as deprecated so `npm install` warns consumers:
+
+```sh
+npm deprecate vellar-sdk@<broken-version> "This version is broken — upgrade to <fixed-version>"
+```
+
+Replace `<broken-version>` with the exact semver (e.g. `0.7.0`) and
+`<fixed-version>` with the next patch release (e.g. `0.7.1`).
+
+## 2. Fast-follow with a patch release
+
+1. Fix the issue on a branch off `dev`.
+2. Bump the patch version in `package.json` (e.g. `0.7.0` → `0.7.1`).
+3. Update `CHANGELOG.md` with the fix (see step 3 below).
+4. Open a PR targeting `dev`, get it reviewed and merged.
+5. A maintainer cuts the release from `main` as usual.
+
+**Do not unpublish the broken version** — consumers may already have it cached
+in lockfiles, and unpublishing creates a supply-chain gap.
+
+## 3. Notify consumers via CHANGELOG.md
+
+Add an entry at the top of `CHANGELOG.md` in the new release section:
+
+```markdown
+## X.Y.Z — YYYY-MM-DD
+
+**Hotfix for X.Y.W.** That version contained <brief description of the bug>.
+Upgrade to this release to get the fix.
+
+### What changed
+
+- <one-line description of the fix>
+
+### Migration
+
+No breaking changes. Replace `vellar-sdk@X.Y.W` with `vellar-sdk@X.Y.Z` in
+your dependencies.
+```
+
+Keep the entry concise — consumers scanning the changelog need to know three
+things: what was broken, what's fixed, and whether migration is required.
+
+## 4. Communicate beyond the changelog
+
+- Post in the [Telegram group](https://t.me/+RWPCKXXJTj45Njk0) with a link to
+  the changelog entry.
+- If the break is security-critical, open a GitHub Advisory and follow the
+  security disclosure process.
+
+## Quick reference
+
+| Step | Command / Action |
+|------|-----------------|
+| Deprecate | `npm deprecate vellar-sdk@X.Y.W "..."` |
+| Fix | Branch off `dev`, patch, PR, merge |
+| Release | Bump version, update CHANGELOG, maintainer cuts release |
+| Notify | Telegram post + changelog entry |

--- a/contrib/tx-status-cleanup.test.ts
+++ b/contrib/tx-status-cleanup.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it } from "vitest";
+import {
+  cleanupStaleEntries,
+  createCachedStatusStore,
+  type CacheEntry,
+} from "./tx-status-cleanup";
+
+function entry<T>(value: T, ageMs: number, now: number): CacheEntry<T> {
+  return { value, createdAt: now - ageMs };
+}
+
+describe("cleanupStaleEntries", () => {
+  it("removes entries older than maxAgeMs", () => {
+    const now = 1_000_000;
+    const cache = new Map<string, CacheEntry<string>>([
+      ["fresh", entry("a", 100, now)],
+      ["stale", entry("b", 200_000, now)],
+    ]);
+    const cleaned = cleanupStaleEntries(cache, { maxAgeMs: 150_000, now: () => now });
+    expect(cleaned.size).toBe(1);
+    expect(cleaned.get("fresh")?.value).toBe("a");
+    expect(cleaned.has("stale")).toBe(false);
+  });
+
+  it("keeps all entries when none are stale", () => {
+    const now = 1_000_000;
+    const cache = new Map<string, CacheEntry<number>>([
+      ["a", entry(1, 10, now)],
+      ["b", entry(2, 20, now)],
+    ]);
+    const cleaned = cleanupStaleEntries(cache, { maxAgeMs: 1000, now: () => now });
+    expect(cleaned.size).toBe(2);
+  });
+
+  it("returns empty map when all entries are stale", () => {
+    const now = 1_000_000;
+    const cache = new Map<string, CacheEntry<string>>([
+      ["a", entry("x", 500_000, now)],
+      ["b", entry("y", 600_000, now)],
+    ]);
+    const cleaned = cleanupStaleEntries(cache, { maxAgeMs: 100_000, now: () => now });
+    expect(cleaned.size).toBe(0);
+  });
+
+  it("does not mutate the original map", () => {
+    const now = 1_000_000;
+    const cache = new Map<string, CacheEntry<string>>([
+      ["stale", entry("x", 500_000, now)],
+    ]);
+    cleanupStaleEntries(cache, { maxAgeMs: 100_000, now: () => now });
+    expect(cache.size).toBe(1);
+  });
+
+  it("defaults maxAgeMs to 1 hour", () => {
+    const now = 3_600_000;
+    const cache = new Map<string, CacheEntry<string>>([
+      ["at-limit", entry("a", 3_600_000, now)],
+      ["just-over", entry("b", 3_600_001, now)],
+    ]);
+    const cleaned = cleanupStaleEntries(cache, { now: () => now });
+    expect(cleaned.size).toBe(1);
+    expect(cleaned.has("at-limit")).toBe(true);
+  });
+});
+
+describe("createCachedStatusStore", () => {
+  it("stores and retrieves values", () => {
+    const store = createCachedStatusStore<string>({ now: () => 1000 });
+    store.set("tx1", "success");
+    expect(store.get("tx1")).toBe("success");
+    expect(store.size).toBe(1);
+  });
+
+  it("returns undefined for missing keys", () => {
+    const store = createCachedStatusStore<string>();
+    expect(store.get("nonexistent")).toBeUndefined();
+  });
+
+  it("cleanup removes only stale entries and returns count", () => {
+    let time = 0;
+    const store = createCachedStatusStore<string>({
+      maxAgeMs: 100_000,
+      now: () => time,
+    });
+
+    time = 50_000;
+    store.set("stale1", "c");
+    store.set("stale2", "d");
+    time = 200_000;
+    store.set("fresh1", "a");
+    store.set("fresh2", "b");
+
+    const removed = store.cleanup();
+    expect(removed).toBe(2);
+    expect(store.size).toBe(2);
+    expect(store.get("fresh1")).toBe("a");
+    expect(store.get("fresh2")).toBe("b");
+    expect(store.get("stale1")).toBeUndefined();
+    expect(store.get("stale2")).toBeUndefined();
+  });
+
+  it("cleanup returns 0 when nothing is stale", () => {
+    const store = createCachedStatusStore<number>({ now: () => 1000 });
+    store.set("a", 1);
+    expect(store.cleanup()).toBe(0);
+    expect(store.size).toBe(1);
+  });
+
+  it("entries() exposes the underlying cache", () => {
+    const store = createCachedStatusStore<string>({ now: () => 1000 });
+    store.set("tx1", "pending");
+    const entries = store.entries();
+    expect(entries.size).toBe(1);
+    expect(entries.get("tx1")?.value).toBe("pending");
+  });
+});

--- a/contrib/tx-status-cleanup.ts
+++ b/contrib/tx-status-cleanup.ts
@@ -1,0 +1,92 @@
+/**
+ * Cleanup helper for stale cached tx-status entries.
+ *
+ * The tx-status module polls until a transaction reaches a final state, but
+ * callers that cache status entries in memory may accumulate stale entries for
+ * transactions that completed long ago. This utility provides a configurable
+ * cleanup pass that removes entries past a defined age.
+ */
+
+export interface CacheEntry<T> {
+  value: T;
+  createdAt: number;
+}
+
+export interface CleanupOptions {
+  /** Maximum age in milliseconds before an entry is considered stale. Default: 1 hour. */
+  maxAgeMs?: number;
+  /** Current time provider for testability. Default: Date.now. */
+  now?: () => number;
+}
+
+/**
+ * Remove stale entries from a Map of cache entries.
+ *
+ * Returns a new Map containing only entries whose `createdAt` is within
+ * `maxAgeMs` of the current time. The original map is not mutated.
+ *
+ * @param cache - Map of key → CacheEntry to clean
+ * @param options - Cleanup configuration
+ * @returns New Map with stale entries removed
+ */
+export function cleanupStaleEntries<T>(
+  cache: Map<string, CacheEntry<T>>,
+  options: CleanupOptions = {},
+): Map<string, CacheEntry<T>> {
+  const maxAgeMs = options.maxAgeMs ?? 60 * 60 * 1000;
+  const now = options.now ?? Date.now;
+  const cutoff = now() - maxAgeMs;
+  const cleaned = new Map<string, CacheEntry<T>>();
+
+  for (const [key, entry] of cache) {
+    if (entry.createdAt >= cutoff) {
+      cleaned.set(key, entry);
+    }
+  }
+
+  return cleaned;
+}
+
+/**
+ * Create a cached status store with built-in cleanup.
+ *
+ * Wraps a Map and exposes `get`, `set`, and `cleanup` methods. The `cleanup`
+ * method prunes entries older than `maxAgeMs`.
+ */
+export function createCachedStatusStore<T>(options: CleanupOptions = {}) {
+  const maxAgeMs = options.maxAgeMs ?? 60 * 60 * 1000;
+  const now = options.now ?? Date.now;
+  const cache = new Map<string, CacheEntry<T>>();
+
+  return {
+    get(key: string): T | undefined {
+      return cache.get(key)?.value;
+    },
+
+    set(key: string, value: T): void {
+      cache.set(key, { value, createdAt: now() });
+    },
+
+    /** Remove entries older than maxAgeMs. Returns the number of entries removed. */
+    cleanup(): number {
+      const before = cache.size;
+      const cutoff = now() - maxAgeMs;
+      for (const [key, entry] of cache) {
+        if (entry.createdAt < cutoff) {
+          cache.delete(key);
+        }
+      }
+      return before - cache.size;
+    },
+
+    /** Current number of entries in the cache. */
+    get size(): number {
+      return cache.size;
+    },
+
+    /** Expose the underlying cache for inspection (read-only). */
+    entries(): ReadonlyMap<string, CacheEntry<T>> {
+      return cache;
+    },
+  };
+}


### PR DESCRIPTION
Closes #294, Closes #298, Closes #289, Closes #295

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Refactoring (no functional or behavioral changes)
- [ ] Performance improvement
- [x] Documentation update
- [ ] Build / CI configuration change
- [ ] Dependency update
- [ ] Other: <!-- describe -->

---

## Summary

This PR addresses four assigned issues in the contrib/ sandbox:

1. **#294** — Adds a configurable cleanup helper for stale cached tx-status entries, with `cleanupStaleEntries` and `createCachedStatusStore` utilities and full test coverage.
2. **#298** — Audits `connector.ts` for dead legacy fallback code; confirms the interface-only file contains no dead code to remove.
3. **#289** — Adds a rollback guidance document covering npm deprecation, fast-follow patch releases, and consumer notification via CHANGELOG.md.
4. **#295** — Adds schema validation for `PolicyTemplateInfo` fixtures with batch validation and intentional invalid fixture detection tests.

## Motivation / Context

Closes #294, Closes #298, Closes #289, Closes #295

All changes are scoped to `contrib/` per the contribution rules. Tests pass (534/534).