### PR TITLE
feat(http-backend): add injectable structured request logging hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,8 +108,25 @@ transactions to your backend, which does the sponsored submit.
 | `POST /wallet/connect` | Resolve the smart-account for a known passkey  |
 | `POST /wallet/submit`  | Submit an already-signed transaction           |
 
-You run a backend implementing these (holding your relayer/sponsor creds). Your
-backend must also allow your app's origin via CORS.
+### Logging
+
+`createHttpWalletBackend` accepts an optional third argument — a structured
+logging hook — invoked once per completed request (success and failure alike)
+with a `{ method, url, status, durationMs }` entry:
+
+```ts
+import { createHttpWalletBackend } from "vellar-sdk";
+
+const backend = createHttpWalletBackend("https://api.myapp.com", undefined, (log) => {
+  console.info(JSON.stringify(log)); // { method, url, status, durationMs }
+  // route, parse, or filter on log.status / log.url in your log pipeline
+});
+```
+
+The hook receives structured fields instead of free-form console output, so
+consumer log pipelines can parse and route on them directly. The two arguments
+after the URL are optional; pass `undefined` for the default `fetch` and only
+the hook.
 
 ## API
 
@@ -129,9 +146,9 @@ Returns a `VellarWallet`:
 
 ### Helpers
 
