### PR TITLE
Add x402 payment completion telemetry event

### DIFF
--- a/contrib/examples/issue-296-x402-payment-telemetry/README.md
+++ b/contrib/examples/issue-296-x402-payment-telemetry/README.md
@@ -1,0 +1,122 @@
+# x402 Payment Completion Telemetry
+
+Self-contained reference for issue [#296](https://github.com/Vellar-Wallet/vellar-sdk/issues/296): emitting an optional telemetry event when an x402 payment completes.
+
+## Run tests
+
+```bash
+npx vitest run contrib/examples/issue-296-x402-payment-telemetry
+```
+
+## Why
+
+`wallet.x402.fetch()` resolves with `{ response, paid, settlement }` and that is the end of it. A host that wants to know how much its agents are spending, on what, and how often, has to instrument every call site by hand. That is the gap in consumer usage insight #296 describes.
+
+This adds one event — `x402.payment.completed` — emitted once per payment that actually settled.
+
+## Usage
+
+```ts
+import { withPaymentTelemetry } from "./x402-telemetry";
+
+const wallet = createVellarWallet({ /* ... */ });
+
+wallet.x402.fetch = withPaymentTelemetry(wallet.x402.fetch, {
+  sink: (event) => analytics.track(event.type, toJSON(event)),
+  onError: (err) => console.warn("x402 telemetry sink failed", err),
+});
+
+// Unchanged from the caller's perspective:
+const { response, settlement } = await wallet.x402.fetch(url, { maxAmount: 5_000_000n });
+```
+
+Omit `sink` and `withPaymentTelemetry` returns the original function untouched — telemetry is entirely opt-in, with no per-call cost when it's off.
+
+## The event
+
+```ts
+{
+  type: "x402.payment.completed",
+  resourceId: "https://api.test/v1/report",  // the issue's "resource id"
+  amount: 1000000n,                          // the issue's "amount", base units
+  asset: "CBIN4HTP…",                        // SEP-41 asset contract
+  network: "testnet",
+  transaction: "1f0a6c62…",                  // on-chain settlement hash
+  payer: "CAAAA…",                           // payer C-address
+  status: 200,                               // unlocked resource response
+  timestamp: 1700000000000,
+  durationMs: 250,                           // when measured
+}
+```
+
+`resourceId` and `amount` are the two properties the issue asks for; the rest is what makes an event reconcilable against chain rather than merely countable.
+
+## Design rules
+
+### Telemetry must never break a payment
+
+A payment that reaches this event has already moved real money on-chain. If the sink throws, rejects, or hangs, the caller still gets their `X402Response`. There is no configuration that lets telemetry fail a settled payment.
+
+Covered explicitly by tests: a synchronous throw, a rejected async sink, an `onError` that itself throws, and a sink that never resolves. The promise from an async sink is deliberately **not awaited** — a slow analytics call must not add latency to a payment that already settled — so its rejection is caught internally rather than surfacing as an unhandled rejection (also tested).
+
+### It must not leak secrets
+
+The event carries no request headers and no bodies. `PAYMENT-SIGNATURE` is a signed authorization, and the SDK already treats leaking it as a security bug — see [`packages/mcp-x402-payer/src/output.ts`](../../../packages/mcp-x402-payer/src/output.ts).
+
+URLs are stripped of query and fragment by default, because API keys live in query strings:
+
+| `resourceIdMode` | `https://api.test/v1/r?apiKey=secret` becomes |
+| --- | --- |
+| `"path"` (default) | `https://api.test/v1/r` |
+| `"origin"` | `https://api.test` |
+| `"full"` | unchanged — opt-in, only when you control the URLs |
+
+A URL that fails to parse still has its query and fragment cut off lexically. An unparseable URL is not a reason to log a raw secret.
+
+### Amounts stay exact
+
+Base-unit amounts are `bigint` throughout the SDK, and a stroop-precision value can exceed `Number.MAX_SAFE_INTEGER`. The event keeps the `bigint`.
+
+Because `JSON.stringify` throws on a `bigint`, `toJSON(event)` renders `amount` as a decimal string — exact, and round-trippable via `BigInt(...)`. Both the throw and the round-trip are tested, since a sink that serializes is the common case.
+
+### Only real payments count
+
+A resource that returned no 402 resolves with `paid: false`. That is a cache hit, not a payment, and emitting it would inflate every "payments made" metric built on this event. Nothing is emitted unless `paid` is true **and** a settlement is present. A failed payment emits nothing and rethrows untouched.
+
+## Semantics
+
+| Case | Result |
+|------|--------|
+| Payment settles | One event, after the result is in hand |
+| Resource needed no payment (`paid: false`) | No event |
+| `paid: true` but no settlement header | No event |
+| The fetch itself throws | No event; the error propagates unchanged |
+| Sink throws or rejects | Result still returned; `onError` called |
+| `onError` throws | Swallowed — the payment stays intact |
+| Sink is slow | Not awaited; adds no latency |
+| No `sink` configured | Original fetch returned as-is |
+
+## Aggregating spend
+
+`createMemorySink()` accumulates events and totals spend per asset — useful in tests, and as a spend-report source for a short-lived agent session:
+
+```ts
+const { sink, events, totalFor } = createMemorySink();
+wallet.x402.fetch = withPaymentTelemetry(wallet.x402.fetch, { sink });
+// ...
+totalFor(USDC_CONTRACT); // => 2000000n
+```
+
+For enforcing a budget rather than observing one, use the chain-enforced path instead — [`src/x402-budget-attributes.ts`](../../../src/x402-budget-attributes.ts) and the session-key ceiling in [`packages/mcp-x402-payer/src/ledger.ts`](../../../packages/mcp-x402-payer/src/ledger.ts). Telemetry is for insight; it is not a spending control, because a sink that fails must never block a payment.
+
+## Documentation note
+
+The issue asks for the event to be documented in the README's observability section. `README.md` sits outside `contrib/`, which contributor PRs may not touch, so the reference documentation lives in this file instead — the tables above are written to be lifted into that section verbatim when the event moves into `src/x402-client.ts`.
+
+## Moving this into the SDK
+
+`withPaymentTelemetry` wraps the public `fetch`, so it works today without SDK changes. Emitting from inside `src/x402-client.ts` would be a small change: the completion point is where `readSettlement()` returns and `x402Fetch` resolves `{ response: paid, paid: true, settlement }`. Adding an optional `telemetry?: X402TelemetryOptions` to `X402ClientDeps` (threaded through `X402FacadeDeps.config`, alongside `budgetAttributes`) and calling `buildPaymentCompletedEvent` there would emit the same event for every caller, including those who never touch the facade.
+
+## Limits
+
+One event type. No batching, sampling, or retry — a sink that wants those should implement them, since the right policy depends on the backend. `durationMs` measures the whole `fetch` call including the unpaid first request and the signing round-trip, not just the settlement.

--- a/contrib/examples/issue-296-x402-payment-telemetry/x402-telemetry.test.ts
+++ b/contrib/examples/issue-296-x402-payment-telemetry/x402-telemetry.test.ts
@@ -1,0 +1,356 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  buildPaymentCompletedEvent,
+  createMemorySink,
+  sanitizeResourceId,
+  toJSON,
+  withPaymentTelemetry,
+  type X402PaymentCompletedEvent,
+  type X402ResponseLike,
+} from "./x402-telemetry";
+
+const TOKEN = "CBIN4HTPJM2QLJ32DTRO6OCLIMM7TR7D74JDIPVQYLNYGL7SBWOXH5ND";
+const PAYER = "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABSC4";
+const TX = "1f0a6c621f0a6c631f0a6c641f0a6c651f0a6c661f0a6c671f0a6c681f0a6c69";
+
+/** A settled x402 result, as `wallet.x402.fetch()` would resolve it. */
+function paidResult(over: Partial<X402ResponseLike> = {}): X402ResponseLike {
+  return {
+    response: { status: 200 },
+    paid: true,
+    settlement: {
+      transaction: TX,
+      payer: PAYER,
+      asset: TOKEN,
+      amount: 1_000_000n,
+      network: "testnet",
+    },
+    ...over,
+  };
+}
+
+/** A resource that needed no payment. */
+const unpaidResult: X402ResponseLike = { response: { status: 200 }, paid: false };
+
+const frozenClock = () => 1_700_000_000_000;
+
+describe("sanitizeResourceId", () => {
+  it("keeps origin and path but drops the query string, where API keys live", () => {
+    expect(sanitizeResourceId("https://api.test/v1/report?apiKey=secret&x=1")).toBe(
+      "https://api.test/v1/report",
+    );
+  });
+
+  it("drops the fragment too", () => {
+    expect(sanitizeResourceId("https://api.test/v1/report#section")).toBe(
+      "https://api.test/v1/report",
+    );
+  });
+
+  it("records only the origin in origin mode", () => {
+    expect(sanitizeResourceId("https://api.test/v1/report?k=v", "origin")).toBe("https://api.test");
+  });
+
+  it("records the URL verbatim in full mode, which is opt-in", () => {
+    const url = "https://api.test/v1/report?apiKey=secret";
+    expect(sanitizeResourceId(url, "full")).toBe(url);
+  });
+
+  it("still strips query and fragment from a URL that does not parse", () => {
+    // An unparseable URL is not a reason to log a raw secret.
+    expect(sanitizeResourceId("not a url?token=secret")).toBe("not a url");
+  });
+});
+
+describe("buildPaymentCompletedEvent", () => {
+  it("carries the resource id and amount the issue asks for", () => {
+    const event = buildPaymentCompletedEvent("https://api.test/v1/report", paidResult(), {
+      now: frozenClock,
+    });
+
+    expect(event).toMatchObject({
+      type: "x402.payment.completed",
+      resourceId: "https://api.test/v1/report",
+      amount: 1_000_000n,
+    });
+  });
+
+  it("includes the settlement details needed to reconcile against chain", () => {
+    const event = buildPaymentCompletedEvent("https://api.test/r", paidResult(), {
+      now: frozenClock,
+    });
+
+    expect(event).toMatchObject({
+      asset: TOKEN,
+      network: "testnet",
+      transaction: TX,
+      payer: PAYER,
+      status: 200,
+      timestamp: 1_700_000_000_000,
+    });
+  });
+
+  it("emits nothing when the resource needed no payment", () => {
+    // A cache hit is not a payment; counting it would inflate every
+    // "payments made" metric built on this event.
+    expect(buildPaymentCompletedEvent("https://api.test/r", unpaidResult)).toBeUndefined();
+  });
+
+  it("emits nothing when paid is true but no settlement was returned", () => {
+    const noSettlement = paidResult({ settlement: undefined });
+    expect(buildPaymentCompletedEvent("https://api.test/r", noSettlement)).toBeUndefined();
+  });
+
+  it("keeps a stroop-precision amount exact, beyond Number.MAX_SAFE_INTEGER", () => {
+    const huge = 9_007_199_254_740_993n; // MAX_SAFE_INTEGER + 2
+    const event = buildPaymentCompletedEvent(
+      "https://api.test/r",
+      paidResult({ settlement: { ...paidResult().settlement!, amount: huge } }),
+      { now: frozenClock },
+    );
+
+    expect(event?.amount).toBe(huge);
+    // The lossy alternative, for contrast: converting to Number rounds this
+    // value down, so a Number-typed amount would silently misreport the spend.
+    expect(BigInt(Number(huge))).not.toBe(huge);
+  });
+
+  it("omits durationMs entirely when it was not measured", () => {
+    const event = buildPaymentCompletedEvent("https://api.test/r", paidResult(), {
+      now: frozenClock,
+    });
+    expect(event).not.toHaveProperty("durationMs");
+  });
+});
+
+describe("toJSON", () => {
+  it("renders the bigint amount as a decimal string, since JSON has no bigint", () => {
+    const event = buildPaymentCompletedEvent("https://api.test/r", paidResult(), {
+      now: frozenClock,
+    })!;
+
+    expect(toJSON(event).amount).toBe("1000000");
+    // The trap this exists to remove.
+    expect(() => JSON.stringify(event)).toThrow(TypeError);
+    expect(() => JSON.stringify(toJSON(event))).not.toThrow();
+  });
+
+  it("round-trips a huge amount without precision loss", () => {
+    const huge = 9_007_199_254_740_993n;
+    const event = buildPaymentCompletedEvent(
+      "https://api.test/r",
+      paidResult({ settlement: { ...paidResult().settlement!, amount: huge } }),
+      { now: frozenClock },
+    )!;
+
+    expect(BigInt(toJSON(event).amount as string)).toBe(huge);
+  });
+});
+
+describe("withPaymentTelemetry", () => {
+  it("emits exactly one event per completed payment, and returns the result untouched", async () => {
+    const { sink, events } = createMemorySink();
+    const result = paidResult();
+    const fetchImpl = vi.fn(async () => result);
+
+    const wrapped = withPaymentTelemetry(fetchImpl, { sink, now: frozenClock });
+    const returned = await wrapped("https://api.test/v1/report?key=secret", {});
+
+    expect(returned).toBe(result);
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({
+      resourceId: "https://api.test/v1/report",
+      amount: 1_000_000n,
+    });
+  });
+
+  it("emits nothing for a resource that needed no payment", async () => {
+    const { sink, events } = createMemorySink();
+    const wrapped = withPaymentTelemetry(async () => unpaidResult, { sink });
+
+    await wrapped("https://api.test/free", {});
+
+    expect(events).toEqual([]);
+  });
+
+  it("returns the original fetch untouched when no sink is configured", () => {
+    const fetchImpl = vi.fn(async () => paidResult());
+    expect(withPaymentTelemetry(fetchImpl, {})).toBe(fetchImpl);
+  });
+
+  it("passes url and init through unchanged", async () => {
+    const { sink } = createMemorySink();
+    const fetchImpl = vi.fn(async () => paidResult());
+    const init = { maxAmount: 5_000_000n };
+
+    await withPaymentTelemetry(fetchImpl, { sink })("https://api.test/r", init);
+
+    expect(fetchImpl).toHaveBeenCalledWith("https://api.test/r", init);
+  });
+
+  it("records how long the paid fetch took", async () => {
+    const { sink, events } = createMemorySink();
+    let t = 1000;
+    const now = () => t;
+    const wrapped = withPaymentTelemetry(
+      async () => {
+        t += 250;
+        return paidResult();
+      },
+      { sink, now },
+    );
+
+    await wrapped("https://api.test/r", {});
+
+    expect(events[0].durationMs).toBe(250);
+  });
+
+  it("honours resourceIdMode", async () => {
+    const { sink, events } = createMemorySink();
+    const wrapped = withPaymentTelemetry(async () => paidResult(), {
+      sink,
+      resourceIdMode: "origin",
+    });
+
+    await wrapped("https://api.test/v1/report", {});
+
+    expect(events[0].resourceId).toBe("https://api.test");
+  });
+});
+
+describe("withPaymentTelemetry — telemetry must never break a payment", () => {
+  it("still returns the settled result when the sink throws synchronously", async () => {
+    const result = paidResult();
+    const onError = vi.fn();
+    const wrapped = withPaymentTelemetry(async () => result, {
+      sink: () => {
+        throw new Error("analytics down");
+      },
+      onError,
+    });
+
+    // The payment already moved real money on-chain. A broken sink cannot
+    // be allowed to turn that into a rejected call.
+    await expect(wrapped("https://api.test/r", {})).resolves.toBe(result);
+    expect(onError).toHaveBeenCalledTimes(1);
+    expect((onError.mock.calls[0][0] as Error).message).toBe("analytics down");
+  });
+
+  it("still returns the settled result when an async sink rejects", async () => {
+    const result = paidResult();
+    const onError = vi.fn();
+    const wrapped = withPaymentTelemetry(async () => result, {
+      sink: async () => {
+        throw new Error("network down");
+      },
+      onError,
+    });
+
+    await expect(wrapped("https://api.test/r", {})).resolves.toBe(result);
+    // The rejection is caught asynchronously; let the microtask queue drain.
+    await vi.waitFor(() => expect(onError).toHaveBeenCalledTimes(1));
+  });
+
+  it("does not produce an unhandled rejection from a rejecting sink", async () => {
+    const unhandled = vi.fn();
+    process.on("unhandledRejection", unhandled);
+    try {
+      const wrapped = withPaymentTelemetry(async () => paidResult(), {
+        sink: async () => {
+          throw new Error("boom");
+        },
+      });
+
+      await wrapped("https://api.test/r", {});
+      await new Promise((resolve) => setTimeout(resolve, 10));
+
+      expect(unhandled).not.toHaveBeenCalled();
+    } finally {
+      process.off("unhandledRejection", unhandled);
+    }
+  });
+
+  it("survives an onError that itself throws", async () => {
+    const result = paidResult();
+    const wrapped = withPaymentTelemetry(async () => result, {
+      sink: () => {
+        throw new Error("sink");
+      },
+      onError: () => {
+        throw new Error("handler");
+      },
+    });
+
+    await expect(wrapped("https://api.test/r", {})).resolves.toBe(result);
+  });
+
+  it("does not await a slow sink, so telemetry adds no latency to a settled payment", async () => {
+    let released!: () => void;
+    const blocked = new Promise<void>((resolve) => (released = resolve));
+
+    const wrapped = withPaymentTelemetry(async () => paidResult(), {
+      sink: () => blocked,
+    });
+
+    // Resolves while the sink is still pending.
+    await expect(wrapped("https://api.test/r", {})).resolves.toBeDefined();
+    released();
+  });
+
+  it("emits nothing and rethrows when the payment itself fails", async () => {
+    const { sink, events } = createMemorySink();
+    const boom = new Error("payment rejected");
+    const wrapped = withPaymentTelemetry(
+      async () => {
+        throw boom;
+      },
+      { sink },
+    );
+
+    await expect(wrapped("https://api.test/r", {})).rejects.toBe(boom);
+    expect(events).toEqual([]);
+  });
+});
+
+describe("createMemorySink", () => {
+  it("totals spend per asset across recorded payments", async () => {
+    const { sink, totalFor } = createMemorySink();
+    const wrapped = withPaymentTelemetry(async () => paidResult(), { sink });
+
+    await wrapped("https://api.test/a", {});
+    await wrapped("https://api.test/b", {});
+
+    expect(totalFor(TOKEN)).toBe(2_000_000n);
+    expect(totalFor("COTHER")).toBe(0n);
+  });
+});
+
+describe("event shape", () => {
+  it("carries no request headers or bodies, so PAYMENT-SIGNATURE cannot leak", () => {
+    const event = buildPaymentCompletedEvent("https://api.test/r", paidResult(), {
+      now: frozenClock,
+      durationMs: 12,
+    })!;
+
+    const keys = Object.keys(event) as Array<keyof X402PaymentCompletedEvent>;
+    expect(keys.sort()).toEqual(
+      [
+        "amount",
+        "asset",
+        "durationMs",
+        "network",
+        "payer",
+        "resourceId",
+        "status",
+        "timestamp",
+        "transaction",
+        "type",
+      ].sort(),
+    );
+
+    // Nothing that could carry the signed authorization or a credential.
+    const serialized = JSON.stringify(toJSON(event));
+    expect(serialized).not.toMatch(/PAYMENT-SIGNATURE/i);
+    expect(serialized).not.toMatch(/header|body|authorization|cookie/i);
+  });
+});

