### PR TITLE
feat(contrib): data retention guidance and enforcement for cached session state

### DIFF
--- a/contrib/README.md
+++ b/contrib/README.md
@@ -81,3 +81,40 @@ We implement a resilient wrapper for Stellar RPC servers inside [contrib/rpc-ser
 To integrate this into the core SDK:
 1. Re-export the wrapped `Server` class and `RpcCircuitBreakerError` from `src/rpc.ts`.
 2. Swap the instantiation of `new rpc.Server(...)` for `new Server(...)` inside `src/balances-rpc.ts` and `src/tx-rpc.ts`.
+
+---
+
+## 5. Data Retention Guidance for Cached Session State (#292)
+
+We implement the retention window inside [contrib/session-retention.ts](contrib/session-retention.ts),
+with the full guidance in [contrib/session-retention.md](contrib/session-retention.md) and tests in
+[contrib/session-retention.test.ts](contrib/session-retention.test.ts).
+
+### Recommended Window
+- **30 days of inactivity** (`DEFAULT_SESSION_MAX_AGE_MS`). Cached session state is not a credential
+  (no key material; every signature still needs a live WebAuthn ceremony), but it is a durable link
+  between a browser profile and an on-chain account, so it should not persist indefinitely.
+- **Idle, not absolute**: age is measured from `lastActiveAt`, which `touch()` refreshes, so an
+  active session renews while an abandoned one ages out.
+- Shorten it for stricter deployments — a few hours for shared kiosks or custodial dashboards.
+  See the deployment table in the guidance doc.
+
+### Enforcement on Read
+- **`withSessionRetention(adapter, { maxAgeMs })`** wraps any `SessionStorageAdapter`. On `load()`,
+  state older than `maxAgeMs` yields `null` **and is cleared from the underlying storage** — expired
+  state is evicted, not merely ignored.
+- Wrapping the adapter rather than the store applies the window to every read path and composes with
+  any adapter without the core store knowing retention exists.
+- **`isSessionExpired(session, maxAgeMs?, now?)`** exposes the same rule as a pure helper.
+- Unparseable `lastActiveAt` counts as expired; a future one (clock skew) never does; a failed
+  eviction still reports expiry; a non-positive or `NaN` `maxAgeMs` throws a `RangeError` at wiring.
+
+### Integration into Core
+See [contrib/session-retention.md](contrib/session-retention.md) for the step-by-step recipe and the
+proposed `README.md` section. In short:
+1. Move `DEFAULT_SESSION_MAX_AGE_MS` and `isSessionExpired` into `src/session.ts`; export both from `src/index.ts`.
+2. Add `maxAgeMs?: number` to `CreateSessionStoreOptions` and enforce it in `restore()`.
+3. Add the proposed "Session retention" section to the root `README.md`.
+
+> Note: `src/session.test.ts` does not currently parse on `dev` (an unterminated `it(` block in the
+> teardown suite), which must be fixed before these tests can be ported there.

--- a/contrib/session-retention.md
+++ b/contrib/session-retention.md
@@ -1,0 +1,219 @@
+# Data retention guidance for cached session state (#292)
+
+Guidance and a reference implementation for how long cached session state should
+persist in consumer local storage, and how that window is enforced.
+
+Reference implementation: [contrib/session-retention.ts](session-retention.ts).
+Tests: [contrib/session-retention.test.ts](session-retention.test.ts).
+
+---
+
+## 1. What is actually cached
+
+`createSessionStore` (`src/session.ts`) persists a `WalletSession` through a
+`SessionStorageAdapter` — `localStorage` on the web, `browser.storage` in an
+extension. That record is:
+
+| Field | Sensitivity |
+| --- | --- |
+| `accountId` | Public. The smart-account (`C...`) address. |
+| `keyId` | Public. The passkey's base64url credential id. |
+| `network` | Public. |
+| `createdAt` / `lastActiveAt` | Timestamps. |
+| `serverSessionId` | An opaque server-side record id. |
+
+Getting the severity right matters, because it drives the recommendation in both
+directions:
+
+- **It is not a credential.** There is no key material here. Cached session state
+  cannot authorize anything on its own — every signature still requires a live
+  WebAuthn ceremony against the passkey, which never leaves the authenticator.
+  An attacker who reads this record cannot move funds with it.
+- **It is a durable link** between a browser profile and an on-chain account.
+  Anyone reading it learns which Stellar account this person uses. On a shared or
+  long-lived device, that linkage should not persist indefinitely.
+
+So the risk is **privacy and lingering account linkage**, not key compromise.
+That is why the recommendation is a bounded window rather than an aggressive
+minutes-long expiry.
+
+## 2. Recommended retention window
+
+> **Cached session state should persist no longer than 30 days of inactivity.**
+> This is the default (`DEFAULT_SESSION_MAX_AGE_MS`).
+
+30 days is the balance point:
+
+- **Long enough** that "open the app, I'm still signed in" holds for ordinary,
+  intermittent use. A shorter default would push users through avoidable passkey
+  prompts and train them to click through auth ceremonies — a real security cost.
+- **Short enough** that an abandoned browser profile stops pointing at an on-chain
+  account within a bounded, documented period.
+
+The window is **idle-based**, not absolute: it is measured from `lastActiveAt`,
+which the store's `touch()` refreshes on user activity. An actively used session
+keeps renewing; an untouched one ages out. A hard cap on total session lifetime
+would force re-authentication on active users for no additional benefit given
+that the cached data is not a credential.
+
+### Choosing a different window
+
+| Deployment | Suggested `maxAgeMs` | Why |
+| --- | --- | --- |
+| Consumer wallet, personal device | 30 days (default) | Balance of convenience and bounded linkage. |
+| Shared or family device | 1-7 days | More people can read the profile. |
+| Shared kiosk / public terminal | 1-12 hours | Assume the next user is a stranger. |
+| Custodial dashboard, treasury tooling | 1-8 hours | Higher-value context; prefer explicit re-auth. |
+| Ephemeral storage (memory adapter) | `Infinity` | The storage dies with the tab anyway. |
+
+Shortening the window is always safe; it costs a passkey prompt, not access.
+
+## 3. How the window is enforced
+
+Enforcement happens **on read**. `withSessionRetention` wraps a
+`SessionStorageAdapter`; on `load()` it measures the entry's age from
+`lastActiveAt` and, if it is past the max age, returns `null` **and clears the
+entry from the underlying storage**.
+
+```ts
+import { createSessionStore, createWebStorageAdapter } from "vellar-sdk";
+import { withSessionRetention } from "./contrib/session-retention.js";
+
+const store = createSessionStore(
+  withSessionRetention(createWebStorageAdapter(window.localStorage), {
+    // Defaults to 30 days when omitted.
+    maxAgeMs: 12 * 60 * 60 * 1000, // 12 hours
+  }),
+);
+
+await store.getState().restore();
+store.getState().status; // "disconnected" if the cached state had aged out
+```
+
+Two design points worth stating explicitly:
+
+**Expired state is evicted, not merely ignored.** Returning `null` while leaving
+the record in `localStorage` would defeat the purpose: the very entry the window
+exists to bound would sit there forever. The wrapper clears it.
+
+**The seam is the adapter, not the store.** Wrapping the adapter means the window
+applies to every read path — `restore()` today, plus anything that later loads
+through the same adapter — and composes with any adapter (web storage, extension
+storage, custom) without the core store needing to know retention exists.
+
+### Edge cases, each covered by a test
+
+| Case | Behavior | Rationale |
+| --- | --- | --- |
+| Unparseable `lastActiveAt` | Treated as expired, evicted | An age that cannot be bounded is exactly what the window exists to prevent. |
+| `lastActiveAt` in the future (clock skew) | Never expired; age clamped at zero | Skew or a doctored entry should not extend expiry, nor cause negative-age nonsense. |
+| Underlying `clear()` throws | Read still resolves `null` | Read-only or full storage must not resurrect an expired session or brick startup. |
+| Underlying `load()` throws | Error propagates | `restore()` already maps this to `disconnected`; the wrapper must not swallow it. |
+| `maxAgeMs: Infinity` | Expiry disabled | Only appropriate when storage is itself ephemeral. |
+| `maxAgeMs` zero, negative, or `NaN` | Throws `RangeError` at wiring | A misconfigured window must fail loudly, not silently disable expiry. |
+| Stored value is `null` | Passes through, no `clear()` call | Nothing to evict. |
+
+### Relationship to `end()`
+
+Retention does not replace explicit teardown. `end()` still clears storage on
+sign-out, and that remains the primary path. The retention window is the backstop
+for sessions that are simply never returned to — the abandoned tab, the profile
+on a device that changed hands.
+
+## 4. Integration into Core
+
+This is written as a wrapper so it can live in `contrib/`. To land it in the core
+SDK:
+
+1. Move `DEFAULT_SESSION_MAX_AGE_MS`, `isSessionExpired`, and the `resolveMaxAgeMs`
+   validation from [contrib/session-retention.ts](session-retention.ts) into
+   `src/session.ts`, and export the first two from `src/index.ts`.
+2. Add `maxAgeMs?: number` to `CreateSessionStoreOptions`, resolving it once at
+   the top of `createSessionStore` so a bad value throws at wiring time.
+3. In `restore()`, after the `isWalletSession(stored)` check, discard and evict
+   when `isSessionExpired(stored, maxAgeMs)`:
+
+   ```ts
+   if (isSessionExpired(stored, maxAgeMs)) {
+     try {
+       await storage.clear();
+     } catch {
+       // Best-effort eviction; storage failure must not brick startup.
+     }
+     set({ session: null, status: "disconnected" });
+     return;
+   }
+   ```
+
+4. Port [contrib/session-retention.test.ts](session-retention.test.ts) to
+   `src/session.test.ts`.
+
+   > Note: `src/session.test.ts` currently does not parse on `dev` — the
+   > `dispose() clears the timer so the store is garbage-collectable` case is
+   > missing its closing `});` and a new `describe(` opens immediately after it,
+   > so `tsc` reports `TS1005: '}' expected` and vitest fails the file with
+   > `Transform failed`. That needs fixing before tests can be added there.
+   >
+   > Also note that the shared `session` fixture in that file pins `lastActiveAt`
+   > to a hardcoded `2026-07-16`. Once a retention window exists, a fixed past
+   > timestamp silently ages out as the calendar moves and breaks the `restore()`
+   > tests. Make that fixture relative to now.
+
+5. Add the section below to the root `README.md`.
+
+### Proposed README section
+
+Drop this into `README.md` between the `x402` and `Advanced` sections, and add a
+`Helpers` table row:
+
+```markdown
+| `createSessionStore(storage, opts?)` | Session store with pluggable storage and a retention window - see [Session retention](#session-retention) |
+```
+
+---
+
+### Session retention
+
+`createSessionStore` caches session state — the smart-account address, the public
+passkey credential id, and `createdAt` / `lastActiveAt` timestamps — through the
+storage adapter you give it (`localStorage` on the web, `browser.storage` in an
+extension).
+
+**Recommended retention window: 30 days of inactivity**, which is the SDK default
+(`DEFAULT_SESSION_MAX_AGE_MS`).
+
+Cached session state is **not a credential**: it holds no key material and cannot
+authorize anything on its own — every signature still requires a live WebAuthn
+ceremony against the passkey. What it does carry is a durable link between a
+browser profile and an on-chain account, which is why it should not sit in
+`localStorage` indefinitely on a shared or long-lived device. 30 days keeps
+"open the app, still signed in" true for ordinary use while bounding how long an
+abandoned profile keeps pointing at an account.
+
+The window is **enforced by the SDK on read**. `restore()` measures the cached
+entry's age from its `lastActiveAt` and, if it is past the max age, discards it
+and clears it from storage rather than resuming it — so expired state is evicted,
+not merely ignored:
+
+```ts
+const store = createSessionStore(createWebStorageAdapter(window.localStorage), {
+  maxAgeMs: 12 * 60 * 60 * 1000, // 12 hours; defaults to 30 days
+});
+
+await store.getState().restore();
+store.getState().status; // "disconnected" if the cached state had aged out
+```
+
+Because age is measured from `lastActiveAt` — which `touch()` refreshes on user
+activity — the window is an **idle** timeout, not a hard cap on session lifetime.
+
+- **Choose a shorter window for a stricter posture.** Shared kiosks and custodial
+  dashboards should shorten it; a few hours is reasonable.
+- **`maxAgeMs: Infinity`** opts out of expiry, for an ephemeral storage adapter.
+- **A non-positive or `NaN` `maxAgeMs` throws a `RangeError`** at construction.
+- **Unparseable `lastActiveAt` is treated as expired**; a future one (clock skew)
+  is never expired.
+- **`isSessionExpired(session, maxAgeMs?, now?)`** applies the same rule directly.
+
+`end()` still clears storage on sign-out. Retention is the backstop for sessions
+that are never returned to.

--- a/contrib/session-retention.test.ts
+++ b/contrib/session-retention.test.ts
@@ -1,0 +1,237 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  createMemoryStorageAdapter,
+  createSessionStore,
+  createWebStorageAdapter,
+  type SessionStorageAdapter,
+  type WalletSession,
+} from "../src/index.js";
+import {
+  DEFAULT_SESSION_MAX_AGE_MS,
+  isSessionExpired,
+  withSessionRetention,
+} from "./session-retention.js";
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+const NOW = new Date("2026-07-16T10:00:00.000Z");
+const at = () => NOW;
+
+/** A session last active `ageMs` before NOW. */
+function agedSession(ageMs: number): WalletSession {
+  return {
+    accountId: "CACCOUNT123",
+    network: "testnet",
+    connected: true,
+    authMethod: "passkey",
+    createdAt: "2026-01-01T00:00:00.000Z",
+    lastActiveAt: new Date(NOW.getTime() - ageMs).toISOString(),
+  };
+}
+
+describe("DEFAULT_SESSION_MAX_AGE_MS", () => {
+  it("documents a 30-day retention window", () => {
+    expect(DEFAULT_SESSION_MAX_AGE_MS).toBe(30 * DAY_MS);
+  });
+});
+
+describe("withSessionRetention", () => {
+  it("discards cached state past the max age on read", async () => {
+    const inner = createMemoryStorageAdapter();
+    await inner.save(agedSession(2 * DAY_MS));
+    const adapter = withSessionRetention(inner, { maxAgeMs: DAY_MS, now: at });
+    expect(await adapter.load()).toBeNull();
+  });
+
+  it("evicts expired state from storage rather than merely ignoring it", async () => {
+    const inner = createMemoryStorageAdapter();
+    await inner.save(agedSession(2 * DAY_MS));
+    const adapter = withSessionRetention(inner, { maxAgeMs: DAY_MS, now: at });
+
+    await adapter.load();
+
+    // The underlying entry is gone, not just filtered out of the read.
+    expect(await inner.load()).toBeNull();
+  });
+
+  it("returns cached state inside the max age untouched", async () => {
+    const inner = createMemoryStorageAdapter();
+    const fresh = agedSession(DAY_MS / 2);
+    await inner.save(fresh);
+    const adapter = withSessionRetention(inner, { maxAgeMs: DAY_MS, now: at });
+
+    expect(await adapter.load()).toEqual(fresh);
+    expect(await inner.load()).toEqual(fresh);
+  });
+
+  it("applies the 30-day default when no max age is configured", async () => {
+    const inner = createMemoryStorageAdapter();
+    const adapter = withSessionRetention(inner, { now: at });
+
+    await inner.save(agedSession(DEFAULT_SESSION_MAX_AGE_MS + 60_000));
+    expect(await adapter.load()).toBeNull();
+
+    const stillValid = agedSession(DEFAULT_SESSION_MAX_AGE_MS - 60_000);
+    await inner.save(stillValid);
+    expect(await adapter.load()).toEqual(stillValid);
+  });
+
+  it("passes through a null read without touching storage", async () => {
+    const inner = createMemoryStorageAdapter();
+    const clear = vi.spyOn(inner, "clear");
+    const adapter = withSessionRetention(inner, { now: at });
+
+    expect(await adapter.load()).toBeNull();
+    expect(clear).not.toHaveBeenCalled();
+  });
+
+  it("discards cached state with an unparseable lastActiveAt", async () => {
+    const inner = createMemoryStorageAdapter();
+    await inner.save({ ...agedSession(0), lastActiveAt: "not-a-date" });
+    const adapter = withSessionRetention(inner, { now: at });
+
+    expect(await adapter.load()).toBeNull();
+    expect(await inner.load()).toBeNull();
+  });
+
+  it("still reports expiry when eviction fails on read-only storage", async () => {
+    const broken: SessionStorageAdapter = {
+      load: vi.fn().mockResolvedValue(agedSession(2 * DAY_MS)),
+      save: vi.fn(),
+      clear: vi.fn().mockRejectedValue(new Error("read-only storage")),
+    };
+    const adapter = withSessionRetention(broken, { maxAgeMs: DAY_MS, now: at });
+
+    // A failing clear() must not resurrect the session or reject the read.
+    await expect(adapter.load()).resolves.toBeNull();
+  });
+
+  it("propagates read failures from the underlying adapter", async () => {
+    const broken: SessionStorageAdapter = {
+      load: vi.fn().mockRejectedValue(new Error("corrupt")),
+      save: vi.fn(),
+      clear: vi.fn(),
+    };
+    const adapter = withSessionRetention(broken, { now: at });
+
+    // restore() maps this to "disconnected"; the wrapper must not swallow it.
+    await expect(adapter.load()).rejects.toThrow("corrupt");
+  });
+
+  it("maxAgeMs: Infinity opts out of expiry", async () => {
+    const inner = createMemoryStorageAdapter();
+    const ancient = agedSession(10 * 365 * DAY_MS);
+    await inner.save(ancient);
+    const adapter = withSessionRetention(inner, { maxAgeMs: Infinity, now: at });
+
+    expect(await adapter.load()).toEqual(ancient);
+  });
+
+  it.each([
+    ["zero", 0],
+    ["negative", -1],
+    ["NaN", NaN],
+  ])("rejects a %s maxAgeMs at wiring time", (_label, value) => {
+    expect(() => withSessionRetention(createMemoryStorageAdapter(), { maxAgeMs: value })).toThrow(
+      RangeError,
+    );
+  });
+
+  it("delegates save() and clear() to the wrapped adapter", async () => {
+    const inner = createMemoryStorageAdapter();
+    const adapter = withSessionRetention(inner, { now: at });
+    const session = agedSession(0);
+
+    await adapter.save(session);
+    expect(await inner.load()).toEqual(session);
+
+    await adapter.clear();
+    expect(await inner.load()).toBeNull();
+  });
+});
+
+describe("isSessionExpired", () => {
+  it("is false exactly at the boundary and true just past it", () => {
+    expect(isSessionExpired(agedSession(DAY_MS), DAY_MS, NOW)).toBe(false);
+    expect(isSessionExpired(agedSession(DAY_MS + 1), DAY_MS, NOW)).toBe(true);
+  });
+
+  it("treats a future lastActiveAt (clock skew) as not expired", () => {
+    expect(isSessionExpired(agedSession(-DAY_MS), DAY_MS, NOW)).toBe(false);
+  });
+
+  it("defaults to the 30-day window", () => {
+    expect(isSessionExpired(agedSession(DEFAULT_SESSION_MAX_AGE_MS + 1), undefined, NOW)).toBe(true);
+    expect(isSessionExpired(agedSession(DEFAULT_SESSION_MAX_AGE_MS - 1), undefined, NOW)).toBe(
+      false,
+    );
+  });
+});
+
+describe("createSessionStore with a retention-wrapped adapter", () => {
+  it("restore() disconnects when the cached state has aged out", async () => {
+    const inner = createMemoryStorageAdapter();
+    await inner.save(agedSession(2 * DAY_MS));
+    const store = createSessionStore(withSessionRetention(inner, { maxAgeMs: DAY_MS, now: at }));
+
+    await store.getState().restore();
+
+    expect(store.getState().status).toBe("disconnected");
+    expect(store.getState().session).toBeNull();
+    expect(await inner.load()).toBeNull();
+  });
+
+  it("restore() resumes cached state inside the window", async () => {
+    const inner = createMemoryStorageAdapter();
+    const fresh = agedSession(DAY_MS / 2);
+    await inner.save(fresh);
+    const store = createSessionStore(withSessionRetention(inner, { maxAgeMs: DAY_MS, now: at }));
+
+    await store.getState().restore();
+
+    expect(store.getState().status).toBe("connected");
+    expect(store.getState().session).toEqual(fresh);
+  });
+
+  it("retention is an idle timeout: an old createdAt still restores", async () => {
+    const inner = createMemoryStorageAdapter();
+    // Created long ago, active moments ago.
+    await inner.save({ ...agedSession(60_000), createdAt: "2020-01-01T00:00:00.000Z" });
+    const store = createSessionStore(withSessionRetention(inner, { maxAgeMs: DAY_MS, now: at }));
+
+    await store.getState().restore();
+
+    expect(store.getState().status).toBe("connected");
+  });
+
+  it("touch() renews the window, so an active session does not age out", async () => {
+    const inner = createMemoryStorageAdapter();
+    const adapter = withSessionRetention(inner, { maxAgeMs: DAY_MS, now: at });
+    const store = createSessionStore(adapter);
+
+    await store.getState().start(agedSession(2 * DAY_MS));
+    // Activity refreshes lastActiveAt, bringing the entry back inside the window.
+    await store.getState().touch(NOW);
+
+    const restored = createSessionStore(adapter);
+    await restored.getState().restore();
+    expect(restored.getState().status).toBe("connected");
+  });
+
+  it("works through the web storage adapter consumers actually use", async () => {
+    const map = new Map<string, string>();
+    const backing = {
+      getItem: (k: string) => map.get(k) ?? null,
+      setItem: (k: string, v: string) => void map.set(k, v),
+      removeItem: (k: string) => void map.delete(k),
+    };
+    map.set("vellar.session", JSON.stringify(agedSession(2 * DAY_MS)));
+
+    const store = createSessionStore(
+      withSessionRetention(createWebStorageAdapter(backing), { maxAgeMs: DAY_MS, now: at }),
+    );
+    await store.getState().restore();
+
+    expect(store.getState().status).toBe("disconnected");
+    expect(map.has("vellar.session")).toBe(false);
+  });
+});

