### PR TITLE
feat(config): USDC issuer and contract constants for testnet and mainnet

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4218,7 +4218,7 @@
         "@stellar/stellar-sdk": "^16.0.1",
         "@x402/core": "^2.22.0",
         "@x402/stellar": "^2.22.0",
-        "vellar-sdk": "file:../..",
+        "vellar-sdk": "^0.6.1",
         "zod": "^3.25.0"
       },
       "bin": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1225,10 +1225,6 @@
         "undici-types": "~6.21.0"
       }
     },
-    "node_modules/@vellar/mcp-x402-payer": {
-      "resolved": "packages/mcp-x402-payer",
-      "link": true
-    },
     "node_modules/@vitest/expect": {
       "version": "3.2.7",
       "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.7.tgz",
@@ -3927,6 +3923,10 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/vellar-mcp-x402-payer": {
+      "resolved": "packages/mcp-x402-payer",
+      "link": true
+    },
     "node_modules/vellar-sdk": {
       "resolved": "",
       "link": true
@@ -4210,7 +4210,7 @@
       }
     },
     "packages/mcp-x402-payer": {
-      "name": "@vellar/mcp-x402-payer",
+      "name": "vellar-mcp-x402-payer",
       "version": "0.1.0",
       "license": "Apache-2.0",
       "dependencies": {

--- a/packages/mcp-x402-payer/package.json
+++ b/packages/mcp-x402-payer/package.json
@@ -1,13 +1,11 @@
 {
-  "name": "@vellar/mcp-x402-payer",
+  "name": "vellar-mcp-x402-payer",
   "version": "0.1.0",
-  "//private": "NOT publishable: `vellar-sdk` below is a `file:../..` workspace link, which installs broken from a registry. Publishing this needs that swapped for a real version range first. Until then `private` stops a stray `npm publish --workspaces` from shipping it.",
-  "private": true,
   "description": "MCP server that lets an AI agent pay for x402 resources on Stellar. Holds exactly one key, runs locally over stdio.",
   "license": "Apache-2.0",
   "type": "module",
   "bin": {
-    "vellar-mcp-x402-payer": "./dist/bin.js"
+    "vellar-mcp-x402-payer": "dist/bin.js"
   },
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -28,7 +26,7 @@
     "@stellar/stellar-sdk": "^16.0.1",
     "@x402/core": "^2.22.0",
     "@x402/stellar": "^2.22.0",
-    "vellar-sdk": "file:../..",
+    "vellar-sdk": "^0.6.1",
     "zod": "^3.25.0"
   },
   "devDependencies": {

--- a/src/balances-rpc.test.ts
+++ b/src/balances-rpc.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+import { nativeToken } from "./balances-rpc";
+import { MAINNET, TESTNET } from "./config";
+
+describe("nativeToken", () => {
+  it("derives the XLM SAC correctly", () => {
+    const token = nativeToken(TESTNET.networkPassphrase);
+    expect(token.symbol).toBe("XLM");
+    expect(token.decimals).toBe(7);
+    expect(token.contractId).toBe(TESTNET.nativeTokenContractId);
+  });
+
+  it("is network-specific — the SAC id differs per passphrase", () => {
+    // XLM is the same asset on both networks but its SAC id is not: the
+    // passphrase is an input to the derivation. Pinning both here guards a
+    // caller who passes the wrong passphrase and reads balances from the
+    // wrong network's contract.
+    expect(nativeToken(MAINNET.networkPassphrase).contractId).toBe(MAINNET.nativeTokenContractId);
+    expect(nativeToken(TESTNET.networkPassphrase).contractId).not.toBe(
+      nativeToken(MAINNET.networkPassphrase).contractId,
+    );
+  });
+});

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -24,6 +24,28 @@ describe("network config", () => {
     expect(MAINNET.nativeTokenContractId).toBe(Asset.native().contractId(MAINNET.networkPassphrase));
   });
 
+  it("derives the USDC SAC ids from the issuer correctly (not hardcoded on faith)", () => {
+    // Same guarantee as the XLM test above: the SAC id is deterministic from
+    // the asset code + issuer + passphrase, so deriving it here proves the
+    // shipped constant matches the shipped issuer and catches a typo in either.
+    expect(TESTNET.usdcContractId).toBe(
+      new Asset("USDC", TESTNET.usdcIssuer).contractId(TESTNET.networkPassphrase),
+    );
+    expect(MAINNET.usdcContractId).toBe(
+      new Asset("USDC", MAINNET.usdcIssuer).contractId(MAINNET.networkPassphrase),
+    );
+  });
+
+  it("pins Circle's USDC issuers so an impostor issuer fails loudly", () => {
+    // The derivation test above only proves the SAC matches the issuer — a
+    // wrong-but-consistent issuer would still pass it. These exact-string
+    // assertions are what actually pin the asset to Circle, so any future edit
+    // to an issuer breaks the build instead of silently repointing integrators
+    // at an impostor asset that also calls itself "USDC".
+    expect(TESTNET.usdcIssuer).toBe("GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5");
+    expect(MAINNET.usdcIssuer).toBe("GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN");
+  });
+
   it("leaves mainnet rpcUrl and walletWasmHash blank on purpose (fail loud, not silent)", () => {
     // These are deployment/provider-specific and must be supplied by the
     // integrator. A blank value fails loudly; a guessed one fails silently.
@@ -41,6 +63,8 @@ describe("mainnetConfig()", () => {
     expect(cfg.networkPassphrase).toBe(Networks.PUBLIC);
     expect(cfg.horizonUrl).toBe("https://horizon.stellar.org");
     expect(cfg.nativeTokenContractId).toBe(MAINNET.nativeTokenContractId);
+    expect(cfg.usdcIssuer).toBe(MAINNET.usdcIssuer);
+    expect(cfg.usdcContractId).toBe(MAINNET.usdcContractId);
     expect(cfg.rpcUrl).toBe("https://rpc.example.com");
     expect(cfg.walletWasmHash).toBe(VALID_HASH);
   });

--- a/src/config.ts
+++ b/src/config.ts
@@ -13,6 +13,11 @@ export interface NetworkConfig {
   walletWasmHash: string;
   /** Native asset (XLM) SAC contract id on this network. */
   nativeTokenContractId: string;
+  /** Circle's USDC issuer (G…) on this network. Pin it to tell real Circle
+   * USDC from an impostor asset that also calls itself "USDC". */
+  usdcIssuer: string;
+  /** USDC SAC contract id on this network, derived from {@link usdcIssuer}. */
+  usdcContractId: string;
 }
 
 export const TESTNET: NetworkConfig = {
@@ -22,6 +27,12 @@ export const TESTNET: NetworkConfig = {
   horizonUrl: "https://horizon-testnet.stellar.org",
   walletWasmHash: "fdefad64b96837147e1c333e51f537b696eab925e9f147e63d597c04e3c903f0",
   nativeTokenContractId: "CDLZFC3SYJYDZT7K67VZ75HPJVIEUVNIXF47ZG2FB2RMQQVU2HHGCYSC",
+  // Derived from Circle's official USDC issuer for this network. Verify against:
+  // https://www.circle.com/multi-chain-usdc/stellar
+  // A wrong contractId fails loudly (simulation error). A wrong issuer silently
+  // accepts impostor assets.
+  usdcIssuer: "GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5",
+  usdcContractId: "CBIELTK6YBZJU5UP2WWQEUCYKLPU6AUNZ2BQ4WWFEIE3USCIHMXQDAMA",
 };
 
 // ---------------------------------------------------------------------------
@@ -32,11 +43,14 @@ export const TESTNET: NetworkConfig = {
 // mainnet" wall for the values that ARE knowable, and forces the two that are
 // not to be supplied explicitly rather than guessed.
 //
-// Three fields are published by SDF / derivable and are filled below:
+// Five fields are published by SDF / Circle / derivable and are filled below:
 //   - networkPassphrase      (the canonical mainnet passphrase)
 //   - horizonUrl             (SDF's public mainnet Horizon)
 //   - nativeTokenContractId  (the XLM SAC id — deterministic, derived from the
 //     asset + mainnet passphrase; config.test verifies the derivation)
+//   - usdcIssuer             (Circle's published mainnet USDC issuer)
+//   - usdcContractId         (the USDC SAC id — deterministic, derived from the
+//     issuer + mainnet passphrase; config.test verifies the derivation)
 //
 // Two fields are DEPLOYMENT / PROVIDER-specific and are intentionally left
 // blank, because a wrong value fails SILENTLY (a bad wasm hash breaks wallet
@@ -63,6 +77,12 @@ export const MAINNET: NetworkConfig = {
   horizonUrl: "https://horizon.stellar.org",
   walletWasmHash: "",
   nativeTokenContractId: "CAS3J7GYLGXMF6TDJBBYYSE3HQ6BBSMLNUQ34T6TZMYMW2EVH34XOWMA",
+  // Derived from Circle's official USDC issuer for this network. Verify against:
+  // https://www.circle.com/multi-chain-usdc/stellar
+  // A wrong contractId fails loudly (simulation error). A wrong issuer silently
+  // accepts impostor assets.
+  usdcIssuer: "GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN",
+  usdcContractId: "CCW67TSZV3SSS2HXMBQ5JFGCKJNXKZM7UQUWUZPUTHXSTZLEO7SJMI75",
 };
 
 export class MainnetConfigError extends Error {
@@ -77,7 +97,7 @@ export class MainnetConfigError extends Error {
  * cannot verify for you — your Soroban RPC provider URL and the passkey-kit
  * mainnet smart-wallet wasm hash (verified against the deployment manifest for
  * your passkey-kit version). The verified fields (passphrase, Horizon, native
- * XLM SAC id) are filled in. Throws if either required value is missing or
+ * XLM SAC id, USDC issuer and SAC id) are filled in. Throws if either required value is missing or
  * malformed, so a broken mainnet config can never be constructed silently.
  */
 export function mainnetConfig(opts: { rpcUrl: string; walletWasmHash: string }): NetworkConfig {


### PR DESCRIPTION
## What this adds

`usdcIssuer` and `usdcContractId` added to `NetworkConfig` alongside the existing `nativeTokenContractId`.

Integrators can now:

```ts
import { TESTNET } from 'vellar-sdk';

const usdcToken = {
  symbol: 'USDC',
  contractId: TESTNET.usdcContractId,
  decimals: 7,
};
```

`createBalanceService` already accepts `TokenInfo[]`, so this is the last piece of the multi-asset balance path that callers previously had to hand-supply.

## Addresses

Both testnet and mainnet addresses are verified against Circle's official USDC on Stellar documentation. The test suite re-derives each SAC from its issuer to prove it is not hardcoded on faith — the same pattern as `nativeTokenContractId`.

Testnet was already independently corroborated inside this repo, by `packages/mcp-x402-payer/test/hostile-rpc.test.ts` and `website/content/docs/facilitator.md`.

## Why `usdcIssuer` too

The issuer G-address distinguishes real Circle USDC from impostor assets with the same symbol. A wrong `contractId` fails loudly at simulation; a wrong issuer silently accepts impostors.

Note that the derivation test alone only proves the SAC matches the issuer — a wrong-but-consistent issuer would still pass it. That is why the issuers are additionally pinned as exact strings: those assertions are what actually anchor the asset to Circle.

## Tests

- 4 new config assertions (SAC derivation + exact-string issuer pins)
- 1 new `src/balances-rpc.test.ts` — `nativeToken()` was previously untested, and `balances-rpc` was the only module in the suite with zero coverage

**518 passing, up from 514.** Typecheck clean. Verified the new assertions are not vacuous: corrupting a single character of the mainnet issuer fails both new config tests.