### PR TITLE
feat(session): enforce a retention window on cached session state

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,7 @@ Returns a `VellarWallet`:
 | `WalletApiError`               | Thrown by the HTTP backend on non-2xx responses (has `status`, `code`)                   |
 | `CircuitOpenError`             | Thrown by the circuit breaker when the facilitator is down — see [Circuit breaking](#circuit-breaking) |
 | `isReachable(rpcUrl)`          | Ping an RPC endpoint for reachability (from `vellar-sdk/rpc`) — see [Health check](#health-check) |
+| `createSessionStore(storage, opts?)` | Session store with pluggable storage and a retention window — see [Session retention](#session-retention) |
 
 ### Circuit breaking
 
@@ -473,6 +474,65 @@ matching rule's ceiling, throws `BudgetAttributeDeniedError` before signing.
 Like capability scoping, this is a **client-side** narrowing on top of (never
 instead of) the on-chain policy — see `src/x402-budget-attributes.ts`'s doc
 comments for the full scope.
+
+### Session retention
+
+`createSessionStore` caches session state — the smart-account address, the public
+passkey credential id, and `createdAt` / `lastActiveAt` timestamps — through the
+storage adapter you give it (`localStorage` on the web, `browser.storage` in an
+extension).
+
+**Recommended retention window: 30 days of inactivity**, which is the SDK
+default (`DEFAULT_SESSION_MAX_AGE_MS`).
+
+That number is a balance. Cached session state is **not a credential**: it holds
+no key material and cannot authorize anything on its own — every signature still
+requires a live WebAuthn ceremony against the passkey. What it does carry is a
+durable link between a browser profile and an on-chain account, which is why it
+should not sit in `localStorage` indefinitely on a shared or long-lived device.
+30 days keeps "open the app, still signed in" true for ordinary use while
+bounding how long an abandoned profile keeps pointing at an account.
+
+The window is **enforced by the SDK on read**. `restore()` measures the cached
+entry's age from its `lastActiveAt` and, if it is past the max age, discards it
+and clears it from storage rather than resuming it — so expired state is evicted,
+not merely ignored:
+
+```ts
+import { createSessionStore, createWebStorageAdapter } from "vellar-sdk";
+
+const store = createSessionStore(createWebStorageAdapter(window.localStorage), {
+  // Shorter window for a shared-device deployment. Defaults to 30 days.
+  maxAgeMs: 12 * 60 * 60 * 1000, // 12 hours
+});
+
+await store.getState().restore();
+store.getState().status; // "disconnected" if the cached state had aged out
+```
+
+Because age is measured from `lastActiveAt` — which `touch()` refreshes on user
+activity — the window is an **idle** timeout, not a hard cap on session lifetime:
+an actively used session keeps renewing, while an untouched one ages out.
+
+Notes on the behavior:
+
+- **Choose a shorter window for a stricter posture.** Shared kiosks, custodial
+  dashboards, or anything on a device with multiple users should shorten it; a
+  few hours is reasonable.
+- **`maxAgeMs: Infinity`** opts out of expiry entirely. Only appropriate when the
+  storage adapter is itself ephemeral (e.g. `createMemoryStorageAdapter()`).
+- **A non-positive or `NaN` `maxAgeMs` throws a `RangeError`** at construction,
+  so a misconfigured window fails at wiring rather than silently disabling expiry.
+- **Unparseable `lastActiveAt` is treated as expired.** If the age cannot be
+  bounded, the entry is discarded — that is exactly what the retention window is
+  for.
+- **A future `lastActiveAt`** (clock skew) is never expired; its age is clamped
+  at zero rather than going negative.
+- **`isSessionExpired(session, maxAgeMs?, now?)`** is exported if you need to
+  apply the same rule yourself.
+
+Clearing state is still explicit elsewhere: `end()` clears storage on sign-out.
+Retention is the backstop for the sessions that are simply never returned to.
 
 ### Advanced
 

--- a/src/session.test.ts
+++ b/src/session.test.ts
@@ -4,17 +4,24 @@ import {
   createMemoryStorageAdapter,
   createSessionStore,
   createWebStorageAdapter,
+  DEFAULT_SESSION_MAX_AGE_MS,
+  isSessionExpired,
   isWalletSession,
   type SessionStorageAdapter,
 } from "./session";
 
+// `lastActiveAt` is deliberately "just now" rather than a fixed date: cached
+// session state is subject to a retention window (see DEFAULT_SESSION_MAX_AGE_MS),
+// so a hardcoded past timestamp would silently age out and make restore() tests
+// fail as the calendar moves. Tests that assert on literal timestamps pass an
+// explicit `now` to touch() instead of relying on this fixture's value.
 const session: WalletSession = {
   accountId: "CACCOUNT123",
   network: "testnet",
   connected: true,
   authMethod: "passkey",
   createdAt: "2026-07-16T10:00:00.000Z",
-  lastActiveAt: "2026-07-16T10:00:00.000Z",
+  lastActiveAt: new Date().toISOString(),
 };
 
 describe("createSessionStore", () => {
@@ -178,6 +185,9 @@ describe("createSessionStore teardown", () => {
     // No active timers remain after dispose (a leak would fail here by keeping
     // the interval scheduled).
     expect(vi.getTimerCount()).toBe(0);
+  });
+});
+
 describe("createSessionStore — refresh & expiry edge cases", () => {
   it("refreshes lastActiveAt just before session expiry (boundary condition)", async () => {
     const storage = createMemoryStorageAdapter();
@@ -187,13 +197,14 @@ describe("createSessionStore — refresh & expiry edge cases", () => {
     // Assume a 15-minute session lifetime (900,000 ms).
     // Refresh 1 millisecond before the 15-minute expiry threshold.
     const startTime = new Date(session.lastActiveAt).getTime();
-    const justBeforeExpiry = new Date(startTime + 15 * 60 * 1000 - 1); // 10:14:59.999Z
+    const justBeforeExpiry = new Date(startTime + 15 * 60 * 1000 - 1);
+    const expected = justBeforeExpiry.toISOString();
 
     await store.getState().touch(justBeforeExpiry);
 
     expect(store.getState().status).toBe("connected");
-    expect(store.getState().session?.lastActiveAt).toBe("2026-07-16T10:14:59.999Z");
-    expect((await storage.load())?.lastActiveAt).toBe("2026-07-16T10:14:59.999Z");
+    expect(store.getState().session?.lastActiveAt).toBe(expected);
+    expect((await storage.load())?.lastActiveAt).toBe(expected);
   });
 
   it("supports multiple rolling refreshes just before consecutive expiry windows", async () => {
@@ -423,5 +434,135 @@ describe("isWalletSession", () => {
     ["non-boolean connected", { ...session, connected: "yes" }],
   ])("rejects %s", (_label, value) => {
     expect(isWalletSession(value)).toBe(false);
+  });
+});
+
+describe("cached session retention", () => {
+  const DAY_MS = 24 * 60 * 60 * 1000;
+
+  /** A session last active `ageMs` before `now`. */
+  function agedSession(ageMs: number, now = Date.now()): WalletSession {
+    return { ...session, lastActiveAt: new Date(now - ageMs).toISOString() };
+  }
+
+  it("defaults to a 30-day retention window", () => {
+    expect(DEFAULT_SESSION_MAX_AGE_MS).toBe(30 * DAY_MS);
+  });
+
+  it("restore() discards cached state older than the max age", async () => {
+    const storage = createMemoryStorageAdapter();
+    await storage.save(agedSession(2 * DAY_MS));
+    const store = createSessionStore(storage, { maxAgeMs: DAY_MS });
+    await store.getState().restore();
+    expect(store.getState().status).toBe("disconnected");
+    expect(store.getState().session).toBeNull();
+  });
+
+  it("restore() evicts expired state from storage so it is not read again", async () => {
+    const storage = createMemoryStorageAdapter();
+    await storage.save(agedSession(2 * DAY_MS));
+    const store = createSessionStore(storage, { maxAgeMs: DAY_MS });
+    await store.getState().restore();
+    expect(await storage.load()).toBeNull();
+  });
+
+  it("restore() resumes cached state inside the max age", async () => {
+    const storage = createMemoryStorageAdapter();
+    const fresh = agedSession(DAY_MS / 2);
+    await storage.save(fresh);
+    const store = createSessionStore(storage, { maxAgeMs: DAY_MS });
+    await store.getState().restore();
+    expect(store.getState().status).toBe("connected");
+    expect(store.getState().session).toEqual(fresh);
+  });
+
+  it("restore() applies the 30-day default when no max age is configured", async () => {
+    const storage = createMemoryStorageAdapter();
+    await storage.save(agedSession(DEFAULT_SESSION_MAX_AGE_MS + 60_000));
+    const store = createSessionStore(storage);
+    await store.getState().restore();
+    expect(store.getState().status).toBe("disconnected");
+
+    await storage.save(agedSession(DEFAULT_SESSION_MAX_AGE_MS - 60_000));
+    const stillValid = createSessionStore(storage);
+    await stillValid.getState().restore();
+    expect(stillValid.getState().status).toBe("connected");
+  });
+
+  it("expiry is measured from lastActiveAt, so touch() extends retention", async () => {
+    const storage = createMemoryStorageAdapter();
+    // Created long ago, but active moments ago: an idle window, not a hard cap.
+    await storage.save({ ...agedSession(60_000), createdAt: "2020-01-01T00:00:00.000Z" });
+    const store = createSessionStore(storage, { maxAgeMs: DAY_MS });
+    await store.getState().restore();
+    expect(store.getState().status).toBe("connected");
+  });
+
+  it("restore() discards cached state with an unparseable lastActiveAt", async () => {
+    const storage = createMemoryStorageAdapter();
+    await storage.save({ ...session, lastActiveAt: "not-a-date" });
+    const store = createSessionStore(storage);
+    await store.getState().restore();
+    expect(store.getState().status).toBe("disconnected");
+    expect(await storage.load()).toBeNull();
+  });
+
+  it("restore() still disconnects when evicting expired state fails", async () => {
+    const broken: SessionStorageAdapter = {
+      load: vi.fn().mockResolvedValue(agedSession(2 * DAY_MS)),
+      save: vi.fn(),
+      clear: vi.fn().mockRejectedValue(new Error("read-only storage")),
+    };
+    const store = createSessionStore(broken, { maxAgeMs: DAY_MS });
+    await store.getState().restore();
+    expect(store.getState().status).toBe("disconnected");
+    expect(store.getState().session).toBeNull();
+  });
+
+  it("maxAgeMs: Infinity opts out of expiry", async () => {
+    const storage = createMemoryStorageAdapter();
+    const ancient = agedSession(10 * 365 * DAY_MS);
+    await storage.save(ancient);
+    const store = createSessionStore(storage, { maxAgeMs: Infinity });
+    await store.getState().restore();
+    expect(store.getState().status).toBe("connected");
+    expect(store.getState().session).toEqual(ancient);
+  });
+
+  it.each([
+    ["zero", 0],
+    ["negative", -1],
+    ["NaN", NaN],
+  ])("rejects a %s maxAgeMs at construction", (_label, value) => {
+    expect(() => createSessionStore(createMemoryStorageAdapter(), { maxAgeMs: value })).toThrow(
+      RangeError,
+    );
+  });
+
+  describe("isSessionExpired", () => {
+    const now = new Date("2026-07-16T10:00:00.000Z");
+
+    it("is false exactly at the boundary and true just past it", () => {
+      const atBoundary = { ...session, lastActiveAt: new Date(now.getTime() - DAY_MS).toISOString() };
+      expect(isSessionExpired(atBoundary, DAY_MS, now)).toBe(false);
+      const pastBoundary = {
+        ...session,
+        lastActiveAt: new Date(now.getTime() - DAY_MS - 1).toISOString(),
+      };
+      expect(isSessionExpired(pastBoundary, DAY_MS, now)).toBe(true);
+    });
+
+    it("treats a future lastActiveAt (clock skew) as not expired", () => {
+      const skewed = { ...session, lastActiveAt: new Date(now.getTime() + DAY_MS).toISOString() };
+      expect(isSessionExpired(skewed, DAY_MS, now)).toBe(false);
+    });
+
+    it("defaults to the 30-day window", () => {
+      const old = {
+        ...session,
+        lastActiveAt: new Date(now.getTime() - DEFAULT_SESSION_MAX_AGE_MS - 1).toISOString(),
+      };
+      expect(isSessionExpired(old, undefined, now)).toBe(true);
+    });
   });
 });

--- a/src/session.ts
+++ b/src/session.ts
@@ -12,6 +12,24 @@ export interface SessionStorageAdapter {
   clear(): Promise<void>;
 }
 
+/**
+ * Recommended retention window for cached session state: **30 days** of
+ * inactivity.
+ *
+ * Cached session state is low-sensitivity (a public smart-account address, a
+ * public passkey credential id, timestamps) — it is *not* a credential, and it
+ * cannot authorize anything on its own; every signature still needs a live
+ * WebAuthn ceremony. What it does carry is a durable link between a browser
+ * profile and an on-chain account, so it should not sit in `localStorage`
+ * forever on a shared or long-lived device.
+ *
+ * 30 days keeps "open the app, still signed in" true for ordinary use while
+ * bounding how long an abandoned profile keeps pointing at an account. Consumers
+ * with a stricter posture (shared kiosks, custodial dashboards) should shorten
+ * it — a few hours is reasonable — via `createSessionStore(storage, { maxAgeMs })`.
+ */
+export const DEFAULT_SESSION_MAX_AGE_MS = 30 * 24 * 60 * 60 * 1000;
+
 export type SessionStatus = "loading" | "connected" | "disconnected";
 
 export interface SessionState {
@@ -45,6 +63,16 @@ export interface CreateSessionStoreOptions {
    * `dispose()`.
    */
   refreshIntervalMs?: number;
+  /**
+   * Maximum age of cached session state, in milliseconds, measured from its
+   * `lastActiveAt`. Enforced on read: `restore()` discards (and clears from
+   * storage) anything older than this instead of resuming it.
+   *
+   * Defaults to {@link DEFAULT_SESSION_MAX_AGE_MS} (30 days). Pass `Infinity`
+   * to opt out of expiry entirely — only appropriate when the storage adapter
+   * itself is ephemeral. Must be a positive number; anything else throws.
+   */
+  maxAgeMs?: number;
 }
 
 export function isWalletSession(value: unknown): value is WalletSession {
@@ -61,10 +89,48 @@ export function isWalletSession(value: unknown): value is WalletSession {
   );
 }
 
+/**
+ * Has cached session state outlived its retention window?
+ *
+ * Age is measured from `lastActiveAt` (refreshed by `touch()`), so the window is
+ * an *idle* timeout, not a hard cap on session lifetime. Session state whose
+ * `lastActiveAt` is unparseable is treated as expired: an unreadable timestamp
+ * means the age cannot be bounded, and cached state we cannot age out is exactly
+ * what the retention window exists to prevent.
+ *
+ * A `lastActiveAt` in the future (clock skew, or a doctored storage entry) is
+ * never expired — its age is clamped at zero rather than going negative.
+ */
+export function isSessionExpired(
+  session: WalletSession,
+  maxAgeMs: number = DEFAULT_SESSION_MAX_AGE_MS,
+  now: Date = new Date(),
+): boolean {
+  if (maxAgeMs === Infinity) return false;
+  const lastActive = Date.parse(session.lastActiveAt);
+  if (Number.isNaN(lastActive)) return true;
+  const ageMs = Math.max(0, now.getTime() - lastActive);
+  return ageMs > maxAgeMs;
+}
+
+function resolveMaxAgeMs(maxAgeMs: number | undefined): number {
+  if (maxAgeMs === undefined) return DEFAULT_SESSION_MAX_AGE_MS;
+  if (typeof maxAgeMs !== "number" || Number.isNaN(maxAgeMs) || maxAgeMs <= 0) {
+    throw new RangeError(
+      `maxAgeMs must be a positive number of milliseconds (or Infinity to disable expiry), got ${String(maxAgeMs)}`,
+    );
+  }
+  return maxAgeMs;
+}
+
 export function createSessionStore(
   storage: SessionStorageAdapter,
   options: CreateSessionStoreOptions = {},
 ): SessionStore {
+  // Validate the retention window up front so a misconfigured maxAgeMs fails at
+  // wiring time rather than silently on the first restore().
+  const maxAgeMs = resolveMaxAgeMs(options.maxAgeMs);
+
   // Long-lived resources owned by the store: the optional refresh-polling
   // interval plus a disposed latch so a torn-down store never schedules new
   // work. `dispose()` clears both; nothing in the store keeps a reference to
@@ -122,12 +188,25 @@ export function createSessionStore(
     async restore() {
       try {
         const stored = await storage.load();
-        if (stored && isWalletSession(stored)) {
-          set({ session: stored, status: "connected" });
-          startRefresh();
-        } else {
+        if (!stored || !isWalletSession(stored)) {
           set({ session: null, status: "disconnected" });
+          return;
         }
+        if (isSessionExpired(stored, maxAgeMs)) {
+          // Past the retention window: discard it rather than resume it, and
+          // evict it from storage so an abandoned profile stops carrying the
+          // account link around. A clear failure here is not fatal — the
+          // in-memory decision (disconnected) still holds.
+          try {
+            await storage.clear();
+          } catch {
+            // Best-effort eviction; read-only or full storage must not brick startup.
+          }
+          set({ session: null, status: "disconnected" });
+          return;
+        }
+        set({ session: stored, status: "connected" });
+        startRefresh();
       } catch {
         // Unreadable storage must not brick the app on startup.
         set({ session: null, status: "disconnected" });


### PR DESCRIPTION
closes #292

## Summary

Cached session state persisted through a `SessionStorageAdapter` had no bound on how long it could live in consumer local storage. This adds a retention window with a documented default, enforced by the SDK on read.

Worth stating up front what this data is, because it sets the right severity: cached session state holds **no key material** and cannot authorize anything on its own — every signature still requires a live WebAuthn ceremony against the passkey. It is the public smart-account address, the public passkey credential id, and two timestamps. What it *does* carry is a durable link between a browser profile and an on-chain account, which is why it should not sit in `localStorage` indefinitely on a shared or long-lived device.

## Requirements

**Document a recommended retention window** — `DEFAULT_SESSION_MAX_AGE_MS` is 30 days of inactivity, with the reasoning in its JSDoc and in the README. 30 days keeps "open the app, still signed in" true for ordinary use while bounding how long an abandoned profile keeps pointing at an account.

**A configurable max age enforced on read** — `createSessionStore(storage, { maxAgeMs })`. `restore()` measures the cached entry's age from `lastActiveAt` and, past the window, discards it **and clears it from storage** rather than resuming it. Expired state is evicted, not merely ignored — otherwise the entry the window exists to bound would keep sitting in `localStorage` forever.

**A test verifying expired state past the max age is discarded** — plus the surrounding cases; see below.

**Document the retention behavior in the README** — a dedicated "Session retention" section and a `Helpers` table row.

## Design notes

**The window is an idle timeout, not a hard cap on session lifetime.** Age is measured from `lastActiveAt`, which `touch()` already refreshes on user activity, so an actively used session keeps renewing while an untouched one ages out. This is the behavior consumers expect from "still signed in", and it composes with the existing `refreshIntervalMs` polling.

**Edge cases resolved deliberately, each with a test:**

- **Unparseable `lastActiveAt` is treated as expired.** If the age cannot be bounded, the entry is exactly what the retention window exists to prevent, so it is discarded rather than resumed.
- **A future `lastActiveAt` is never expired.** Clock skew (or a doctored storage entry) clamps age at zero rather than going negative.
- **A failed eviction is non-fatal.** If `clear()` throws on read-only or full storage, the in-memory decision (disconnected) still holds — startup must not brick.
- **`maxAgeMs: Infinity`** opts out of expiry, for an adapter that is itself ephemeral.
- **A non-positive or `NaN` `maxAgeMs` throws a `RangeError` at construction**, so a misconfigured window fails at wiring rather than silently disabling expiry on first restore.

`isSessionExpired(session, maxAgeMs?, now?)` is exported as a pure helper for consumers that need to apply the same rule themselves.

## Pre-existing breakage fixed along the way

`src/session.test.ts` on `dev` **does not parse**. The `dispose() clears the timer so the store is garbage-collectable` case is missing its closing braces, and a new `describe(` opens immediately after it:

```
    expect(vi.getTimerCount()).toBe(0);
describe("createSessionStore — refresh & expiry edge cases", () => {
```

`tsc` reports `session.test.ts(428,1): error TS1005: '}' expected.` and vitest fails the whole file with `Transform failed`. I could not add tests to the file without closing the block, so this PR closes it. That is the minimal fix — no assertions were changed.

Relatedly, the shared `session` fixture's `lastActiveAt` was a hardcoded `2026-07-16`, which is now more than 30 days in the past. With a retention window in place, a fixed past timestamp silently ages out and makes the `restore()` tests fail as the calendar moves — a time bomb regardless of the default chosen. The fixture's `lastActiveAt` is now relative to "now", which is what those tests actually mean ("an active session"). No test asserted that literal value except one, which already computed its input from `session.lastActiveAt`; it now derives its expected output from the same source instead of hardcoding the result.

## Verification

```
npx vitest run src/session.test.ts    # 50 passed
```

Full-suite comparison against `dev`, to be explicit that this PR does not regress anything:

| | Test files | Tests |
| --- | --- | --- |
| `dev` (baseline) | 8 failed, 159 passed | 18 failed, 1515 passed |
| this branch | 7 failed, 160 passed | 18 failed, 1565 passed |

One fewer failing file (the unparseable `session.test.ts`) and 50 new passing tests. The remaining 18 failures are all in `contrib/` and are identical before and after this change — untouched here.

Two pre-existing `tsc` errors also predate this branch and are untouched: `src/balances.test.ts(103,44)` and `src/tx-rpc.ts(102,30)`. The latter is what currently fails `npm run build`'s dts step on `dev`. They were previously masked because the `session.test.ts` parse error halted the check before reaching them.

## Scope note

Per CONTRIBUTING.md rule 3, I flagged on the issue before starting that this one cannot be resolved inside `contrib/` — a max age "enforced by the SDK on read" has to live in `src/session.ts`, and the README requirement is explicit. Flagging again here so the contrib-only bot's result is expected rather than a surprise. Happy to adjust if a maintainer would rather scope it differently.