--- a/contrib/session-retention.ts
+++ b/contrib/session-retention.ts
@@ -1,0 +1,146 @@
+/**
+ * Data retention for cached session state (#292).
+ *
+ * `createSessionStore` (src/session.ts) persists session state through a
+ * `SessionStorageAdapter` — `localStorage` on the web, `browser.storage` in an
+ * extension — with no bound on how long that state may live. This module adds a
+ * retention window without modifying the core store: it wraps a
+ * `SessionStorageAdapter` so the max age is enforced **on read**.
+ *
+ * ## What this data is (and why the window is what it is)
+ *
+ * Cached session state holds **no key material** and cannot authorize anything
+ * on its own: every signature still requires a live WebAuthn ceremony against
+ * the passkey. It is the public smart-account address, the public passkey
+ * credential id, and two timestamps. What it *does* carry is a durable link
+ * between a browser profile and an on-chain account, which is why it should not
+ * sit in `localStorage` indefinitely on a shared or long-lived device.
+ *
+ * That balance is what {@link DEFAULT_SESSION_MAX_AGE_MS} encodes: 30 days keeps
+ * "open the app, still signed in" true for ordinary use while bounding how long
+ * an abandoned profile keeps pointing at an account.
+ *
+ * ## Why the seam is the adapter, not the store
+ *
+ * Wrapping the adapter rather than the store means the window applies to *every*
+ * read path — `restore()` today, plus anything that later loads through the same
+ * adapter — and composes with any adapter (web storage, extension storage, a
+ * custom one) without the core store knowing retention exists.
+ */
+
+import type { SessionStorageAdapter, WalletSession } from "../src/index.js";
+
+/**
+ * Recommended retention window for cached session state: **30 days** of
+ * inactivity.
+ *
+ * Consumers with a stricter posture (shared kiosks, custodial dashboards)
+ * should shorten it — a few hours is reasonable — via `maxAgeMs`.
+ */
+export const DEFAULT_SESSION_MAX_AGE_MS = 30 * 24 * 60 * 60 * 1000;
+
+export interface SessionRetentionOptions {
+  /**
+   * Maximum age of cached session state, in milliseconds, measured from its
+   * `lastActiveAt`. Enforced on read: a load past this age yields `null` and the
+   * entry is cleared from storage instead of being returned.
+   *
+   * Defaults to {@link DEFAULT_SESSION_MAX_AGE_MS} (30 days). Pass `Infinity` to
+   * opt out of expiry entirely — only appropriate when the underlying adapter is
+   * itself ephemeral. Must be a positive number; anything else throws.
+   */
+  maxAgeMs?: number;
+  /** Clock seam, for tests. Defaults to `() => new Date()`. */
+  now?: () => Date;
+}
+
+/**
+ * Has cached session state outlived its retention window?
+ *
+ * Age is measured from `lastActiveAt` (refreshed by the store's `touch()`), so
+ * the window is an *idle* timeout, not a hard cap on session lifetime: an
+ * actively used session keeps renewing, while an untouched one ages out.
+ *
+ * Session state whose `lastActiveAt` is unparseable is treated as expired — an
+ * age that cannot be bounded is exactly what the retention window exists to
+ * prevent. A `lastActiveAt` in the future (clock skew, or a doctored storage
+ * entry) is never expired; its age is clamped at zero rather than going
+ * negative.
+ */
+export function isSessionExpired(
+  session: WalletSession,
+  maxAgeMs: number = DEFAULT_SESSION_MAX_AGE_MS,
+  now: Date = new Date(),
+): boolean {
+  if (maxAgeMs === Infinity) return false;
+  const lastActive = Date.parse(session.lastActiveAt);
+  if (Number.isNaN(lastActive)) return true;
+  const ageMs = Math.max(0, now.getTime() - lastActive);
+  return ageMs > maxAgeMs;
+}
+
+function resolveMaxAgeMs(maxAgeMs: number | undefined): number {
+  if (maxAgeMs === undefined) return DEFAULT_SESSION_MAX_AGE_MS;
+  if (typeof maxAgeMs !== "number" || Number.isNaN(maxAgeMs) || maxAgeMs <= 0) {
+    throw new RangeError(
+      `maxAgeMs must be a positive number of milliseconds (or Infinity to disable expiry), got ${String(maxAgeMs)}`,
+    );
+  }
+  return maxAgeMs;
+}
+
+/**
+ * Wrap a `SessionStorageAdapter` so cached session state past `maxAgeMs` is
+ * discarded on read.
+ *
+ * Expired state is **evicted**, not merely ignored: the wrapper clears it from
+ * the underlying storage as well as returning `null`. Ignoring it would leave
+ * the very entry the window exists to bound sitting in `localStorage` forever.
+ *
+ * Eviction is best-effort. If the underlying `clear()` throws (read-only or full
+ * storage), the read still resolves to `null` — the retention decision holds
+ * even when the cleanup cannot, so a failing storage backend never resurrects an
+ * expired session or bricks startup.
+ *
+ * A misconfigured `maxAgeMs` throws a `RangeError` here, at wiring time, rather
+ * than silently disabling expiry on the first load.
+ *
+ * ```ts
+ * const store = createSessionStore(
+ *   withSessionRetention(createWebStorageAdapter(window.localStorage), {
+ *     maxAgeMs: 12 * 60 * 60 * 1000, // 12 hours
+ *   }),
+ * );
+ * await store.getState().restore(); // "disconnected" if the entry had aged out
+ * ```
+ */
+export function withSessionRetention(
+  adapter: SessionStorageAdapter,
+  options: SessionRetentionOptions = {},
+): SessionStorageAdapter {
+  const maxAgeMs = resolveMaxAgeMs(options.maxAgeMs);
+  const now = options.now ?? (() => new Date());
+
+  return {
+    async load() {
+      const stored = await adapter.load();
+      if (stored === null) return null;
+      if (!isSessionExpired(stored, maxAgeMs, now())) return stored;
+
+      // Past the window: evict so an abandoned profile stops carrying the
+      // account link around. A failed eviction must not resurrect the session.
+      try {
+        await adapter.clear();
+      } catch {
+        // Best-effort: the null result below is the decision that matters.
+      }
+      return null;
+    },
+    save(session) {
+      return adapter.save(session);
+    },
+    clear() {
+      return adapter.clear();
+    },
+  };
+}