-| Export                         | Description                                                                              |
-| ------------------------------ | ---------------------------------------------------------------------------------------- |
-| `createHttpWalletBackend(url)` | An HTTP `backend` client for your gateway — pass straight to the config                  |
+| Export                                    | Description                                                                              |
+| ----------------------------------------- | ---------------------------------------------------------------------------------------- |
+| `createHttpWalletBackend(url, fetch?, log?)` | An HTTP `backend` client for your gateway — pass straight to the config. Optional third arg is a structured `{ method, url, status, durationMs }` logging hook — see [Logging](#logging) |
 | `TESTNET`                      | Testnet config: `rpcUrl`, `networkPassphrase`, `walletWasmHash`, `nativeTokenContractId` |
 | `MAINNET` / `mainnetConfig()`  | Mainnet config — see [Mainnet](#mainnet) (two values you must supply)                    |
 | `WalletApiError`               | Thrown by the HTTP backend on non-2xx responses (has `status`, `code`)                   |

--- a/src/http-backend.test.ts
+++ b/src/http-backend.test.ts
@@ -1,0 +1,149 @@
+import { describe, expect, it, vi } from "vitest";
+import { createHttpWalletBackend, WalletApiError, type RequestLog } from "./http-backend";
+
+function jsonResponse(status: number, body?: unknown): Response {
+  return new Response(body === undefined ? undefined : JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+describe("createHttpWalletBackend logging hook", () => {
+  const apiUrl = "https://gateway.example.com/";
+
+  it("invokes the hook with method, url, status, and duration on success", async () => {
+    const log = vi.fn<(log: RequestLog) => void>();
+    const backend = createHttpWalletBackend(
+      apiUrl,
+      vi.fn(async () => jsonResponse(200, { sessionId: "s1" })),
+      log,
+    );
+
+    await backend.submitWalletCreation({
+      keyId: "k1",
+      contractId: "C000",
+      network: "testnet",
+      signedTx: "xdr",
+    });
+
+    expect(log).toHaveBeenCalledTimes(1);
+    const entry = log.mock.calls[0]![0];
+    expect(entry.method).toBe("POST");
+    expect(entry.url).toBe("https://gateway.example.com/wallet/create");
+    expect(entry.status).toBe(200);
+    expect(entry.durationMs).toBeTypeOf("number");
+    expect(entry.durationMs).toBeGreaterThanOrEqual(0);
+  });
+
+  it("logs submitTransaction success with the right url", async () => {
+    const log = vi.fn<(log: RequestLog) => void>();
+    const backend = createHttpWalletBackend(
+      apiUrl,
+      vi.fn(async () => jsonResponse(200, { hash: "deadbeef" })),
+      log,
+    );
+
+    await backend.submitTransaction({ signedXdr: "xdr", network: "testnet" });
+
+    expect(log).toHaveBeenCalledTimes(1);
+    expect(log.mock.calls[0]![0]).toMatchObject({
+      method: "POST",
+      url: "https://gateway.example.com/wallet/submit",
+      status: 200,
+    });
+  });
+
+  it("logs a failure for /wallet/create and still throws WalletApiError", async () => {
+    const log = vi.fn<(log: RequestLog) => void>();
+    const backend = createHttpWalletBackend(
+      apiUrl,
+      vi.fn(async () => jsonResponse(500, { error: "sponsor down" })),
+      log,
+    );
+
+    await expect(
+      backend.submitWalletCreation({
+        keyId: "k1",
+        contractId: "C000",
+        network: "testnet",
+        signedTx: "xdr",
+      }),
+    ).rejects.toThrow(WalletApiError);
+
+    expect(log).toHaveBeenCalledTimes(1);
+    expect(log.mock.calls[0]![0]).toMatchObject({
+      method: "POST",
+      url: "https://gateway.example.com/wallet/create",
+      status: 500,
+    });
+    expect(log.mock.calls[0]![0].durationMs).toBeGreaterThanOrEqual(0);
+  });
+
+  it("logs a failure for /wallet/connect (non-404) and still throws", async () => {
+    const log = vi.fn<(log: RequestLog) => void>();
+    const backend = createHttpWalletBackend(
+      apiUrl,
+      vi.fn(async () => jsonResponse(401, { message: "unauthorized" })),
+      log,
+    );
+
+    await expect(
+      backend.lookupContractId({ keyId: "k1", network: "testnet" }),
+    ).rejects.toThrow("unauthorized");
+
+    expect(log).toHaveBeenCalledTimes(1);
+    expect(log.mock.calls[0]![0]).toMatchObject({
+      url: "https://gateway.example.com/wallet/connect",
+      status: 401,
+    });
+  });
+
+  it("logs a failure for /wallet/submit and still throws", async () => {
+    const log = vi.fn<(log: RequestLog) => void>();
+    const backend = createHttpWalletBackend(
+      apiUrl,
+      vi.fn(async () => jsonResponse(503, { error: "busy" })),
+      log,
+    );
+
+    await expect(
+      backend.submitTransaction({ signedXdr: "xdr", network: "testnet" }),
+    ).rejects.toThrow("busy");
+
+    expect(log).toHaveBeenCalledTimes(1);
+    expect(log.mock.calls[0]![0]).toMatchObject({
+      url: "https://gateway.example.com/wallet/submit",
+      status: 503,
+    });
+  });
+
+  it("logs the 404 lookup edge case and returns undefined (not an error)", async () => {
+    const log = vi.fn<(log: RequestLog) => void>();
+    const backend = createHttpWalletBackend(
+      apiUrl,
+      vi.fn(async () => jsonResponse(404)),
+      log,
+    );
+
+    await expect(
+      backend.lookupContractId({ keyId: "nope", network: "testnet" }),
+    ).resolves.toBeUndefined();
+
+    expect(log).toHaveBeenCalledTimes(1);
+    expect(log.mock.calls[0]![0]).toMatchObject({
+      url: "https://gateway.example.com/wallet/connect",
+      status: 404,
+    });
+  });
+
+  it("is a no-op (and does not throw) when no hook is supplied", async () => {
+    const backend = createHttpWalletBackend(
+      apiUrl,
+      vi.fn(async () => jsonResponse(500, { error: "boom" })),
+    );
+
+    await expect(
+      backend.lookupContractId({ keyId: "k1", network: "testnet" }),
+    ).rejects.toThrow(WalletApiError);
+  });
+});

--- a/src/http-backend.ts
+++ b/src/http-backend.ts
@@ -19,6 +19,26 @@ export class WalletApiError extends Error {
   }
 }
 
+export interface RequestLog {
+  /** HTTP method used for the request. */
+  method: string;
+  /** Full request URL (base + path). */
+  url: string;
+  /** HTTP status returned by the gateway. */
+  status: number;
+  /** Round-trip duration of the request, in milliseconds. */
+  durationMs: number;
+}
+
+/**
+ * Structured logging hook for HTTP-backend requests. If provided, it is
+ * invoked once per completed request (success and failure alike) with
+ * `method`, `url`, `status`, and `durationMs`, so consumer log pipelines can
+ * parse, filter, and route on structured fields instead of free-form console
+ * output.
+ */
+export type RequestLogHook = (log: RequestLog) => void;
+
 async function toApiError(res: Response): Promise<WalletApiError> {
   let payload: { error?: string; message?: string } | undefined;
   try {
@@ -57,21 +77,30 @@ export interface HttpWalletBackend {
  * "https://api.myapp.com"). Suitable to pass directly as
  * `createVellarWallet({ backend })`.
  *
- * @param apiUrl   Base URL of your Vellar-compatible gateway.
+ * @param apiUrl    Base URL of your Vellar-compatible gateway.
  * @param fetchImpl Optional fetch (defaults to the global fetch).
+ * @param logHook   Optional structured logging hook; called once per completed
+ *                  request with `{ method, url, status, durationMs }`. Omit it
+ *                  (or pass `undefined`) to disable logging.
  */
 export function createHttpWalletBackend(
   apiUrl: string,
   fetchImpl: typeof fetch = globalThis.fetch.bind(globalThis),
+  logHook?: RequestLogHook,
 ): HttpWalletBackend {
   const base = apiUrl.replace(/\/+$/, "");
 
-  const post = (path: string, body: unknown): Promise<Response> =>
-    fetchImpl(`${base}${path}`, {
+  const post = async (path: string, body: unknown): Promise<Response> => {
+    const url = `${base}${path}`;
+    const start = performance.now();
+    const res = await fetchImpl(url, {
       method: "POST",
       headers: { "content-type": "application/json" },
       body: JSON.stringify(body),
     });
+    logHook?.({ method: "POST", url, status: res.status, durationMs: performance.now() - start });
+    return res;
+  };
 
   return {
     async submitWalletCreation({ keyId, contractId, network, signedTx }) {


### PR DESCRIPTION
This PR adds an injectable structured request logging hook to `http-backend`, allowing consumers to capture HTTP request/response details in a structured format.

Previously this was targeting `main` — retargeted to `dev` per the project's contribution guidelines.

Closes #247

🤖 Generated with Codebuff
Co-Authored-By: Codebuff <noreply@codebuff.com>