--- a/contrib/examples/issue-296-x402-payment-telemetry/x402-telemetry.ts
+++ b/contrib/examples/issue-296-x402-payment-telemetry/x402-telemetry.ts
@@ -1,0 +1,284 @@
+/**
+ * Telemetry for x402 payment completion.
+ *
+ * Contributed for issue #296: an x402 payment completing is not currently
+ * tracked as a telemetry event, leaving a gap in consumer usage insight.
+ * `wallet.x402.fetch()` returns `{ response, paid, settlement }` and that is
+ * the end of it — a host that wants to know how much its agents are spending
+ * has to instrument every call site itself.
+ *
+ * This is the event, plus the wrapper that emits it, written against the real
+ * `X402Response` shape so it can wrap `wallet.x402` today and move into
+ * `src/x402-client.ts` unchanged.
+ *
+ * ── Design rules, in the order they mattered ─────────────────────────────
+ *
+ * 1. TELEMETRY MUST NEVER BREAK A PAYMENT. A payment that settled on-chain
+ *    has already moved real money. If the emitter throws — a bad sink, a
+ *    serialization bug, an analytics SDK that is down — the caller must still
+ *    get their `X402Response`. Every emit is wrapped, and a throwing sink is
+ *    reported through `onError` rather than propagated. There is no
+ *    configuration that makes telemetry able to fail a settled payment.
+ *
+ * 2. IT MUST NOT LEAK SECRETS. The event carries the resource URL, the
+ *    settlement hash, the asset, and the amount. It deliberately does NOT
+ *    carry request headers or bodies: `PAYMENT-SIGNATURE` is a signed
+ *    authorization, and the SDK already treats leaking it as a security bug
+ *    (see `packages/mcp-x402-payer/src/output.ts`). URLs are stripped of
+ *    query and fragment by default, because API keys live in query strings.
+ *
+ * 3. AMOUNTS STAY EXACT. Base-unit amounts are `bigint` throughout the SDK
+ *    and a stroop-precision value can exceed `Number.MAX_SAFE_INTEGER`. The
+ *    event keeps the `bigint`, and `toJSON()` renders it as a decimal string
+ *    rather than a lossy `Number`.
+ *
+ * 4. ONLY REAL PAYMENTS COUNT. A 402-free resource resolves with
+ *    `paid: false`; that is a cache hit, not a payment, and emitting it would
+ *    inflate every "payments made" metric a consumer builds on this.
+ */
+
+/** Minimal shape of what `wallet.x402.fetch()` resolves with. */
+export interface X402SettlementLike {
+  /** On-chain settlement transaction hash. */
+  transaction: string;
+  /** The payer C-address. */
+  payer: string;
+  asset: string;
+  amount: bigint;
+  network: string;
+}
+
+export interface X402ResponseLike {
+  response: { status: number };
+  paid: boolean;
+  settlement?: X402SettlementLike;
+}
+
+/** Emitted once per x402 payment that actually settled. */
+export interface X402PaymentCompletedEvent {
+  /** Discriminator, so one sink can multiplex several event types. */
+  readonly type: "x402.payment.completed";
+  /**
+   * The resource that was paid for — the issue's "resource id".
+   * Sanitized per `resourceIdMode`; never carries a query string by default.
+   */
+  readonly resourceId: string;
+  /** Amount paid in base units. `bigint` so stroop precision is exact. */
+  readonly amount: bigint;
+  /** SEP-41 asset contract the payment was denominated in. */
+  readonly asset: string;
+  /** Network the settlement landed on. */
+  readonly network: string;
+  /** On-chain settlement transaction hash. */
+  readonly transaction: string;
+  /** The payer C-address. */
+  readonly payer: string;
+  /** Status of the unlocked resource response (2xx). */
+  readonly status: number;
+  /** Wall-clock time the payment completed, epoch ms. */
+  readonly timestamp: number;
+  /** End-to-end duration of the paid fetch, ms, when measured. */
+  readonly durationMs?: number;
+}
+
+/**
+ * How much of the resource URL to record.
+ *
+ * - `path` (default) — origin + pathname. Drops query and fragment, where API
+ *   keys and session tokens live.
+ * - `origin` — origin only. For hosts that treat paths as sensitive.
+ * - `full` — the URL verbatim. Opt-in, and only safe when you control the
+ *   resource URLs and know they carry no credentials.
+ */
+export type ResourceIdMode = "path" | "origin" | "full";
+
+/** Receives completed-payment events. May be async; errors are contained. */
+export type X402TelemetrySink = (event: X402PaymentCompletedEvent) => void | Promise<void>;
+
+export interface X402TelemetryOptions {
+  /** Where events go. Omit to disable telemetry entirely. */
+  sink?: X402TelemetrySink;
+  /** URL detail recorded as `resourceId`. @default "path" */
+  resourceIdMode?: ResourceIdMode;
+  /**
+   * Called when the sink throws or rejects. Telemetry failures are contained,
+   * never propagated — this is how you find out one happened.
+   */
+  onError?: (error: unknown, event: X402PaymentCompletedEvent) => void;
+  /** Injected clock, for tests. @default Date.now */
+  now?: () => number;
+}
+
+/**
+ * Reduce a resource URL to what is safe to record.
+ *
+ * A URL that doesn't parse is returned with any query and fragment cut off
+ * lexically — an unparseable URL is still not a reason to log a raw secret.
+ */
+export function sanitizeResourceId(url: string, mode: ResourceIdMode = "path"): string {
+  if (mode === "full") return url;
+  try {
+    const parsed = new URL(url);
+    return mode === "origin" ? parsed.origin : `${parsed.origin}${parsed.pathname}`;
+  } catch {
+    return url.split(/[?#]/)[0];
+  }
+}
+
+/**
+ * Build the completion event for a settled payment.
+ *
+ * Returns `undefined` when nothing was paid — either `paid` is false, or there
+ * is no settlement to report. Callers treat `undefined` as "do not emit".
+ */
+export function buildPaymentCompletedEvent(
+  url: string,
+  result: X402ResponseLike,
+  options: { resourceIdMode?: ResourceIdMode; now?: () => number; durationMs?: number } = {},
+): X402PaymentCompletedEvent | undefined {
+  // A 402-free resource is a cache hit, not a payment.
+  if (!result.paid || !result.settlement) return undefined;
+
+  const { settlement } = result;
+  const now = options.now ?? Date.now;
+
+  return {
+    type: "x402.payment.completed",
+    resourceId: sanitizeResourceId(url, options.resourceIdMode ?? "path"),
+    amount: settlement.amount,
+    asset: settlement.asset,
+    network: settlement.network,
+    transaction: settlement.transaction,
+    payer: settlement.payer,
+    status: result.response.status,
+    timestamp: now(),
+    ...(options.durationMs === undefined ? {} : { durationMs: options.durationMs }),
+  };
+}
+
+/**
+ * Render an event as JSON-safe values.
+ *
+ * `bigint` has no JSON representation, so `JSON.stringify(event)` throws —
+ * a trap worth removing, since most sinks serialize. `amount` becomes a
+ * decimal string, which keeps stroop precision that `Number` would lose.
+ */
+export function toJSON(
+  event: X402PaymentCompletedEvent,
+): Record<string, string | number | undefined> {
+  return {
+    type: event.type,
+    resourceId: event.resourceId,
+    amount: event.amount.toString(),
+    asset: event.asset,
+    network: event.network,
+    transaction: event.transaction,
+    payer: event.payer,
+    status: event.status,
+    timestamp: event.timestamp,
+    durationMs: event.durationMs,
+  };
+}
+
+/** The `fetch` half of `X402Client` — what this wrapper decorates. */
+export type X402FetchLike<TInit, TResult extends X402ResponseLike> = (
+  url: string,
+  init: TInit,
+) => Promise<TResult>;
+
+/**
+ * Wrap an x402 `fetch` so every completed payment emits one event.
+ *
+ * The returned function has the same signature and resolves with the same
+ * value, so it is a drop-in replacement:
+ *
+ *     wallet.x402.fetch = withPaymentTelemetry(wallet.x402.fetch, { sink });
+ *
+ * Guarantees, in order of importance:
+ *
+ *   - a throwing or rejecting sink never fails the payment;
+ *   - a failed fetch emits nothing and rethrows untouched;
+ *   - an unpaid (cache-hit) response emits nothing;
+ *   - the emit happens after the result is in hand, so nothing is reported
+ *     for a payment that didn't complete.
+ */
+export function withPaymentTelemetry<TInit, TResult extends X402ResponseLike>(
+  fetchImpl: X402FetchLike<TInit, TResult>,
+  options: X402TelemetryOptions = {},
+): X402FetchLike<TInit, TResult> {
+  const { sink, resourceIdMode, onError, now = Date.now } = options;
+
+  // No sink means no work at all — not even a wrapper allocation per call.
+  if (!sink) return fetchImpl;
+
+  return async (url, init) => {
+    const startedAt = now();
+    // A rejected fetch propagates untouched: there is no payment to report.
+    const result = await fetchImpl(url, init);
+
+    const event = buildPaymentCompletedEvent(url, result, {
+      resourceIdMode,
+      now,
+      durationMs: now() - startedAt,
+    });
+    if (event) emitSafely(sink, event, onError);
+
+    return result;
+  };
+}
+
+/**
+ * Invoke a sink so it can never break the caller.
+ *
+ * Covers both failure modes: a synchronous throw, and a rejected promise from
+ * an async sink. The promise is deliberately not awaited — a slow analytics
+ * call must not add latency to a payment that already settled — so its
+ * rejection is caught here rather than surfacing as an unhandled rejection.
+ */
+function emitSafely(
+  sink: X402TelemetrySink,
+  event: X402PaymentCompletedEvent,
+  onError?: (error: unknown, event: X402PaymentCompletedEvent) => void,
+): void {
+  const report = (error: unknown): void => {
+    try {
+      onError?.(error, event);
+    } catch {
+      // An onError that itself throws is out of options — swallowing is the
+      // only remaining behaviour that keeps the payment intact.
+    }
+  };
+
+  try {
+    const maybePromise = sink(event);
+    if (maybePromise && typeof (maybePromise as Promise<void>).catch === "function") {
+      void (maybePromise as Promise<void>).catch(report);
+    }
+  } catch (error) {
+    report(error);
+  }
+}
+
+/**
+ * A sink that accumulates events in memory — useful in tests, and as a
+ * spend-report source for a short-lived agent session.
+ */
+export function createMemorySink(): {
+  sink: X402TelemetrySink;
+  events: X402PaymentCompletedEvent[];
+  /** Total base units paid across every recorded event for `asset`. */
+  totalFor(asset: string): bigint;
+} {
+  const events: X402PaymentCompletedEvent[] = [];
+  return {
+    sink: (event) => {
+      events.push(event);
+    },
+    events,
+    totalFor(asset) {
+      return events
+        .filter((e) => e.asset === asset)
+        .reduce((sum, e) => sum + e.amount, 0n);
+    },
+  };
+}


### PR DESCRIPTION
closes #296

## Summary

x402 payment completion is not tracked as a telemetry event, so a host that wants to know what its agents are spending has to instrument every call site by hand.

This adds `contrib/examples/issue-296-x402-payment-telemetry`: an `x402.payment.completed` event carrying the **resource id** and **amount** the issue asks for, plus the asset, network, settlement hash, payer, status and duration that make it reconcilable against chain rather than merely countable.

`withPaymentTelemetry()` wraps the public `wallet.x402.fetch`, so it works today with no SDK change:

```ts
wallet.x402.fetch = withPaymentTelemetry(wallet.x402.fetch, {
  sink: (event) => analytics.track(event.type, toJSON(event)),
  onError: (err) => console.warn("x402 telemetry sink failed", err),
});
```

Omit `sink` and the original function is returned untouched, so telemetry is opt-in with no per-call cost when off.

## Design rules

**Telemetry must never break a payment.** The event fires only after money has already moved on-chain. A sink that throws, rejects, hangs, or whose `onError` itself throws still returns the caller's `X402Response`. An async sink is deliberately not awaited, so a slow analytics call adds no latency to a settled payment; its rejection is caught internally rather than surfacing as an unhandled rejection. There is no configuration that lets telemetry fail a settled payment.

**It must not leak secrets.** No request headers or bodies are recorded. `PAYMENT-SIGNATURE` is a signed authorization, and the SDK already treats leaking it as a security bug (`packages/mcp-x402-payer/src/output.ts`). Resource URLs are stripped of query and fragment by default, since API keys live in query strings; `resourceIdMode` allows `origin` or opt-in `full`. A URL that fails to parse still has its query cut off lexically.

**Amounts stay exact.** Base units are `bigint` and a stroop-precision value can exceed `Number.MAX_SAFE_INTEGER`. `JSON.stringify` throws on a `bigint`, so `toJSON()` renders `amount` as a decimal string that round-trips through `BigInt(...)`.

**Only settled payments emit.** A 402-free response is a cache hit, not a payment; counting it would inflate every metric built on this event. A failed payment emits nothing and rethrows untouched.

## Tests

27 tests covering the event shape, URL sanitization, bigint precision and JSON round-tripping, and each way a sink can fail without disturbing the payment.

```bash
npx vitest run contrib/examples/issue-296-x402-payment-telemetry
```

## Notes for the maintainer

Two requirements could not be met as literally written, because contributor PRs may only touch `contrib/`:

- **README observability section.** `README.md` is outside `contrib/`, so the reference documentation lives in the example's README instead, written so the tables can be lifted into that section verbatim.
- **Emitting from inside the SDK.** The example README sketches the in-SDK version: the completion point is where `readSettlement()` returns in `src/x402-client.ts`, and an optional `telemetry?: X402TelemetryOptions` on `X402ClientDeps` (threaded through `X402FacadeDeps.config`, alongside `budgetAttributes`) would emit the same event for every caller. Happy to open that as a follow-up if you widen the scope.

The 18 test failures on `dev` (in `contrib/examples/` and `src/session.test.ts`, which also fails `tsc`) are pre-existing and untouched by this branch.