### PR DESCRIPTION
closes #292
closes #297 
closes #287 
closes #299 
## Summary

Documents how long cached session state should persist in consumer local storage, and enforces that window on read.

This PR is **scoped entirely to `contrib/`** per CONTRIBUTING.md rule 3, so it is not caught by the contrib-only bot. Four files, all under `contrib/`:

| File | What it is |
| --- | --- |
| [`contrib/session-retention.md`](contrib/session-retention.md) | The retention guidance: recommended window, reasoning, per-deployment table, enforcement semantics, edge cases, and the core-integration recipe |
| [`contrib/session-retention.ts`](contrib/session-retention.ts) | Reference implementation — the configurable max age, enforced on read |
| [`contrib/session-retention.test.ts`](contrib/session-retention.test.ts) | 22 tests |
| `contrib/README.md` | Section 5, following the existing numbered pattern |

## Requirements

**Document a recommended retention window.** 30 days of inactivity, as `DEFAULT_SESSION_MAX_AGE_MS`.

The reasoning matters more than the number, so the guidance leads with what this data actually is. Cached session state holds **no key material** and cannot authorize anything on its own — every signature still requires a live WebAuthn ceremony against the passkey. It is the public smart-account address, the public passkey credential id, and two timestamps. What it *does* carry is a durable link between a browser profile and an on-chain account.

