### PR TITLE
Add shared HTTP retry wrapper and migrated wallet backend

### DIFF
--- a/contrib/examples/issue-301-http-retry-wrapper/README.md
+++ b/contrib/examples/issue-301-http-retry-wrapper/README.md
@@ -1,0 +1,96 @@
+# Shared HTTP Retry Wrapper
+
+Self-contained reference for issue [#301](https://github.com/Vellar-Wallet/vellar-sdk/issues/301): extracting the duplicated HTTP retry handling into one wrapper, and migrating the existing call sites onto it.
+
+## Run tests
+
+```bash
+npx vitest run contrib/examples/issue-301-http-retry-wrapper
+```
+
+## What's duplicated today
+
+[`src/http-backend.ts`](../../../src/http-backend.ts) defines one private `post()` helper, then repeats the same request-and-check block three times:
+
+```ts
+const res = await post("/wallet/create", { ... });
+if (!res.ok) throw await toApiError(res);
+return (await res.json()) as { sessionId: string };
+```
+
+[`src/policy-client.ts`](../../../src/policy-client.ts) repeats the same shape again in its own `req()`, with its own error class. Neither retries at all, so a single dropped connection surfaces as a failed wallet creation.
+
+Adding retry to each site separately is how call sites drift: one grows a backoff, another doesn't, and a third quietly retries something it must not.
+
+## The part that actually matters: what must NOT be retried
+
+Retrying HTTP isn't looping until something works. Two of the three wallet endpoints are unsafe to retry blindly, and getting this wrong costs real money:
+
+| Endpoint | Retryable | Why |
+| --- | --- | --- |
+| `POST /wallet/connect` | **yes** | A pure lookup. No side effect, so a replay costs at most a wasted request. |
+| `POST /wallet/create` | **no** | Deploys a wallet. If the response is lost, it may already have deployed. |
+| `POST /wallet/submit` | **no** | Submits a **signed transaction**. Retrying can double-submit and pay twice. |
+
+So the rule the wrapper enforces is: **retry only on positive evidence that the server reached no decision.**
+
+- a transport error (`fetch` threw) — the request never completed;
+- HTTP **408, 429, 502, 503, 504** — the server says it did not process the request, or asks for a retry.
+
+Everything else is terminal, **including 500**. A 500 means the handler ran and failed partway, which is exactly the state where a retry can duplicate a write. A 503 means nothing was decided. That distinction is the whole safety argument, and it matches the reasoning already written down in [`src/policy-types.ts`](../../../src/policy-types.ts) (`isRetryableStatus`) and [`src/x402-guards.ts`](../../../src/x402-guards.ts) (`isRetryableSettleFailure`), so the SDK keeps one consistent story about when a retry is safe.
+
+Retrying is also **opt-in**: `retryable` defaults to `false`, so a call site inherits no retries it didn't ask for. The safe default is the one that can't double-spend.
+
+## Usage
+
+```ts
+import { fetchWithRetry, createRetryingPost } from "./http-retry";
+
+// Wrap a single request:
+const res = await fetchWithRetry(() => fetch(url, init), {
+  retryable: true,       // opt in — reads only
+  maxAttempts: 3,
+  baseDelayMs: 200,
+  onRetry: ({ attempt, delayMs, status }) =>
+    console.warn(`attempt ${attempt} failed (${status ?? "network"}), retrying in ${delayMs}ms`),
+});
+
+// Or bind a policy to an existing `post()` helper — the choke point
+// `src/http-backend.ts` is missing:
+const send = createRetryingPost(post, { maxAttempts: 3 });
+const res = await send("/wallet/connect", { keyId, network }, { retryable: true });
+```
+
+[`retrying-wallet-backend.ts`](./retrying-wallet-backend.ts) shows all three real call sites migrated, keeping `createHttpWalletBackend`'s interface, error type, and base-URL handling identical. The only change is that each call site declares its retryability and the retry lives in one place.
+
+## Backoff
+
+Exponential with subtractive jitter: attempt 1 waits about `baseDelayMs`, attempt 2 about `2x`, attempt 3 about `4x`, each capped at `maxDelayMs`.
+
+Jitter is applied *after* the cap and only ever subtracts, so a delay stays within `[exp * (1 - jitter), exp]` and can never exceed `maxDelayMs`. Jitter matters when a gateway comes back up: without it, every client that failed at the same moment retries at the same moment.
+
+`sleep` and `random` are injectable, so the tests assert exact delay sequences without waiting.
+
+## Semantics
+
+| Case | Result |
+|------|--------|
+| `retryable` omitted or `false` | Exactly one attempt, whatever the outcome |
+| 408 / 429 / 502 / 503 / 504, opted in | Retried up to `maxAttempts` |
+| 500 | Terminal — never retried |
+| Any 2xx, or 4xx other than 408/429 | Returned immediately |
+| `fetch` throws, opted in | Retried; the last error is rethrown if all attempts fail |
+| Retries exhausted on an error status | The last response is returned, exactly as a non-retrying call would |
+| Signal already aborted | `RequestAbortedError`, no request made |
+| Aborted mid-flight | Abort error propagates; not treated as transient |
+| `maxAttempts < 1` | `RangeError`, rather than looping forever |
+
+Exhausted retries deliberately return the last response instead of a wrapper error, so callers keep interpreting failures exactly as they do today — this wrapper never needs to know about `WalletApiError` or `PolicyApiError`.
+
+## Making the writes retryable
+
+`/wallet/create` and `/wallet/submit` could be retried safely if the gateway accepted an **idempotency key** — a caller-generated id echoed back, so a replayed request returns the original result instead of performing the work twice. That is a protocol change on both sides, so it is out of scope here. Until then, silently retrying those endpoints is the bug this wrapper exists to prevent, which is why their non-retryability is fixed rather than configurable.
+
+## Limits
+
+This wraps request *execution*; it does not parse bodies or construct errors — deliberately, so the same wrapper serves both `http-backend.ts` and `policy-client.ts` despite their different error types. It does not honour a `Retry-After` header (worth adding when the gateway starts sending one), and it has no circuit breaker; see [`src/circuit-breaker.ts`](../../../src/circuit-breaker.ts) and [`contrib/examples/exponential-backoff`](../exponential-backoff) for the adjacent pieces.

--- a/contrib/examples/issue-301-http-retry-wrapper/http-retry.test.ts
+++ b/contrib/examples/issue-301-http-retry-wrapper/http-retry.test.ts
@@ -1,0 +1,392 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  computeBackoffDelay,
+  createRetryingPost,
+  fetchWithRetry,
+  isRetryableStatus,
+  RequestAbortedError,
+  RETRYABLE_STATUSES,
+  type RetryEvent,
+} from "./http-retry";
+import { createRetryingWalletBackend, WalletApiError } from "./retrying-wallet-backend";
+
+/** Never actually wait in tests — assert on the delays instead. */
+const noSleep = () => Promise.resolve();
+/** Deterministic RNG so jitter is reproducible. */
+const noJitter = { jitter: 0 };
+
+const json = (body: unknown, status = 200): Response =>
+  new Response(JSON.stringify(body), { status, headers: { "content-type": "application/json" } });
+
+describe("isRetryableStatus", () => {
+  it.each(RETRYABLE_STATUSES)("treats %i as retryable", (status) => {
+    expect(isRetryableStatus(status)).toBe(true);
+  });
+
+  it.each([200, 201, 204, 400, 401, 403, 404, 409, 422])(
+    "treats %i as terminal",
+    (status) => {
+      expect(isRetryableStatus(status)).toBe(false);
+    },
+  );
+
+  it("does NOT retry a 500 — the handler ran, so a side effect may have happened", () => {
+    // The distinction that makes retrying safe: 503 means "no decision was
+    // reached", 500 means "something failed partway through". Retrying the
+    // latter can duplicate a write.
+    expect(isRetryableStatus(500)).toBe(false);
+    expect(isRetryableStatus(503)).toBe(true);
+  });
+});
+
+describe("computeBackoffDelay", () => {
+  it("doubles each attempt", () => {
+    const p = { baseDelayMs: 100, maxDelayMs: 10_000, ...noJitter };
+    expect(computeBackoffDelay(1, p)).toBe(100);
+    expect(computeBackoffDelay(2, p)).toBe(200);
+    expect(computeBackoffDelay(3, p)).toBe(400);
+    expect(computeBackoffDelay(4, p)).toBe(800);
+  });
+
+  it("caps at maxDelayMs", () => {
+    const p = { baseDelayMs: 100, maxDelayMs: 250, ...noJitter };
+    expect(computeBackoffDelay(3, p)).toBe(250);
+    expect(computeBackoffDelay(9, p)).toBe(250);
+  });
+
+  it("keeps jittered delays within [exp*(1-jitter), exp] so the cap still holds", () => {
+    const p = { baseDelayMs: 1000, maxDelayMs: 1000, jitter: 0.5 };
+    // random() === 0 -> no reduction; random() near 1 -> maximum reduction.
+    expect(computeBackoffDelay(1, { ...p, random: () => 0 })).toBe(1000);
+    expect(computeBackoffDelay(1, { ...p, random: () => 0.999 })).toBeGreaterThanOrEqual(500);
+    expect(computeBackoffDelay(1, { ...p, random: () => 0.999 })).toBeLessThanOrEqual(1000);
+  });
+
+  it("never returns a negative delay", () => {
+    const p = { baseDelayMs: 10, maxDelayMs: 10, jitter: 2, random: () => 0.99 };
+    expect(computeBackoffDelay(1, p)).toBeGreaterThanOrEqual(0);
+  });
+});
+
+describe("fetchWithRetry — opting in", () => {
+  it("does not retry unless retryable is true, even on a 503", async () => {
+    const request = vi.fn(async () => json({ error: "busy" }, 503));
+
+    const res = await fetchWithRetry(request, { sleep: noSleep });
+
+    expect(request).toHaveBeenCalledTimes(1);
+    expect(res.status).toBe(503);
+  });
+
+  it("retries a 503 up to maxAttempts once opted in, then returns the last response", async () => {
+    const request = vi.fn(async () => json({ error: "busy" }, 503));
+
+    const res = await fetchWithRetry(request, {
+      retryable: true,
+      maxAttempts: 3,
+      sleep: noSleep,
+    });
+
+    expect(request).toHaveBeenCalledTimes(3);
+    // Exhausted retries look exactly like a call that never retried.
+    expect(res.status).toBe(503);
+  });
+
+  it("stops as soon as an attempt succeeds", async () => {
+    const request = vi
+      .fn<(attempt: number) => Promise<Response>>()
+      .mockResolvedValueOnce(json({ error: "busy" }, 503))
+      .mockResolvedValueOnce(json({ ok: true }, 200));
+
+    const res = await fetchWithRetry(request, { retryable: true, sleep: noSleep });
+
+    expect(request).toHaveBeenCalledTimes(2);
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toEqual({ ok: true });
+  });
+
+  it("passes the 1-based attempt number to the request", async () => {
+    const seen: number[] = [];
+    await fetchWithRetry(
+      async (attempt) => {
+        seen.push(attempt);
+        return json({}, 503);
+      },
+      { retryable: true, maxAttempts: 3, sleep: noSleep },
+    );
+
+    expect(seen).toEqual([1, 2, 3]);
+  });
+});
+
+describe("fetchWithRetry — what must not be retried", () => {
+  it.each([200, 400, 401, 403, 404, 409, 422, 500])(
+    "returns a %i immediately without retrying",
+    async (status) => {
+      const request = vi.fn(async () => json({}, status));
+
+      const res = await fetchWithRetry(request, {
+        retryable: true,
+        maxAttempts: 5,
+        sleep: noSleep,
+      });
+
+      expect(request).toHaveBeenCalledTimes(1);
+      expect(res.status).toBe(status);
+    },
+  );
+});
+
+describe("fetchWithRetry — transport errors", () => {
+  it("retries a thrown transport error", async () => {
+    const request = vi
+      .fn<(attempt: number) => Promise<Response>>()
+      .mockRejectedValueOnce(new TypeError("network down"))
+      .mockResolvedValueOnce(json({ ok: true }));
+
+    const res = await fetchWithRetry(request, { retryable: true, sleep: noSleep });
+
+    expect(request).toHaveBeenCalledTimes(2);
+    expect(res.status).toBe(200);
+  });
+
+  it("rethrows the last transport error when every attempt fails", async () => {
+    const boom = new TypeError("network down");
+    const request = vi.fn(async () => {
+      throw boom;
+    });
+
+    await expect(
+      fetchWithRetry(request, { retryable: true, maxAttempts: 3, sleep: noSleep }),
+    ).rejects.toBe(boom);
+    expect(request).toHaveBeenCalledTimes(3);
+  });
+
+  it("does not retry a transport error when the caller did not opt in", async () => {
+    const request = vi.fn(async () => {
+      throw new TypeError("network down");
+    });
+
+    await expect(fetchWithRetry(request, { sleep: noSleep })).rejects.toThrow("network down");
+    expect(request).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("fetchWithRetry — backoff and observability", () => {
+  it("sleeps with exponential backoff between attempts, and not after the last", async () => {
+    const slept: number[] = [];
+    const request = vi.fn(async () => json({}, 503));
+
+    await fetchWithRetry(request, {
+      retryable: true,
+      maxAttempts: 3,
+      baseDelayMs: 100,
+      ...noJitter,
+      sleep: async (ms) => {
+        slept.push(ms);
+      },
+    });
+
+    // 3 attempts -> 2 sleeps. No trailing sleep before giving up.
+    expect(slept).toEqual([100, 200]);
+  });
+
+  it("reports each retry through onRetry, with the triggering status", async () => {
+    const events: RetryEvent[] = [];
+    await fetchWithRetry(async () => json({}, 429), {
+      retryable: true,
+      maxAttempts: 3,
+      baseDelayMs: 50,
+      ...noJitter,
+      sleep: noSleep,
+      onRetry: (e) => events.push(e),
+    });
+
+    expect(events).toEqual([
+      { attempt: 1, maxAttempts: 3, delayMs: 50, status: 429, error: undefined },
+      { attempt: 2, maxAttempts: 3, delayMs: 100, status: 429, error: undefined },
+    ]);
+  });
+
+  it("reports a transport error through onRetry with no status", async () => {
+    const events: RetryEvent[] = [];
+    const boom = new TypeError("offline");
+
+    await fetchWithRetry(
+      vi
+        .fn<(attempt: number) => Promise<Response>>()
+        .mockRejectedValueOnce(boom)
+        .mockResolvedValueOnce(json({})),
+      { retryable: true, sleep: noSleep, onRetry: (e) => events.push(e) },
+    );
+
+    expect(events).toHaveLength(1);
+    expect(events[0].status).toBeUndefined();
+    expect(events[0].error).toBe(boom);
+  });
+
+  it("rejects a maxAttempts below 1 rather than looping forever", async () => {
+    await expect(
+      fetchWithRetry(async () => json({}), { retryable: true, maxAttempts: 0 }),
+    ).rejects.toBeInstanceOf(RangeError);
+  });
+});
+
+describe("fetchWithRetry — abort", () => {
+  it("does not start a request when the signal is already aborted", async () => {
+    const request = vi.fn(async () => json({}));
+    const controller = new AbortController();
+    controller.abort();
+
+    await expect(
+      fetchWithRetry(request, { retryable: true, signal: controller.signal, sleep: noSleep }),
+    ).rejects.toBeInstanceOf(RequestAbortedError);
+    expect(request).not.toHaveBeenCalled();
+  });
+
+  it("stops retrying once aborted mid-flight, rather than treating it as transient", async () => {
+    const controller = new AbortController();
+    const boom = new Error("aborted");
+    const request = vi.fn(async () => {
+      controller.abort();
+      throw boom;
+    });
+
+    await expect(
+      fetchWithRetry(request, { retryable: true, signal: controller.signal, sleep: noSleep }),
+    ).rejects.toBe(boom);
+    expect(request).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("createRetryingPost", () => {
+  it("forwards path and body to the underlying post", async () => {
+    const post = vi.fn(async () => json({ ok: true }));
+    const send = createRetryingPost(post, { sleep: noSleep });
+
+    await send("/wallet/connect", { keyId: "k1" }, { retryable: true });
+
+    expect(post).toHaveBeenCalledWith("/wallet/connect", { keyId: "k1" });
+  });
+
+  it("lets a per-call option override the bound policy", async () => {
+    const post = vi.fn(async () => json({}, 503));
+    const send = createRetryingPost(post, { maxAttempts: 5, sleep: noSleep });
+
+    await send("/p", {}, { retryable: true, maxAttempts: 2 });
+
+    expect(post).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe("createRetryingWalletBackend — migrated call sites", () => {
+  const CREATED = { sessionId: "sess-1" };
+
+  it("retries /wallet/connect, because a lookup has no side effect to duplicate", async () => {
+    const fetchImpl = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(json({}, 503))
+      .mockResolvedValueOnce(json({ contractId: "C1", sessionId: "s1" }));
+
+    const backend = createRetryingWalletBackend("https://api.test", {
+      fetchImpl,
+      sleep: noSleep,
+    });
+
+    await expect(backend.lookupContractId({ keyId: "k", network: "testnet" })).resolves.toEqual({
+      contractId: "C1",
+      sessionId: "s1",
+    });
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+  });
+
+  it("returns undefined for a 404 lookup without retrying it", async () => {
+    const fetchImpl = vi.fn<typeof fetch>().mockResolvedValue(json({}, 404));
+
+    const backend = createRetryingWalletBackend("https://api.test", { fetchImpl, sleep: noSleep });
+
+    await expect(
+      backend.lookupContractId({ keyId: "k", network: "testnet" }),
+    ).resolves.toBeUndefined();
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+  });
+
+  it("does NOT retry /wallet/submit — resubmitting a signed tx can pay twice", async () => {
+    const fetchImpl = vi.fn<typeof fetch>().mockResolvedValue(json({ error: "busy" }, 503));
+
+    const backend = createRetryingWalletBackend("https://api.test", { fetchImpl, sleep: noSleep });
+
+    await expect(
+      backend.submitTransaction({ signedXdr: "AAAA", network: "testnet" }),
+    ).rejects.toBeInstanceOf(WalletApiError);
+    // The critical assertion of this whole example.
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+  });
+
+  it("does NOT retry /wallet/create — a lost response may mean it already deployed", async () => {
+    const fetchImpl = vi.fn<typeof fetch>().mockResolvedValue(json({ error: "busy" }, 503));
+
+    const backend = createRetryingWalletBackend("https://api.test", { fetchImpl, sleep: noSleep });
+
+    await expect(
+      backend.submitWalletCreation({
+        keyId: "k",
+        contractId: "C",
+        network: "testnet",
+        signedTx: "tx",
+      }),
+    ).rejects.toBeInstanceOf(WalletApiError);
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+  });
+
+  it("surfaces the gateway's error message and code on a terminal failure", async () => {
+    const fetchImpl = vi
+      .fn<typeof fetch>()
+      .mockResolvedValue(json({ error: "bad_request", message: "keyId required" }, 400));
+
+    const backend = createRetryingWalletBackend("https://api.test", { fetchImpl, sleep: noSleep });
+
+    await expect(
+      backend.submitTransaction({ signedXdr: "AAAA", network: "testnet" }),
+    ).rejects.toMatchObject({ status: 400, message: "keyId required", code: "bad_request" });
+  });
+
+  it("falls back to a generic message when the error body is not JSON", async () => {
+    const fetchImpl = vi
+      .fn<typeof fetch>()
+      .mockResolvedValue(new Response("<html>502</html>", { status: 400 }));
+
+    const backend = createRetryingWalletBackend("https://api.test", { fetchImpl, sleep: noSleep });
+
+    await expect(
+      backend.submitTransaction({ signedXdr: "AAAA", network: "testnet" }),
+    ).rejects.toMatchObject({ status: 400, message: "Wallet API request failed (400)" });
+  });
+
+  it("normalizes a trailing slash on the base URL", async () => {
+    const fetchImpl = vi.fn<typeof fetch>().mockResolvedValue(json({ hash: "h" }));
+
+    const backend = createRetryingWalletBackend("https://api.test///", {
+      fetchImpl,
+      sleep: noSleep,
+    });
+    await backend.submitTransaction({ signedXdr: "AAAA", network: "testnet" });
+
+    expect(fetchImpl).toHaveBeenCalledWith("https://api.test/wallet/submit", expect.anything());
+  });
+
+  it("still succeeds on a create that works first time", async () => {
+    const fetchImpl = vi.fn<typeof fetch>().mockResolvedValue(json(CREATED));
+
+    const backend = createRetryingWalletBackend("https://api.test", { fetchImpl, sleep: noSleep });
+
+    await expect(
+      backend.submitWalletCreation({
+        keyId: "k",
+        contractId: "C",
+        network: "testnet",
+        signedTx: "tx",
+      }),
+    ).resolves.toEqual(CREATED);
+  });
+});

--- a/contrib/examples/issue-301-http-retry-wrapper/http-retry.ts
+++ b/contrib/examples/issue-301-http-retry-wrapper/http-retry.ts
@@ -1,0 +1,237 @@
+/**
+ * A shared retry wrapper for the SDK's HTTP call sites.
+ *
+ * Contributed for issue #301: retry handling is duplicated across call sites
+ * instead of living centrally in `src/http-backend.ts`. This is the wrapper
+ * that centralization needs, written against the real shape of those call
+ * sites so it can be dropped into `createHttpWalletBackend` (and
+ * `createPolicyClient`, which repeats the same pattern) without changing any
+ * public signature.
+ *
+ * What is duplicated today. `src/http-backend.ts` has one private `post()`
+ * helper and then repeats, three times:
+ *
+ *     const res = await post("/wallet/create", { ... });
+ *     if (!res.ok) throw await toApiError(res);
+ *     return (await res.json()) as { sessionId: string };
+ *
+ * `src/policy-client.ts` has the same `req()` shape again, with its own error
+ * class. Neither retries at all, so a single dropped connection surfaces as a
+ * failed wallet creation. Adding retry to each site separately is how call
+ * sites drift apart — one grows a backoff, another doesn't, and a third
+ * quietly retries something it must not.
+ *
+ * ── The part that actually matters: what must NOT be retried ──────────────
+ *
+ * Retrying HTTP is not a matter of looping until something works. Two of the
+ * three wallet endpoints are unsafe to retry blindly:
+ *
+ *   - `POST /wallet/submit` submits a SIGNED transaction. If the request
+ *     reaches the gateway and the response is lost, the transaction may
+ *     already be on-chain. Retrying can double-submit. Only failures that
+ *     prove the request never arrived are safe.
+ *   - `POST /wallet/create` has the same hazard for wallet deployment.
+ *
+ * So the rule this wrapper enforces is: **retry only on positive evidence
+ * that the server reached no decision.** That means
+ *
+ *   - a transport error (`fetch` threw): the request never completed;
+ *   - HTTP 408 / 429 / 502 / 503 / 504: the server explicitly says it did not
+ *     process the request, or asks for a retry.
+ *
+ * Everything else — any 2xx, any other 4xx, and a bare 500 — is terminal. A
+ * 500 is deliberately NOT retried: it means the server ran the handler and
+ * something failed partway, which is exactly the state where a retry can
+ * double-submit. This mirrors the reasoning already written down in
+ * `src/policy-types.ts` (`isRetryableStatus`) and `src/x402-guards.ts`
+ * (`isRetryableSettleFailure`), so the SDK has one consistent story about
+ * when a retry is safe.
+ *
+ * `retryable: false` (the default for a request whose method is not known to
+ * be idempotent) switches the wrapper off entirely, so a call site opts in
+ * rather than inheriting retries it never asked for.
+ */
+
+/** Status codes that mean "the server reached no decision" — safe to retry. */
+export const RETRYABLE_STATUSES: readonly number[] = [408, 429, 502, 503, 504];
+
+/**
+ * Is this response status safe to retry?
+ *
+ * Note what is absent: 500. A 500 means the handler ran and failed partway;
+ * whether the side effect happened is unknowable from the outside, so it is
+ * treated as terminal. See the module comment.
+ */
+export function isRetryableStatus(status: number): boolean {
+  return RETRYABLE_STATUSES.includes(status);
+}
+
+export interface RetryPolicy {
+  /**
+   * Total attempts including the first. `1` disables retrying.
+   * @default 3
+   */
+  maxAttempts?: number;
+  /**
+   * Delay before the first retry, in ms. Doubles each attempt.
+   * @default 200
+   */
+  baseDelayMs?: number;
+  /**
+   * Upper bound on a single delay, in ms.
+   * @default 2000
+   */
+  maxDelayMs?: number;
+  /**
+   * Random jitter as a fraction of the computed delay (0 disables it).
+   * Spreads retries so concurrent clients don't resynchronize into a
+   * thundering herd against a gateway that just came back up.
+   * @default 0.25
+   */
+  jitter?: number;
+  /** Injected sleep, for tests. Defaults to `setTimeout`. */
+  sleep?: (ms: number) => Promise<void>;
+  /** Injected RNG in `[0, 1)`, for tests. Defaults to `Math.random`. */
+  random?: () => number;
+  /** Observability hook fired before each retry (never before attempt 1). */
+  onRetry?: (event: RetryEvent) => void;
+}
+
+export interface RetryEvent {
+  /** The attempt that just failed, 1-based. */
+  attempt: number;
+  /** Total attempts allowed. */
+  maxAttempts: number;
+  /** Delay before the next attempt, in ms. */
+  delayMs: number;
+  /** Status that triggered the retry, or `undefined` for a transport error. */
+  status?: number;
+  /** The thrown error, when the failure was a transport error. */
+  error?: unknown;
+}
+
+export interface RetryRequestOptions extends RetryPolicy {
+  /**
+   * Whether this request may be retried at all. Defaults to `false` — a call
+   * site opts in, so a non-idempotent write is never retried by accident.
+   */
+  retryable?: boolean;
+  /** Abort signal; an aborted request stops retrying immediately. */
+  signal?: AbortSignal;
+}
+
+const DEFAULTS = {
+  maxAttempts: 3,
+  baseDelayMs: 200,
+  maxDelayMs: 2000,
+  jitter: 0.25,
+} as const;
+
+const defaultSleep = (ms: number): Promise<void> =>
+  new Promise((resolve) => setTimeout(resolve, ms));
+
+/**
+ * Exponential backoff with jitter for a given 1-based attempt number.
+ *
+ * `attempt` 1 yields roughly `baseDelayMs`, 2 roughly `2x`, 3 roughly `4x`,
+ * each capped at `maxDelayMs`. Jitter is applied after the cap, so the result
+ * can never exceed `maxDelayMs`.
+ */
+export function computeBackoffDelay(attempt: number, policy: RetryPolicy = {}): number {
+  const base = policy.baseDelayMs ?? DEFAULTS.baseDelayMs;
+  const max = policy.maxDelayMs ?? DEFAULTS.maxDelayMs;
+  const jitter = policy.jitter ?? DEFAULTS.jitter;
+  const random = policy.random ?? Math.random;
+
+  const exponential = Math.min(base * 2 ** (attempt - 1), max);
+  if (jitter <= 0) return exponential;
+
+  // Subtractive jitter keeps the delay in [exp*(1-jitter), exp], so it stays
+  // under maxDelayMs while still de-synchronizing concurrent clients.
+  const spread = exponential * jitter;
+  return Math.max(0, Math.round(exponential - random() * spread));
+}
+
+/** Thrown when a request is abandoned because its signal was aborted. */
+export class RequestAbortedError extends Error {
+  constructor() {
+    super("HTTP request aborted");
+    this.name = "RequestAbortedError";
+  }
+}
+
+/**
+ * Run `request` with retries, per the rules in the module comment.
+ *
+ * `request` receives the 1-based attempt number and must perform exactly one
+ * HTTP call, resolving with the `Response` (including error statuses — a non-2xx
+ * is a resolved response, not a throw) or rejecting on a transport failure.
+ *
+ * Returns the first response that is not retryable — which includes error
+ * responses. Interpreting those stays with the caller, so this wrapper does not
+ * need to know about `WalletApiError` or `PolicyApiError`. After the final
+ * attempt the last response is returned (or the last transport error rethrown),
+ * so an exhausted retry looks exactly like a call that never retried.
+ */
+export async function fetchWithRetry(
+  request: (attempt: number) => Promise<Response>,
+  options: RetryRequestOptions = {},
+): Promise<Response> {
+  const maxAttempts = options.retryable === true ? (options.maxAttempts ?? DEFAULTS.maxAttempts) : 1;
+  const sleep = options.sleep ?? defaultSleep;
+
+  if (maxAttempts < 1) {
+    throw new RangeError(`maxAttempts must be >= 1, got ${maxAttempts}`);
+  }
+
+  for (let attempt = 1; ; attempt++) {
+    if (options.signal?.aborted) throw new RequestAbortedError();
+
+    let response: Response | undefined;
+    let error: unknown;
+
+    try {
+      response = await request(attempt);
+      if (!isRetryableStatus(response.status)) return response;
+    } catch (err) {
+      error = err;
+      // An abort is a deliberate cancellation, never a transient fault.
+      if (options.signal?.aborted) throw err;
+    }
+
+    const isLast = attempt >= maxAttempts;
+    if (isLast) {
+      // Exhausted: hand back exactly what a non-retrying call would produce.
+      if (response) return response;
+      throw error;
+    }
+
+    const delayMs = computeBackoffDelay(attempt, options);
+    options.onRetry?.({
+      attempt,
+      maxAttempts,
+      delayMs,
+      status: response?.status,
+      error,
+    });
+
+    await sleep(delayMs);
+  }
+}
+
+/**
+ * Bind a retry policy to a `post`-style helper, producing the single choke
+ * point `src/http-backend.ts` is missing.
+ *
+ * The returned function takes the same `(path, body)` arguments the existing
+ * private `post()` does, plus a per-call `retryable` flag — so migrating a call
+ * site is a one-line change and the retry decision is visible at the call site
+ * rather than buried in the transport.
+ */
+export function createRetryingPost(
+  post: (path: string, body: unknown) => Promise<Response>,
+  policy: RetryPolicy = {},
+): (path: string, body: unknown, options?: RetryRequestOptions) => Promise<Response> {
+  return (path, body, options = {}) =>
+    fetchWithRetry(() => post(path, body), { ...policy, ...options });
+}

--- a/contrib/examples/issue-301-http-retry-wrapper/retrying-wallet-backend.ts
+++ b/contrib/examples/issue-301-http-retry-wrapper/retrying-wallet-backend.ts
@@ -1,0 +1,159 @@
+/**
+ * `src/http-backend.ts`'s three call sites, migrated onto the shared wrapper.
+ *
+ * This is the "migrate existing call sites" half of issue #301, shown as a
+ * working reference rather than a patch, so the retry semantics can be
+ * reviewed and tested before `src/http-backend.ts` itself changes.
+ *
+ * The structure deliberately mirrors the real `createHttpWalletBackend`:
+ * same interface, same error type, same `post()` helper, same base-URL
+ * normalization. The only difference is that each call site now declares
+ * whether it may be retried, and the retry itself lives in one place
+ * (`createRetryingPost`) instead of being open-coded three times.
+ *
+ * The per-endpoint decisions, which are the substance of the change:
+ *
+ *   | Endpoint          | Retryable | Why                                     |
+ *   | ----------------- | --------- | --------------------------------------- |
+ *   | `/wallet/connect` | yes       | A pure lookup. No side effect, so a     |
+ *   |                   |           | replay costs at most a wasted request.  |
+ *   | `/wallet/create`  | no        | Deploys a wallet. A lost response may   |
+ *   |                   |           | mean it already deployed.               |
+ *   | `/wallet/submit`  | no        | Submits a SIGNED transaction. Retrying  |
+ *   |                   |           | can double-submit and pay twice.        |
+ *
+ * The two writes are left non-retryable on purpose. They could be made safe
+ * with an idempotency key echoed by the gateway (see the README), but that is
+ * a protocol change, and silently retrying them without one is the bug this
+ * wrapper exists to prevent.
+ */
+
+import {
+  createRetryingPost,
+  type RetryPolicy,
+  type RetryRequestOptions,
+} from "./http-retry";
+
+/** Mirrors `WalletApiError` from `src/http-backend.ts`. */
+export class WalletApiError extends Error {
+  readonly status: number;
+  readonly code: string | undefined;
+
+  constructor(message: string, status: number, code?: string) {
+    super(message);
+    this.name = "WalletApiError";
+    this.status = status;
+    this.code = code;
+  }
+}
+
+async function toApiError(res: Response): Promise<WalletApiError> {
+  let payload: { error?: string; message?: string } | undefined;
+  try {
+    payload = (await res.json()) as { error?: string; message?: string };
+  } catch {
+    // Non-JSON error body — fall through to the generic message.
+  }
+  return new WalletApiError(
+    payload?.message ?? payload?.error ?? `Wallet API request failed (${res.status})`,
+    res.status,
+    payload?.error,
+  );
+}
+
+/** Mirrors `HttpWalletBackend` from `src/http-backend.ts`. */
+export interface HttpWalletBackend {
+  submitWalletCreation(input: {
+    keyId: string;
+    contractId: string;
+    network: string;
+    signedTx: unknown;
+  }): Promise<{ sessionId: string }>;
+  lookupContractId(input: {
+    keyId: string;
+    network: string;
+  }): Promise<{ contractId: string; sessionId: string } | undefined>;
+  submitTransaction(input: {
+    signedXdr: string;
+    network: string;
+  }): Promise<{ hash: string }>;
+}
+
+export interface RetryingBackendOptions extends RetryPolicy {
+  /** Optional fetch (defaults to the global fetch). */
+  fetchImpl?: typeof fetch;
+  /**
+   * Serializer for the signed transaction. The real backend uses
+   * `defaultSignedToXdr` from `src/passkeykit-connector`; kept injectable here
+   * so this example stays self-contained.
+   */
+  signedToXdr?: (signed: unknown) => unknown;
+}
+
+/**
+ * The same backend `createHttpWalletBackend` returns, with retries centralized.
+ *
+ * `retryPolicy` tunes backoff for the whole backend; per-endpoint retryability
+ * is fixed by the safety analysis above and is not configurable, because
+ * "retry my signed submission" is never a safe thing to opt into.
+ */
+export function createRetryingWalletBackend(
+  apiUrl: string,
+  options: RetryingBackendOptions = {},
+): HttpWalletBackend {
+  const base = apiUrl.replace(/\/+$/, "");
+  const fetchImpl = options.fetchImpl ?? globalThis.fetch.bind(globalThis);
+  const signedToXdr = options.signedToXdr ?? ((signed: unknown) => signed);
+
+  // The one private helper the real file already has.
+  const post = (path: string, body: unknown): Promise<Response> =>
+    fetchImpl(`${base}${path}`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(body),
+    });
+
+  // The single choke point. Every call site below goes through this.
+  const send = createRetryingPost(post, {
+    maxAttempts: options.maxAttempts,
+    baseDelayMs: options.baseDelayMs,
+    maxDelayMs: options.maxDelayMs,
+    jitter: options.jitter,
+    sleep: options.sleep,
+    random: options.random,
+    onRetry: options.onRetry,
+  });
+
+  // Reads are safe to replay; writes are not. Named so each call site reads as
+  // a deliberate decision rather than a magic boolean.
+  const READ: RetryRequestOptions = { retryable: true };
+  const WRITE: RetryRequestOptions = { retryable: false };
+
+  return {
+    async submitWalletCreation({ keyId, contractId, network, signedTx }) {
+      // NOT retried: a lost response may mean the wallet already deployed.
+      const res = await send(
+        "/wallet/create",
+        { keyId, contractId, network, signedTx: signedToXdr(signedTx) },
+        WRITE,
+      );
+      if (!res.ok) throw await toApiError(res);
+      return (await res.json()) as { sessionId: string };
+    },
+
+    async lookupContractId({ keyId, network }) {
+      // Retried: a pure lookup, no side effect to duplicate.
+      const res = await send("/wallet/connect", { keyId, network }, READ);
+      if (res.status === 404) return undefined;
+      if (!res.ok) throw await toApiError(res);
+      return (await res.json()) as { contractId: string; sessionId: string };
+    },
+
+    async submitTransaction({ signedXdr, network }) {
+      // NOT retried: resubmitting a signed transaction can pay twice.
+      const res = await send("/wallet/submit", { signedXdr, network }, WRITE);
+      if (!res.ok) throw await toApiError(res);
+      return (await res.json()) as { hash: string };
+    },
+  };
+}


### PR DESCRIPTION
closes #301

## Summary

HTTP retry handling is duplicated across call sites instead of living centrally. `src/http-backend.ts` defines one private `post()` helper and then repeats the same request-and-check block three times; `src/policy-client.ts` repeats the shape again in its own `req()`, with its own error class. Neither retries at all, so a single dropped connection surfaces as a failed wallet creation.

This adds `contrib/examples/issue-301-http-retry-wrapper`: the shared wrapper that centralization needs, written against the real call sites so it can be dropped into `createHttpWalletBackend` without changing any public signature.

## The part that actually matters: what must not be retried

Retrying HTTP is not looping until something works. Two of the three wallet endpoints are unsafe to retry blindly, and getting this wrong costs real money:

| Endpoint | Retryable | Why |
| --- | --- | --- |
| `POST /wallet/connect` | yes | A pure lookup. No side effect, so a replay costs at most a wasted request. |
| `POST /wallet/create` | no | Deploys a wallet. If the response is lost, it may already have deployed. |
| `POST /wallet/submit` | no | Submits a signed transaction. Retrying can double-submit and pay twice. |

So the rule enforced is: **retry only on positive evidence that the server reached no decision** — a transport error, or 408/429/502/503/504.

Everything else is terminal, **including 500**. A 500 means the handler ran and failed partway, which is exactly the state where a retry can duplicate a write; a 503 means nothing was decided. That distinction is the whole safety argument, and it matches the reasoning already written down in `src/policy-types.ts` (`isRetryableStatus`) and `src/x402-guards.ts` (`isRetryableSettleFailure`), so the SDK keeps one consistent story about when a retry is safe.

Retrying is also **opt-in** (`retryable` defaults to `false`), so no call site inherits retries it never asked for. The safe default is the one that cannot double-spend.

## Design notes

- **Exhausted retries return the last response** rather than a wrapper error, so callers keep interpreting failures exactly as they do today. The wrapper never needs to know about `WalletApiError` or `PolicyApiError`, which is what lets one wrapper serve both files despite their different error types.
- **Backoff** is exponential with subtractive jitter applied *after* the cap, so a delay stays within `[exp * (1 - jitter), exp]` and can never exceed `maxDelayMs`. Jitter matters when a gateway comes back up: without it, every client that failed at the same moment retries at the same moment.
- **`sleep` and `random` are injectable**, so the tests assert exact delay sequences without waiting.
- **Abort is not transient**: an aborted request stops retrying immediately rather than being treated as a transient fault.

`retrying-wallet-backend.ts` shows all three real call sites migrated, keeping the interface, error type and base-URL handling identical. The only change is that each call site declares its retryability and the retry lives in one place.

## Tests

50 tests covering retryable and non-retryable statuses, transport errors, abort handling, exact backoff sequences, and the three migrated call sites — including the assertions that `/wallet/submit` and `/wallet/create` are attempted exactly once on a 503.

```bash
npx vitest run contrib/examples/issue-301-http-retry-wrapper
```

## Notes for the maintainer

Scoped to `contrib/` per CONTRIBUTING.md, so `src/http-backend.ts` is not modified here. The migrated backend is a working, tested reference for that change rather than a patch; happy to apply it to `src/` directly if you widen the scope on the issue.

`/wallet/create` and `/wallet/submit` could become retryable with an **idempotency key** echoed by the gateway, but that is a protocol change on both sides, so their non-retryability is currently fixed rather than configurable.

The 18 test failures on `dev` (in `contrib/examples/` and `src/session.test.ts`, which also fails `tsc`) are pre-existing and untouched by this branch.