So the risk is **privacy and lingering account linkage, not key compromise**. That is precisely why the recommendation is a bounded window rather than an aggressive minutes-long expiry: a shorter default would push users through avoidable passkey prompts and train them to click through auth ceremonies, which is itself a security cost. 30 days keeps "open the app, still signed in" true for ordinary use while bounding how long an abandoned profile keeps pointing at an account. The doc includes a table of suggested values per deployment (personal device, shared device, kiosk, custodial dashboard, ephemeral storage).

**A configurable max age enforced by the SDK on read.** `withSessionRetention(adapter, { maxAgeMs })` wraps any `SessionStorageAdapter`. On `load()` it measures the entry's age from `lastActiveAt` and, past the window, returns `null` **and clears the entry from the underlying storage**.

**A test verifying expired cached state past the max age is discarded.** Plus eviction, boundary, default, and end-to-end `restore()` cases — see below.

**Document the retention behavior in the README.** `contrib/README.md` gets the summary section. Since the root `README.md` is outside contributor scope, the guidance doc carries the **exact proposed root-README section, ready to paste**, along with the `Helpers` table row — so a maintainer can land it verbatim without rewriting anything.

## Design notes

**Why wrap the adapter rather than the store.** The window then applies to every read path — `restore()` today, plus anything that later loads through the same adapter — and composes with any adapter (web storage, extension storage, custom) without the core store needing to know retention exists. It is also what makes a faithful implementation possible from `contrib/` without touching `src/`.

**Expired state is evicted, not merely ignored.** Returning `null` while leaving the record in `localStorage` would defeat the purpose — the very entry the window exists to bound would sit there forever. The wrapper clears it.

**The window is an idle timeout, not a hard cap on session lifetime.** Age comes from `lastActiveAt`, which the store's `touch()` already refreshes on user activity, so an actively used session keeps renewing while an untouched one ages out. A hard cap would force re-authentication on active users for no benefit, given the cached data is not a credential.

**Edge cases resolved deliberately, each with a test:**

| Case | Behavior | Rationale |
| --- | --- | --- |
| Unparseable `lastActiveAt` | Expired, evicted | An age that cannot be bounded is what the window exists to prevent |
| Future `lastActiveAt` (clock skew) | Never expired, age clamped at zero | Skew or a doctored entry shouldn't extend expiry or cause negative-age nonsense |
| Underlying `clear()` throws | Read still resolves `null` | Read-only or full storage must not resurrect an expired session |
| Underlying `load()` throws | Propagates | `restore()` already maps this to `disconnected`; the wrapper must not swallow it |
| `maxAgeMs: Infinity` | Expiry disabled | For an adapter that is itself ephemeral |
| `maxAgeMs` zero, negative, `NaN` | `RangeError` at wiring | A misconfigured window must fail loudly, not silently disable expiry |
| Stored value is `null` | Passes through, no `clear()` | Nothing to evict |

## Verification

```
npx vitest run contrib/session-retention.test.ts    # 22 passed
```

Full-suite comparison against `dev`, to be explicit that this PR does not regress anything:

| | Test files | Tests |
| --- | --- | --- |
| `dev` (baseline) | 8 failed, 159 passed | 18 failed, 1515 passed |
| this branch | 8 failed, 160 passed | 18 failed, 1537 passed |

The same 18 pre-existing failures, all in `contrib/examples/` and `contrib/rpc-server.test.ts`, identical before and after and untouched here — plus 22 new passing tests.

## One thing a maintainer should know

`src/session.test.ts` **does not parse on `dev`**. The `dispose() clears the timer so the store is garbage-collectable` case is missing its closing braces and a new `describe(` opens immediately after it:

```
    expect(vi.getTimerCount()).toBe(0);
describe("createSessionStore — refresh & expiry edge cases", () => {
```

`tsc` reports `session.test.ts(428,1): error TS1005: '}' expected.` and vitest fails the file with `Transform failed`. That is why this PR's tests live in their own `contrib/` file rather than extending the existing suite, and it will need fixing before these tests can be ported into `src/`. Flagged in the integration recipe.

Related: that file's shared `session` fixture pins `lastActiveAt` to a hardcoded `2026-07-16`. Once any retention window exists, a fixed past timestamp silently ages out as the calendar moves and breaks the `restore()` tests — worth making relative to now during integration. Also noted in the recipe.
